### PR TITLE
Fixed Mapquest API format_string RE: Issue #36

### DIFF
--- a/geopy/geocoders/mapquest.py
+++ b/geopy/geocoders/mapquest.py
@@ -72,7 +72,7 @@ class MapQuest(Geocoder): # pylint: disable=W0223
             .. versionadded:: 0.97
         """
         params = {
-            'location' : query
+            'location' : self.format_string % query
         }
         if exactly_one:
             params['maxResults'] = 1


### PR DESCRIPTION
format_string was never used when forming the query to the API
RE: https://github.com/geopy/geopy/issues/36
