### PR TITLE
add support for the 'components' param of Google Maps v3

### DIFF
--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -92,6 +92,13 @@ class GoogleV3(Geocoder):
         signature = base64.urlsafe_b64encode(signature.digest()).decode('utf-8')
         return '%s://%s%s&signature=%s' % (self.scheme, self.domain, path, signature)
 
+    @staticmethod
+    def _format_components_param(components):
+        """
+        Format the components dict to something Google understands.
+        """
+        return '|'.join(['%s:%s' % (a, b) for a, b in components.items()])
+
     def geocode(self, query, bounds=None, region=None, # pylint: disable=W0221,R0913
                 components=None,
                 language=None, sensor=False, exactly_one=True, timeout=None):
@@ -134,8 +141,7 @@ class GoogleV3(Geocoder):
         if region:
             params['region'] = region
         if components:
-            params['components'] = '|'.join(
-                    ['%s:%s' % (a, b) for a, b in components.items()])
+            params['components'] = self._format_components_param(components)
         if language:
             params['language'] = language
 

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -236,6 +236,24 @@ class GoogleV3TestCase(_BackendTestCase): # pylint: disable=R0904,C0111
         result = self.geocoder.geocode('')
         self.assertIsNone(result)
 
+    def test_format_components_param(self):
+        f = GoogleV3._format_components_param
+        self.assertEqual(f({}), '')
+        self.assertEqual(f({'country': 'FR'}), 'country:FR')
+        output = f({'administrative_area': 'CA', 'country': 'FR'})
+        # the order the dict is iterated over is not important
+        self.assertTrue(output == 'administrative_area:CA|country:FR' or
+            output == 'country:FR|administrative_area:CA')
+
+        with self.assertRaises(AttributeError):
+            f(None)
+
+        with self.assertRaises(AttributeError):
+            f([])
+
+        with self.assertRaises(AttributeError):
+            f('administrative_area:CA|country:FR')
+
 
 @unittest.skipUnless( # pylint: disable=R0904,C0111
     env['BING_KEY'] is not None,


### PR DESCRIPTION
This PR adds support for the `components` parameter.
#### Testing

``` python
from geopy import geocoders
g = geocoders.GoogleV3()

g.geocode('santa cruz')
# GoogleV3.geocode: https://maps.googleapis.com/maps/api/geocode/json?sensor=false&address=santa+cruz
# (u'Santa Cruz, CA, USA', (36.9741171, -122.0307963))

g.geocode('santa cruz', components={'country': 'ES'})
# GoogleV3.geocode: https://maps.googleapis.com/maps/api/geocode/json?sensor=false&components=country%3AES&address=santa+cruz
# (u'Santa Cruz de Tenerife, Spain', (28.4636296, -16.2518467))
```

docs:
https://developers.google.com/maps/documentation/geocoding/#ComponentFiltering
