### PR TITLE
SemanticMediaWiki throws ImportError if BeautifulSoup is not present, and BeautifulSoup warning is removed

### DIFF
--- a/geopy/geocoders/wiki_semantic.py
+++ b/geopy/geocoders/wiki_semantic.py
@@ -7,8 +7,7 @@ from geopy import util
 try:
     from BeautifulSoup import BeautifulSoup
 except ImportError:
-    util.logger.warn("BeautifulSoup was not found. " \
-          "The SemanticMediaWiki geocoder will not work.")
+    BeautifulSoup = None
 
 try:
     set
@@ -18,6 +17,11 @@ except NameError:
 class SemanticMediaWiki(Geocoder):
     def __init__(self, format_url, attributes=None, relations=None,
                  prefer_semantic=False, transform_string=None):
+        if not BeautifulSoup:
+            raise ImportError(
+                "BeautifulSoup was not found. Please install BeautifulSoup "
+                "in order to use the SemanticMediaWiki Geocoder."
+            )
         self.format_url = format_url
         self.attributes = attributes
         self.relations = relations


### PR DESCRIPTION
geopy gives a warning to all its users if the optional dependency BeautifulSoup is not installed. It would be better if only users who touched functionality needing BeautifulSoup were affected; and, that users who attempt to use functionality needing BeautifulSoup see an `ImportError` on initialization, rather than a warning on initialization followed by an undefined variable exception. 

This pull request defines BeautifulSoup as either the package or, if not available, `None`, and if the consuming `SemanticMediaWiki` geocoder is used with a BeautifulSoup of `None`, an `ImportError` is thrown.
