### PR TITLE
Fix support for GoogleV3 bounds parameter

### DIFF
--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -136,6 +136,13 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
              for item in components.items()
             )
         )
+        
+    @staticmethod
+    def _format_bounds_param(bounds):
+      """
+      Format the bounds to something Google understands.
+      """
+      return '%f,%f|%f,%f' % (bounds[0], bounds[1], bounds[2], bounds[3])        
 
     def geocode(
             self,
@@ -187,7 +194,7 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
         if self.api_key:
             params['key'] = self.api_key
         if bounds:
-            params['bounds'] = bounds
+            params['bounds'] = self._format_bounds_param(bounds)
         if region:
             params['region'] = region
         if components:

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -202,3 +202,11 @@ class GoogleV3TestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
         with self.assertRaises(exc.GeocoderQueryError):
             self.geocoder.timezone(self.new_york_point, "eek")
 
+    def test_geocode(self):
+        """
+        GoogleV3.geocode check bounds restriction
+        """
+        self.geocode_run(
+            {"query": "221b Baker St", "bounds": [50, -2, 55, 2]},
+            {"latitude": 51.52, "longitude": -0.15},
+        )


### PR DESCRIPTION
GoogleV3 expects bounds in this format `lat,lon|lat,lon`.

From docs:
"The bounds parameter defines the latitude/longitude coordinates of the southwest and northeast corners of this bounding box using a pipe (|) character to separate the coordinates." (https://developers.google.com/maps/documentation/geocoding/)