### PR TITLE
Hotfix: baidu geocoder python 3 compatibility

### DIFF
--- a/geopy/geocoders/baidu.py
+++ b/geopy/geocoders/baidu.py
@@ -159,7 +159,7 @@ class Baidu(Geocoder):
         """
         Validates error statuses.
         """
-        print status
+        print(status)
         if status == '0':
             # When there are no results, just return.
             return


### PR DESCRIPTION
the `geocoders/baidu.py` module was using a print statement incompatible with python3.X.
It ended up breaking the usage of the whole library using python3.X.

Just fixed the failing print statement.

**Nota**: a lot of tests were failing because of this one in python3. Moreover there are still 3-4 tests which are not passing whether you use py27 or py3 (`tox`). I don't understand how you came to release a `1.0.0` version with failing tests ;)
