### PR TITLE
Handling proxy for urllib2

### DIFF
--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -42,12 +42,12 @@ class Geocoder(object): # pylint: disable=R0921
         # built in OS proxy details
         # See: http://docs.python.org/2/library/urllib2.html
         # And: http://stackoverflow.com/questions/1450132/proxy-with-urllib2
-        if self.proxies is None:
-            self.urlopen = urllib_urlopen
-        else:
-            self.urlopen = build_opener(
+        if self.proxies:
+            opener = build_opener(
                 ProxyHandler(self.proxies)
             )
+            urllib2.install_opener(opener)
+        self.urlopen = urllib_urlopen
 
     @staticmethod
     def _coerce_point_to_string(point):


### PR DESCRIPTION
build_opener returns a OpenerDirector, which is not 1) callable, 2) does not install it in urlopen, and 3), urlopen is still the way to access resource.

From the docs:

```
proxy_support = urllib2.ProxyHandler({"http" : "http://ahad-haam:3128"})

# build a new opener that adds authentication and caching FTP handlers
opener = urllib2.build_opener(proxy_support, authinfo, urllib2.CacheFTPHandler)

# install it
urllib2.install_opener(opener)

f = urllib2.urlopen('http://www.python.org/')
```
