### PR TITLE
fixed exception, make geocode_first to work correcly with GoogleV3 when multiple places are found

### DIFF
--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -21,8 +21,8 @@ class Geocoder(object):
         else:
             raise GeocoderResultError("Geocoder returned no results!")
 
-    def geocode_first(self, location):
-        results = self.geocode(location)
+    def geocode_first(self, location, **kwargs):
+        results = self.geocode(location, **kwargs)
         for result in results:
             return result
         return None

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -90,6 +90,11 @@ class GoogleV3(Geocoder):
 
         return self.parse_json(page, exactly_one)
 
+    def geocode_first(self, location, **kwargs):
+        ''' Tell the geocoder explicitly to allow more than one result '''
+        kwargs['exactly_one'] = False
+        return super(GoogleV3, self).geocode_first(location, **kwargs)
+
     def geocode(self, string, bounds=None, region=None,
                 language=None, sensor=False, exactly_one=True):
         '''Geocode an address.


### PR DESCRIPTION
When geocoding address which has more than one result with GoogleV3, the exception was thrown saying that multiple results were found. 
The method geocode_first didn't worked correctly, because "exactly_one" was not passed to the GoogleV3's geocode method. 
It has been fixed here
