### PR TITLE
Fix dumb typo with detection of timeouts

### DIFF
--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -113,7 +113,7 @@ class Geocoder(object): # pylint: disable=R0921
             elif isinstance(error, SocketTimeout):
                 raise GeocoderTimedOut('Service timed out')
             elif isinstance(error, SSLError):
-                if "timed out in message":
+                if "timed out" in message:
                     raise GeocoderTimedOut('Service timed out')
             if not py3k:
                 err = GeocoderServiceError(message)


### PR DESCRIPTION
If you take a look at the commit where this was made ( https://github.com/geopy/geopy/commit/70413a2631b281445c11b61ca154449bcb96d466 ) you'll see that this is a pretty straightforward typo.
