### PR TITLE
Custom nominatim server

### DIFF
--- a/geopy/__init__.py
+++ b/geopy/__init__.py
@@ -13,4 +13,4 @@ from geopy.location import Location
 from geopy.geocoders import * # pylint: disable=W0401
 
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -40,6 +40,7 @@ class Nominatim(Geocoder):
             country_bias=None,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            api=None,
     ):  # pylint: disable=R0913
         """
         :param string format_string: String containing '%s' where the
@@ -57,6 +58,9 @@ class Nominatim(Geocoder):
             :class:`urllib2.ProxyHandler`.
 
             .. versionadded:: 0.96
+
+        :param string api: Use a different server than openstreetmap.org
+           .. versionadded:: 1.8.2
         """
         super(Nominatim, self).__init__(
             format_string, 'http', timeout, proxies
@@ -66,8 +70,8 @@ class Nominatim(Geocoder):
         self.view_box = view_box
         self.country_bias = country_bias
 
-        self.api = "%s://nominatim.openstreetmap.org/search" % self.scheme
-        self.reverse_api = (
+        self.api = api or ("%s://nominatim.openstreetmap.org/search" % self.scheme)
+        self.reverse_api = api or (
             "%s://nominatim.openstreetmap.org/reverse" % self.scheme
         )
 

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -74,10 +74,9 @@ class Nominatim(Geocoder):
         self.domain = domain.strip('/')
         self.scheme = scheme
 
-        self.api = ("%s://%s/search" % (self.scheme, self.domain))
-        self.reverse_api = (
-            "%s://%s/reverse" % (self.scheme, self.domain)
-        )
+        self.api = "%s://%s/search" % (self.scheme, self.domain)
+        self.reverse_api = "%s://%s/reverse" % (self.scheme, self.domain)
+
 
     def geocode(
             self,

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -6,6 +6,7 @@ from geopy.geocoders.base import (
     Geocoder,
     DEFAULT_FORMAT_STRING,
     DEFAULT_TIMEOUT,
+    DEFAULT_SCHEME
 )
 from geopy.compat import urlencode
 from geopy.location import Location
@@ -40,7 +41,8 @@ class Nominatim(Geocoder):
             country_bias=None,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
-            api=None,
+            domain='nominatim.openstreetmap.org',
+            scheme=DEFAULT_SCHEME
     ):  # pylint: disable=R0913
         """
         :param string format_string: String containing '%s' where the
@@ -69,10 +71,12 @@ class Nominatim(Geocoder):
         self.format_string = format_string
         self.view_box = view_box
         self.country_bias = country_bias
+        self.domain = domain.strip('/')
+        self.scheme = scheme
 
-        self.api = api or ("%s://nominatim.openstreetmap.org/search" % self.scheme)
-        self.reverse_api = api or (
-            "%s://nominatim.openstreetmap.org/reverse" % self.scheme
+        self.api = ("%s://%s/search" % (self.scheme, self.domain))
+        self.reverse_api = (
+            "%s://%s/reverse" % (self.scheme, self.domain)
         )
 
     def geocode(

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -61,8 +61,17 @@ class Nominatim(Geocoder):
 
             .. versionadded:: 0.96
 
-        :param string api: Use a different server than openstreetmap.org
-           .. versionadded:: 1.8.2
+        :param string domain: Should be the localized Openstreetmap domain to
+            connect to. The default is 'nominatim.openstreetmap.org', but you
+            can change it to a domain of your own.
+
+            .. versionadded:: 1.8.2
+
+        :param string scheme: Use 'https' or 'http' as the API URL's scheme.
+            Default is https. Note that SSL connections' certificates are not
+            verified.
+
+            .. versionadded:: 1.8.2
         """
         super(Nominatim, self).__init__(
             format_string, 'http', timeout, proxies


### PR DESCRIPTION
Allow one to specify a custom Nominatim server.

- adds **domain** and **scheme** parameter to Nominatim class.
- bump version to **1.8.2**
- does not break existing tests