### PR TITLE
Add geocoder support for navidata.pl service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ geopy includes geocoder classes for the [OpenStreetMap Nominatim][osm],
 [ESRI ArcGIS][arcgis], [Google Geocoding API (V3)][googlev3],
 [Baidu Maps][baidu], [Bing Maps API][bing], [Yahoo! PlaceFinder][placefinder],
 [Yandex][yandex], [IGN France][ignfrance], [GeoNames][geonames],
-[MapQuest][mapquest], [OpenMapQuest][openmapquest], [What3Words][what3words],
+[MapQuest][mapquest], [NaviData][navidata], [OpenMapQuest][openmapquest], [What3Words][what3words],
 [OpenCage][opencage], [SmartyStreets][smartystreets], [geocoder.us][dot_us],
 and [GeocodeFarm][geocodefarm] geocoder services.
 The various geocoder classes are located in [geopy.geocoders][geocoders_src].
@@ -26,6 +26,7 @@ The various geocoder classes are located in [geopy.geocoders][geocoders_src].
 [googlev3]: https://developers.google.com/maps/documentation/geocoding/
 [ignfrance]: http://api.ign.fr/tech-docs-js/fr/developpeur/search.html
 [mapquest]: http://www.mapquestapi.com/geocoding/
+[navidata]: http://navidata.pl
 [opencage]: http://geocoder.opencagedata.com/api.html
 [openmapquest]: http://developer.mapquest.com/web/products/open/geocoding-service
 [osm]: https://wiki.openstreetmap.org/wiki/Nominatim

--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -108,6 +108,8 @@ from geopy.geocoders.smartystreets import LiveAddress
 from geopy.geocoders.what3words import What3Words
 from geopy.geocoders.yandex import Yandex
 from geopy.geocoders.ignfrance import IGNFrance
+from geopy.geocoders.navidata import NaviData
+
 
 from geopy.exc import GeocoderNotFound
 
@@ -130,6 +132,7 @@ SERVICE_TO_GEOCODER = {
     "what3words": What3Words,
     "yandex": Yandex,
     "ignfrance": IGNFrance,
+    "navidata": NaviData
 }
 
 

--- a/geopy/geocoders/navidata.py
+++ b/geopy/geocoders/navidata.py
@@ -36,7 +36,7 @@ class NaviData(Geocoder):
         NaviData traffic use plain http.
 
         :param string api_key: The commercial API key for service. None required if you
-            use this API for non-commercial puproses
+            use this API for non-commercial purposes
 
         :param string domain: Currently it is 'api.navidata.pl', can
             be changed for testing purposes.
@@ -53,7 +53,6 @@ class NaviData(Geocoder):
 
         self.api_key = api_key
         self.domain = domain.strip('/')
-        #self.scheme = scheme
         self.geocode_api = 'http://%s/geocode' % (self.domain)
         self.reverse_geocode_api = 'http://%s/revGeo' % (self.domain)
 

