### PR TITLE
Made it possible to geocode non-ascii values in Python2.

### DIFF
--- a/geopy/compat.py
+++ b/geopy/compat.py
@@ -17,6 +17,32 @@ if py3k: # pragma: no cover
         build_opener, ProxyHandler, URLError, install_opener)
     from urllib.error import HTTPError # pylint: disable=W0611,F0401,W0611,E0611
 else: # pragma: no cover
-    from urllib import urlencode, quote # pylint: disable=W0611,F0401,W0611,E0611
+    from urllib import urlencode as original_urlencode, quote # pylint: disable=W0611,F0401,W0611,E0611
     from urllib2 import (Request, HTTPError,   # pylint: disable=W0611,F0401,W0611,E0611
         ProxyHandler, URLError, urlopen, build_opener, install_opener)
+
+    def force_str(str_or_unicode):
+        """
+        Python2-only, ensures that a string is encoding to a str.
+        """
+        if isinstance(str_or_unicode, unicode):
+            return str_or_unicode.encode('utf-8')
+        else:
+            return str_or_unicode
+
+    def urlencode(query, doseq=0):
+        """
+        A version of Python's urllib.urlencode() function that can operate on
+        unicode strings. The parameters are first cast to UTF-8 encoded strings
+        and then encoded as per normal.
+
+        Based on the urlencode from django.utils.http
+        """
+        if hasattr(query, 'items'):
+            query = query.items()
+        return original_urlencode(
+            [(force_str(k),
+              [force_str(i) for i in v]
+              if isinstance(v, (list, tuple)) else force_str(v))
+             for k, v in query],
+            doseq)

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -229,6 +229,22 @@ class _BackendTestCase(unittest.TestCase): # pylint: disable=R0904
         self.assertAlmostEqual(latlon[0], 46.1912, delta=self.delta_inexact)
         self.assertAlmostEqual(latlon[1], -122.1944, delta=self.delta_inexact)
 
+    def test_unicode_name(self):
+        # The Forbidden City in Beijing
+        address = u'\u6545\u5bab'
+
+        try:
+            result = self.geocoder.geocode(address, exactly_one=True)
+        except exc.GeocoderQuotaExceeded:
+            raise unittest.SkipTest("Quota exceeded")
+        if result is None:
+            self.fail('No result found')
+        clean_address, latlon = result # pylint: disable=W0612
+
+        self.assertTrue(result.raw is not None)
+        self.assertAlmostEqual(latlon[0], 39.916, delta=self.delta_inexact)
+        self.assertAlmostEqual(latlon[1], 116.390, delta=self.delta_inexact)
+
 
 class GoogleV3TestCase(_BackendTestCase): # pylint: disable=R0904,C0111
     def setUp(self):


### PR DESCRIPTION
This code would throw a UnicodeError in Python2 because urllib.urlencode doesn't support unicode strings.

``` python
>>> from geopy.geocoders import OpenMapQuest
>>> geocoder = OpenMapQuest()
>>> geocoder.geocode(u'你好')
```

In order to make this work in my code, I had to encode my unicode string as `utf-8`.

``` python
>>> geocoder.geocode(u'你好'.encode('utf-8'))
```

I thought it would be nice if geopy did this for me instead, as it's something that's easy to miss, so I created a version of urlencode (only for Python2) that works more nicely with unicode strings based off of the one that exists in Django.
