### PR TITLE
Fix for issue #55 - formatted Point always having zero seconds

### DIFF
--- a/geopy/format.py
+++ b/geopy/format.py
@@ -67,7 +67,7 @@ def format_degrees(degrees, fmt=DEGREES_FORMAT, symbols=None):
     TODO docs.
     """
     symbols = symbols or ASCII_SYMBOLS
-    arcminutes = round(units.arcminutes(degrees=degrees - int(degrees)))
+    arcminutes = units.arcminutes(degrees=degrees - int(degrees))
     arcseconds = units.arcseconds(arcminutes=arcminutes - int(arcminutes))
     format_dict = dict(
         symbols,


### PR DESCRIPTION
Rounding of the arc minutes in format_degrees zeroed out the seconds field. The correct truncation of the minutes (not rounding) is done by the format string.

Before:

```
 >>> from geopy import Point
 >>> p = Point('51 19m 12.9s N, 0 1m 24.95s E')
 >>> p.format()
 '51 19m 0.0s N, 0 1m 0.0s E'
```

After:

```
 >>> from geopy import Point
 >>> p = Point('51 19m 12.9s N, 0 1m 24.95s E')
 >>> p.format()
 '51 19m 12.9s N, 0 1m 24.95s E'
```