--- a/geopy/geocoders/navidata.py
+++ b/geopy/geocoders/navidata.py
@@ -1,0 +1,200 @@
+"""
+:class:`.NaviData` is the NaviData.pl geocoder.
+"""
+
+from geopy.compat import urlencode, string_compare
+from geopy.location import Location
+from geopy.point import Point
+from geopy.util import logger
+from geopy.geocoders.base import Geocoder, DEFAULT_TIMEOUT, DEFAULT_SCHEME
+
+from geopy.exc import (
+    GeocoderQueryError,
+    GeocoderQuotaExceeded,
+)
+
+
+__all__ = ("NaviData", )
+
+
+
+class NaviData(Geocoder):
+    """
+    Geocoder using the NaviData  API.
+    See http://www.navidata.pl
+    """
+
+    def __init__(
+            self,
+            api_key=None,
+            domain='api.navidata.pl',
+            timeout=DEFAULT_TIMEOUT,
+            proxies=None,
+    ):
+        """
+        Initialize NaviData geocoder. Please note that 'scheme' parameter is not supported - at present state, all
+        NaviData traffic use plain http.
+
+        :param string api_key: The commercial API key for service. None required if you
+            use this API for non-commercial puproses
+
+        :param string domain: Currently it is 'api.navidata.pl', can
+            be changed for testing purposes.
+
+        :param dict proxies: If specified, routes this geocoder's requests
+            through the specified proxy. E.g., {"https": "192.0.2.0"}. For
+            more information, see documentation on
+            :class:`urllib2.ProxyHandler`.
+
+        """
+        super(NaviData, self).__init__(
+            scheme="http", timeout=timeout, proxies=proxies
+        )
+
+        self.api_key = api_key
+        self.domain = domain.strip('/')
+        #self.scheme = scheme
+        self.geocode_api = 'http://%s/geocode' % (self.domain)
+        self.reverse_geocode_api = 'http://%s/revGeo' % (self.domain)
+
+    def geocode(
+            self,
+            query,
+            exactly_one=True,
+            timeout=None,
+    ):
+        """
+        Geocode a location query.
+
+        :param string query: The query string to be geocoded; this must
+            be URL encoded.
+
+        :param bool exactly_one: Return one result or a list of results, if
+            available.
+
+        :param int timeout: Time, in seconds, to wait for the geocoding service
+            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
+            exception. Set this only if you wish to override, on this call
+            only, the value set during the geocoder's initialization.
+
+        """
+        params = {
+            'q': self.format_string % query,
+        }
+
+
+        if self.api_key is not None:
+            params["api_key"] = self.api_key
+
+        url = "?".join((self.geocode_api, urlencode(params)))
+
+        logger.debug("%s.geocode: %s", self.__class__.__name__, url)
+        return self._parse_json_geocode(
+            self._call_geocoder(url, timeout=timeout), exactly_one
+        )
+
+    def reverse(
+            self,
+            query,
+            exactly_one=True,
+            timeout=None,
+    ):
+
+        """
+        Given a point, find an address.
+
+        :param query: The coordinates for which you wish to obtain the
+            closest human-readable addresses.
+        :type query: :class:`geopy.point.Point`, list or tuple of (latitude,
+            longitude), or string as "%(latitude)s, %(longitude)s"
+
+        :param boolean exactly_one: Return one result or a list of results, if
+            available. Currently this has no effect (only one address is returned by API)
+
+        :param int timeout: Time, in seconds, to wait for the geocoding service
+            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
+            exception. Set this only if you wish to override, on this call
+            only, the value set during the geocoder's initialization.
+
+        """
+
+        (lat, lon) = self._coerce_point_to_string(query).split(',')
+
+        params = {
+            'lat': lat,
+            'lon': lon
+        }
+
+
+        if self.api_key is not None:
+            params["api_key"] = self.api_key
+
+        url = "?".join((self.reverse_geocode_api, urlencode(params)))
+        logger.debug("%s.reverse: %s", self.__class__.__name__, url)
+        return self._parse_json_revgeocode(
+            self._call_geocoder(url, timeout=timeout), exactly_one
+        )
+
+    def _parse_json_geocode(self, page, exactly_one=True):
+        '''Returns location, (latitude, longitude) from json feed.'''
+
+        places = page
+
+        if not len(places):
+            #self._check_status(page.get('status'))
+            return None
+
+        def parse_place(place):
+            '''Get the location, lat, lon from a single json result.'''
+            location = place.get('description')
+            latitude = place.get('lat')
+            longitude = place.get('lon')
+            return Location(location, (latitude, longitude), place)
+
+        if exactly_one:
+            return parse_place(places[0])
+        else:
+            return [parse_place(place) for place in places]
+
+
+    def _parse_json_revgeocode(self, page, exactly_one=True):
+        '''Returns location, (latitude, longitude) from json feed.'''
+
+ 
+        result = page
+
+        if result.get('description', None) is None:
+            return None
+
+        location = result.get('description')
+        latitude = result.get('lat')
+        longitude = result.get('lon')
+
+        return Location(location, (latitude, longitude), result)
+
+
+    @staticmethod
+    def _check_status(status):
+        """
+        Validates error statuses.
+        """
+        status_code = status['code']
+
+        if status_code == 200:
+            # When there are no results, just return.
+            return
+
+        elif status_code == 429:
+            # Rate limit exceeded
+            raise GeocoderQuotaExceeded(
+                'The given key has gone over the requests limit in the 24'
+                ' hour period or has submitted too many requests in too'
+                ' short a period of time.'
+            )
+
+        elif status_code == 403:
+            raise GeocoderQueryError(
+                'Your request was denied.'
+            )
+        else:
+            raise GeocoderQueryError('Unknown error: ' + str(status_code))

--- a/test/geocoders/__init__.py
+++ b/test/geocoders/__init__.py
@@ -16,3 +16,5 @@ from .smartystreets import LiveAddressTestCase
 from .what3words import What3WordsTestCase
 from .yandex import YandexTestCase
 from .ignfrance import IGNFranceTestCase
+from .navidata import NaviDataTestCase
+

--- a/test/geocoders/navidata.py
+++ b/test/geocoders/navidata.py
@@ -1,0 +1,72 @@
+# -*- coding: UTF-8 -*-
+import unittest
+
+from geopy.compat import u
+from geopy.geocoders import NaviData
+from test.geocoders.util import GeocoderTestBase, env
+
+
+
+class NaviDataTestCase(GeocoderTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.delta = 0.04
+
+    def test_unicode_name(self):
+        """
+        NaviData.geocode unicode
+        """
+
+        self.geocoder = NaviData()
+        self.geocode_run(
+            {"query": "Warszawa, mazowieckie"},
+            {"latitude": 52.231, "longitude": 21.006},
+        )
+
+
+
+    def test_unicode_name_exactly_one_false(self):
+        """
+        NaviData.geocode unicode
+        """
+
+        self.geocoder = NaviData()
+        self.geocode_run(
+            {"query": "Warszawa, mazowieckie", "exactly_one" : False},
+            {"latitude": 52.231, "longitude": 21.006},
+        )
+
+    def test_api_key(self):
+        """
+        NaviData.geocode - test API key parameter. Given API key is bogus - but invalid keys are silently discarded by geocoding service so
+        for testing purposes this is fine
+        """
+
+        self.geocoder = NaviData(api_key='geopy_test')
+        self.geocode_run(
+            {"query": "Warszawa, mazowieckie"},
+            {"latitude": 52.231, "longitude": 21.006},
+        )
+
+    def test_reverse(self):
+        """
+        NaviData.reverse
+        """
+
+        self.geocoder = NaviData()
+        self.reverse_run(
+            {"query": "51.036963, 16.755802"},
+            {"latitude": 51.036963, "longitude": 16.755802},
+        )
+
+    def test_reverse_with_api(self):
+        """
+        NaviData.reverse
+        """
+
+        self.geocoder = NaviData(api_key='geopy_test')
+        self.reverse_run(
+            {"query": "51.036963, 16.755802"},
+            {"latitude": 51.036963, "longitude": 16.755802},
+        )


### PR DESCRIPTION
Recreating pull request due to technical problems. All discussed code parts from #96 have been fixed.

This pull request adds support for navidata.pl geocoding service. NaviData geocodes (and reverse geocodes) locations in Poland - Europe will be supported soon. API and services are free for non-commercial purposes.