### PR TITLE
Updated smartystreets.py

### DIFF
--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -103,7 +103,7 @@ class LiveAddress(Geocoder): # pylint: disable=W0223
 
         
         
-        url = self._compose_url(self.street, self.city, self.state, self.zipcode, self.l
+        url = self._compose_url(self.street, self.city, self.state, self.zipcode, self.lastline)
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
         return self._parse_json(self._call_geocoder(url), exactly_one)
 


### PR DESCRIPTION
Hi,

I noticed that I got a 401 error when trying to use the SmartyStreets service with geopy. I saw that the SmartyStreets api requires an auth-id and auth-token to work, while the current code only accepts an auth-token. I therefore updated the code for the smartystreets.py file to take that additional parameter from the user when calling the class. I also altered the geocoding function so that the user can optionally submit addresses as components after talking to someone at SmartyStreets who suggested that that would improve accuracy if one is working with address data that is broken into components rather than in freeform.

Hope this is useful.

Jeff
