### PR TITLE
Geocoder http proxy support

### DIFF
--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -1,6 +1,16 @@
+import urllib2
+
 class Geocoder(object):
     def __init__(self, format_string='%s'):
         self.format_string = format_string
+
+        # Add urllib proxy support using environment variables or 
+        # built in OS proxy details
+        # See: http://docs.python.org/2/library/urllib2.html
+        # And: http://stackoverflow.com/questions/1450132/proxy-with-urllib2
+        proxy = urllib2.ProxyHandler()
+        opener = urllib2.build_opener(proxy)
+        urllib2.install_opener(opener)
 
     def geocode(self, location):
         raise NotImplementedError

--- a/geopy/tests/daemon.py
+++ b/geopy/tests/daemon.py
@@ -1,0 +1,87 @@
+#! /bin/env python
+#
+# Routine to daemonize a process on unix
+#
+#
+DAEMON_HOME = '/'
+
+class NullDevice:
+	def write(self, s):
+		pass
+
+def daemonize(homeDir = DAEMON_HOME):
+	import os
+	import sys
+
+	if os.fork() != 0:   				# Parent
+		os._exit(0)						# Kill parent
+
+				
+	os.chdir(homeDir)					# Detach from parent tty
+	os.setsid()							# and start new session
+	os.umask(0)
+	
+	sys.stdin.close()					# Close stdin, stdout
+	sys.stdout.close()
+	sys.stdin = NullDevice()
+	sys.stdout = NullDevice()
+	
+	for n in range(3, 256):				# Close any remaining file
+		try: 							# descriptors
+			os.close(n)
+		except:
+			pass
+
+	if os.fork() != 0:					# finally fork again
+		os._exit(0)						# to fully daemonize
+
+	
+
+def spawn(cmd, args):
+	import string
+	import os
+	import sys
+	import signal
+
+	# Prevent zombie orphans by ignoring SIGCHLD signal
+	signal.signal(signal.SIGCHLD, signal.SIG_IGN)
+
+	args = string.split(args)
+	if os.fork() != 0:					# Calling Parent
+		return							# allow this parent to continue running
+
+	os.chdir(DAEMON_HOME)				# Temp Parent
+	os.setsid()							# Detach from calling parent
+	os.umask(0)							
+
+	if os.fork() != 0:					# Kill temp parent 
+		os._exit(0)						# Run cmd in new child
+	
+	os.execvpe(cmd, [cmd] + args, os.environ)
+
+
+def createPid(pidPath='/var/run'):
+	'''Creates PID file for process'''
+	
+	import os	
+	import sys
+	
+	currentPid = os.getpid() #Gets PID number
+	if not currentPid:
+		print 'Could not find PID'
+		sys.exit()	
+	
+	scriptFilename, ext = os.path.splitext(os.path.basename(sys.argv[0])) 
+	
+	pidFile = '%s.pid' % (scriptFilename) #Creates PIDfile  filename
+	pidFilePath = os.path.join(pidPath, pidFile)
+	
+	f = file(pidFilePath, 'w') #Writes PIDfile name
+	print >> f, currentPid
+	f.close()
+
+if __name__ == "__main__":
+        while True:
+                daemonize()
+                print "hello world"
+

--- a/geopy/tests/proxy_server.py
+++ b/geopy/tests/proxy_server.py
@@ -1,0 +1,38 @@
+import SimpleHTTPServer
+import SocketServer
+import urllib
+
+class Proxy(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        self.copyfile(urllib.urlopen(self.path), self.wfile)     
+
+class ProxyServer():
+    '''Class used to invoke a simple test HTTP Proxy server''' 
+    def __init__(self):
+        self.proxy_port = 1337
+        self.proxy_host = 'localhost'
+
+        self.proxyd = None
+
+    def run_proxy(self):
+        '''Starts Instance of Proxy in a TCPServer'''
+        #Setup Proxy in thread
+        self.proxyd = SocketServer.TCPServer((self.proxy_host, self.proxy_port), Proxy).serve_forever()
+        # Start Proxy Process
+        print "serving at port %s on PID %s " % (self.proxy_port, self.proxyd.pid) 
+
+    def get_proxy_url(self):
+        return "http://%s:%s" % (self.proxy_host, self.proxy_port)
+
+
+if __name__ == '__main__':
+    import daemon 
+
+    daemon.daemonize()
+    daemon.createPid()
+
+    proxy = ProxyServer()
+    proxy.run_proxy()
+
+
+

--- a/geopy/tests/test_proxy.py
+++ b/geopy/tests/test_proxy.py
@@ -1,0 +1,53 @@
+import SimpleHTTPServer
+import SocketServer
+import os
+import urllib
+import urllib2
+import unittest
+import proxy_server
+from geopy.geocoders.base import Geocoder
+
+### UNIT TEST(S) to test Proxy in Geocoder base class ###
+###
+### Solution requires that proxy_server.py is run to start simple proxy
+### daemon proxy PID is located in /var/run/proxy_server.pid and can be 
+### stoped using the command `kill -9 $(cat /var/run/proxy_server.pid)`
+
+
+class ProxyTestCase(unittest.TestCase):
+    def setUp(self):
+       
+        # Backup environ settings
+        self.orig_http_proxy = os.environ['http_proxy'] if os.environ.has_key('http_proxy') else None
+        
+        # Get HTTP for comparison before proxy test
+        base_http = urllib2.urlopen('http://www.blankwebsite.com/')
+        base_html = base_http.read()
+        self.noproxy_data = base_html if base_html else None
+
+        # Create the proxy instance
+        self.proxyd = proxy_server.ProxyServer()
+        # Set the http_proxy environment variable with Proxy_server default value
+        os.environ['http_proxy'] = self.proxyd.get_proxy_url()
+
+    def teardown(self):
+        if self.orig_http_proxy:
+            os.environ['http_proxy'] = self.orig_http_proxy
+        else:
+            del os.environ['http_proxy']
+
+
+    def test_proxy(self):
+        ''' Test of OTB Geocoder Proxy functionality works'''
+        class DummyGeocoder(Geocoder):
+            def geocode(self, location):
+                geo_request = urllib2.urlopen(location)
+                geo_html = geo_request.read()
+                return geo_html if geo_html else None
+
+        '''Testcase to test that proxy standup code works'''
+        geocoder_dummy = DummyGeocoder()
+        self.assertTrue(self.noproxy_data, geocoder_dummy.geocode('http://www.blankwebsite.com/'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
With all of the geocoders using urllib2 for accessing the different geocoding web services, I have added http proxy support to the **Geocoder** base class that these geocoders inherit from. 

This implementation uses the built in support for environment variables to be supported using the non defined **ProxyHandler** class in urllib2. This allows for other protocols to be supported via '<protocol>_proxy' (eg. http_proxy) environment variables. 

Tests are included for this with a simple HTTP proxy.
