### PR TITLE
Add timeout argument to geocoder.geocode method.

### DIFF
--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -36,18 +36,18 @@ class Bing(Geocoder):
         self.format_string = format_string
         self.url = "http://dev.virtualearth.net/REST/v1/Locations?%s"
 
-    def geocode(self, string, exactly_one=True):
+    def geocode(self, string, exactly_one=True, timeout=None):
         if isinstance(string, unicode):
             string = string.encode('utf-8')
         params = {'query': self.format_string % string,
                   'key': self.api_key
                   }
         url = self.url % urlencode(params)
-        return self.geocode_url(url, exactly_one)
+        return self.geocode_url(url, exactly_one, timeout)
 
-    def geocode_url(self, url, exactly_one=True):
+    def geocode_url(self, url, exactly_one=True, timeout=None):
         logger.debug("Fetching %s..." % url)
-        page = urlopen(url)
+        page = urlopen(url, timeout=timeout)
 
         return self.parse_json(page, exactly_one)
 

--- a/geopy/geocoders/dot_us.py
+++ b/geopy/geocoders/dot_us.py
@@ -28,15 +28,15 @@ class GeocoderDotUS(Geocoder):
         
         return 'http://%sgeocoder.us/%s' % (auth, resource)
     
-    def geocode(self, query, exactly_one=True):
+    def geocode(self, query, exactly_one=True, timeout=None):
         if isinstance(query, unicode):
             query = query.encode('utf-8')
         query_str = self.format_string % query
         
         page = urlopen("%s?%s" % (
             self.get_url(),
-            urlencode({'address':query_str})
-        ))
+            urlencode({'address': query_str})),
+                       timeout=timeout)
         
         reader = csv.reader(page)
         

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -27,7 +27,7 @@ class GeoNames(Geocoder):
         self.country_bias = country_bias
         self.url = "http://ws.geonames.org/searchJSON?%s"
     
-    def geocode(self, string, exactly_one=True):
+    def geocode(self, string, exactly_one=True, timeout=None):
         if isinstance(string, unicode):
             string = string.encode('utf-8')
         params = {
@@ -37,10 +37,10 @@ class GeoNames(Geocoder):
             params['countryBias'] = self.country_bias
         
         url = self.url % urlencode(params)
-        return self.geocode_url(url, exactly_one)
+        return self.geocode_url(url, exactly_one, timeout)
     
-    def geocode_url(self, url, exactly_one=True):
-        page = urlopen(url)
+    def geocode_url(self, url, exactly_one=True, timeout=None):
+        page = urlopen(url, timeout=timeout)
         return self.parse_json(page, exactly_one)
     
     def parse_json(self, page, exactly_one):

--- a/geopy/geocoders/google.py
+++ b/geopy/geocoders/google.py
@@ -67,7 +67,7 @@ class Google(Geocoder):
         domain = self.domain.strip('/')
         return "http://%s/maps/geo?%%s" % domain
 
-    def geocode(self, string, exactly_one=True):
+    def geocode(self, string, exactly_one=True, timeout=None):
         if isinstance(string, unicode):
             string = string.encode('utf-8')
         params = {'q': self.format_string % string,
@@ -77,11 +77,11 @@ class Google(Geocoder):
                   }
         
         url = self.url % urlencode(params)
-        return self.geocode_url(url, exactly_one)
+        return self.geocode_url(url, exactly_one, timeout)
 
-    def geocode_url(self, url, exactly_one=True):
+    def geocode_url(self, url, exactly_one=True, timeout=None):
         util.logger.debug("Fetching %s..." % url)
-        page = urlopen(url)
+        page = urlopen(url, timeout=timeout)
         
         dispatch = getattr(self, 'parse_' + self.output_format)
         return dispatch(page, exactly_one)

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -83,15 +83,16 @@ class GoogleV3(Geocoder):
         return 'http://%(domain)s/maps/api/geocode/json?%(params)s' % (
             {'domain': self.domain, 'params': urlencode(params)})
     
-    def geocode_url(self, url, exactly_one=True):
+    def geocode_url(self, url, exactly_one=True, timeout=None):
         '''Fetches the url and returns the result.'''
         util.logger.debug("Fetching %s..." % url)
-        page = urlopen(url)
+        page = urlopen(url, timeout=timeout)
 
         return self.parse_json(page, exactly_one)
 
     def geocode(self, string, bounds=None, region=None,
-                language=None, sensor=False, exactly_one=True):
+                language=None, sensor=False, exactly_one=True,
+                timeout=None):
         '''Geocode an address.
 
         ``string`` (required) The address that you want to geocode.
@@ -111,6 +112,9 @@ class GoogleV3(Geocoder):
         ``sensor`` (required) Indicates whether or not the geocoding request
         comes from a device with a location sensor.
         This value must be either True or False.
+
+        ``timeout`` (optional) Interrupts the connection to the server after
+        timeout seconds (None to ignore).
         '''
         if isinstance(string, unicode):
             string = string.encode('utf-8')

