### PR TITLE
Fix by adding comment when executing make test that send

### DIFF
--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -3,7 +3,7 @@ Test distance formulas
 """
 import math
 
-from nose.tools import assert_raises, assert_almost_equal
+from nose.tools import assert_raises, assert_almost_equal # pylint: disable=E0611
 
 from geopy.point import Point
 from geopy.distance import (Distance,


### PR DESCRIPTION
The build onTravis do not use Pylint and do not raise errors.
When executing locally `make test`, pylint complains about: 

```
"FAIL: test/test_distance.py:6 | E0611 no-name-in-module:  No name 'assert_raises' in module 'nose.tools'"
```

See for a fix http://blog.daniel-watkins.co.uk/2013/09/fixing-nosetools-pylint-errors.html
I choose the option to comment for ignoring the E0611 error or more refactoring with `unittest.TestCase` would be required
e.g https://stackoverflow.com/questions/10716506/where-is-noses-assert-raises-function whereas `nose.tools` approach is valid IMO.
