### PR TITLE
Added handling case for ZERO_RESULTS from GoogleV3 with test case

### DIFF
--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -211,6 +211,9 @@ class GoogleV3(Geocoder):
         """
         Validates error statuses.
         """
+        if status == 'ZERO_RESULTS':
+            # When there are no results, just return.
+            return
         if status == 'OVER_QUERY_LIMIT':
             raise GeocoderQuotaExceeded(
                 'The given key has gone over the requests limit in the 24'

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -186,6 +186,10 @@ class GoogleV3TestCase(_BackendTestCase): # pylint: disable=R0904,C0111
         self.assertAlmostEqual(coords[0], known_coords[0], delta=self.delta_exact)
         self.assertAlmostEqual(coords[1], known_coords[1], delta=self.delta_exact)
 
+    def test_zero_results(self):
+        result = self.geocoder.geocode('')
+        self.assertIsNone(result)
+
 
 @unittest.skipUnless( # pylint: disable=R0904,C0111
     env['BING_KEY'] is not None,


### PR DESCRIPTION
Without this, geocode() would raise `GeocoderQueryError('Unknown error.')`, which is highly confusing, as opposed to simply returning `None`, which was the old behavior of this. Includes a test case.