--- a/geopy/geocoders/mapquest.py
+++ b/geopy/geocoders/mapquest.py
@@ -22,12 +22,13 @@ class MapQuest(Geocoder):
         self.format_string = format_string
         self.url = "http://www.mapquestapi.com/geocoding/v1/address"
 
-    def geocode(self, location, exactly_one=True):
+    def geocode(self, location, exactly_one=True, timeout=None):
         if isinstance(location, unicode):
             location = location.encode('utf-8')
         params = {'location' : location}
         data = urlencode(params)
-        page = urlopen(self.url + '?key=' + self.api_key + '&' + data).read()
+        page = urlopen(self.url + '?key=' + self.api_key + '&' + data,
+                       timeout=timeout).read()
         return self.parse_json(page, exactly_one)
 
     def parse_json(self, page, exactly_one=True):

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -29,14 +29,14 @@ class OpenMapQuest(Geocoder):
         self.format_string = format_string
         self.url = "http://open.mapquestapi.com/nominatim/v1/search?format=json&%s"
     
-    def geocode(self, string, exactly_one=True):
+    def geocode(self, string, exactly_one=True, timeout=None):
         if isinstance(string, unicode):
             string = string.encode('utf-8')
         params = {'q': self.format_string % string}
         url = self.url % urlencode(params)
         
         logger.debug("Fetching %s..." % url)
-        page = urlopen(url)
+        page = urlopen(url, timeout=timeout)
         
         return self.parse_json(page, exactly_one)
     

--- a/geopy/geocoders/wiki_gis.py
+++ b/geopy/geocoders/wiki_gis.py
@@ -30,16 +30,16 @@ class MediaWiki(Geocoder):
         """Do the WikiMedia dance: replace spaces with underscores."""
         return string.replace(' ', '_')
 
-    def geocode(self, string):
+    def geocode(self, string, timeout=None):
         if isinstance(string, unicode):
             string = string.encode('utf-8')
         wiki_string = self.transform_string(string)
         url = self.format_url % wiki_string
-        return self.geocode_url(url)
+        return self.geocode_url(url, timeout=timeout)
 
-    def geocode_url(self, url):
+    def geocode_url(self, url, timeout=None):
         util.logger.debug("Fetching %s..." % url)
-        page = urlopen(url)
+        page = urlopen(url, timeout=timeout)
         name, (latitude, longitude) = self.parse_xhtml(page)
         return (name, (latitude, longitude))        
 

--- a/geopy/geocoders/wiki_semantic.py
+++ b/geopy/geocoders/wiki_semantic.py
@@ -3,6 +3,7 @@ from geopy.geocoders.base import Geocoder
 from geopy.point import Point
 from geopy.location import Location
 from geopy import util
+from urllib2 import urlopen
 
 try:
     from BeautifulSoup import BeautifulSoup
@@ -73,17 +74,17 @@ class SemanticMediaWiki(Geocoder):
     def get_thing_label(self, thing):
         return util.get_first_text(thing, 'rdfs:label')
     
-    def geocode_url(self, url, attempted=None):
+    def geocode_url(self, url, attempted=None, timeout=None):
         if attempted is None:
             attempted = set()
 
         util.logger.debug("Fetching %s..." % url)
-        page = urlopen(url)
+        page = urlopen(url, timeout=timeout)
         soup = BeautifulSoup(page)
 
         rdf_url = self.parse_rdf_link(soup)
         util.logger.debug("Fetching %s..." % rdf_url)
-        page = urlopen(rdf_url)
+        page = urlopen(rdf_url, timeout=timeout)
 
         things, thing = self.parse_rdf(page)
         name = self.get_label(thing)

--- a/geopy/geocoders/yahoo.py
+++ b/geopy/geocoders/yahoo.py
@@ -29,7 +29,7 @@ class Yahoo(Geocoder):
             warn('geopy.geocoders.yahoo.Yahoo: The `output_format` parameter is deprecated '+
                  'and now ignored. JSON will be used internally.', DeprecationWarning)
 
-    def geocode(self, string, exactly_one=True):
+    def geocode(self, string, exactly_one=True, timeout=None):
         if isinstance(string, unicode):
             string = string.encode('utf-8')
         params = {'location': self.format_string % string,
@@ -38,10 +38,10 @@ class Yahoo(Geocoder):
                  }
         url = self.BASE_URL % urlencode(params)
         util.logger.debug("Fetching %s..." % url)
-        return self.geocode_url(url, exactly_one)
+        return self.geocode_url(url, exactly_one, timeout=timeout)
 
-    def geocode_url(self, url, exactly_one=True):
-        page = urlopen(url)
+    def geocode_url(self, url, exactly_one=True, timeout=None):
+        page = urlopen(url, timeout=timeout)
         return self.parse_json(page, exactly_one)
     
     def parse_json(self, page, exactly_one=True):


### PR DESCRIPTION
Sometimes services can be too slow to respond (or unavailable). This adds ability to stop connections after a given timeout and move to the backup geocoder.
