### PR TITLE
change format_degrees() to round minutes

### DIFF
--- a/geopy/format.py
+++ b/geopy/format.py
@@ -30,7 +30,7 @@ XML_SYMBOLS = {'deg': XML_DECIMAL_DEGREE, 'arcmin': XML_DECIMAL_PRIME, 'arcsec':
 ABBR_SYMBOLS = {'deg': ABBR_DEGREE, 'arcmin': ABBR_ARCMIN, 'arcsec': ABBR_ARCSEC}
 
 def format_degrees(degrees, format=DEGREES_FORMAT, symbols=ASCII_SYMBOLS):
-    arcminutes = units.arcminutes(degrees=degrees - int(degrees))
+    arcminutes = round(units.arcminutes(degrees=degrees - int(degrees)))
     arcseconds = units.arcseconds(arcminutes=arcminutes - int(arcminutes))
     format_dict = dict(
         symbols,

--- a/geopy/tests/test_format.py
+++ b/geopy/tests/test_format.py
@@ -1,0 +1,14 @@
+
+import unittest
+import geopy
+
+class TestFormat(unittest.TestCase):
+
+    def test_format(self):
+        d = geopy.point.Point.parse_degrees('-13', '19', 0)
+        s = geopy.format.format_degrees(d)
+        self.assertEqual("-13 19\' 0.0\"", s)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
parsing 3 19' 0" would yield the formatted string 3 18' 60" which is silly.  minutes should be rounded before converted to seconds.
