### PR TITLE
Added support to query full geometry from Nominatm.

### DIFF
--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -156,8 +156,10 @@ class Nominatim(Geocoder):
             params['polygon_kml'] = 1
         elif geometry == 'geojson':
             params['polygon_geojson'] = 1
-        #else:
-        #    raise GeocoderQueryError("Invalid geometry format. Must be one of WKT, svg, kml, geojson.")
+        elif geometry is None:
+            pass
+        else:
+            raise GeocoderQueryError("Invalid geometry format. Must be one of WKT, svg, kml, geojson.")
 
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -60,6 +60,7 @@ class NominatimTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
             geocoder.geocode,
             query,
             addressdetails=True,
+
         )
         self.assertEqual(result.raw['address']['city_district'], u'Mitte')
 


### PR DESCRIPTION
Added support for a  'geometry' attribute to geolocator.geocode which accepts either 'geojson', 'kml', 'svg' or 'WKT' as a value and returns the full geometry of a result in result.raw in the given format.wq
