### PR TITLE
googlev3 geocoder: Only encode given address as UTF-8 when running on Py...

### DIFF
--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -6,6 +6,7 @@ breaking its compatibility or diverging its api too far from the rest of the
 geocoder classes.
 '''
 
+import sys
 import base64
 import hashlib
 import hmac
@@ -112,7 +113,7 @@ class GoogleV3(Geocoder):
         comes from a device with a location sensor.
         This value must be either True or False.
         '''
-        if isinstance(string, unicode):
+        if isinstance(string, unicode) and sys.version_info.major < 3:
             string = string.encode('utf-8')
 
         params = {


### PR DESCRIPTION
Hi,

The geocoder was sending the urlencoded repr() of the string to Google, leading to no results found for any query.
Given the nature and transitiveness of ensuring a single code-base between Python 2 and 3, I think it's an appropriate fix.

Thanks for your work!
