### PR TITLE
Fix broken __repr__ method in Point class

### DIFF
--- a/geopy/point.py
+++ b/geopy/point.py
@@ -148,7 +148,7 @@ class Point(object):
         return iter((self.latitude, self.longitude, self.altitude))
 
     def __repr__(self):
-        return "Point(%r, %r, %r)" % (self._items)
+        return "Point(%r, %r, %r)" % (tuple(self._items))
 
     def format(self, altitude=None, deg_char='', min_char='m', sec_char='s'):
         latitude = "%s %s" % (


### PR DESCRIPTION
Fixes issue #44.

Added convertion to tuple in `Point.__repr__()` method to make it work
with string formatting.
