### PR TITLE
Fix from_sequence class method

### DIFF
--- a/geopy/point.py
+++ b/geopy/point.py
@@ -334,7 +334,7 @@ class Point(object):
         3 elements.  The elements, if present, must be latitude, longitude,
         and altitude, respectively.
         """
-        args = tuple(islice(seq, 4))
+        args = tuple(islice(seq, 3))
         return cls(*args)
 
     @classmethod


### PR DESCRIPTION
creating a Point instance from a sequence containing more than 3 elements raises TypeError ( takes 1 to 4 positional arguments but 5 were given). 
I suppose that the intended behaviour in this case is to still create Point instance but only taking into account the 3 first elements of the sequence.
