### PR TITLE
Add British Columbia Physical Address Online Geocoder (DataBC).

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,9 @@ Geocoders
 .. autoclass:: geopy.geocoders.Bing
     :members: __init__, geocode, reverse
 
+.. autoclass:: geopy.geocoders.DataBC
+    :members: __init__, geocode
+
 .. autoclass:: geopy.geocoders.GeocodeFarm
     :members: __init__, geocode, reverse
 

--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -76,6 +76,7 @@ __all__ = (
     "ArcGIS",
     "Baidu",
     "Bing",
+    "DataBC",
     "GeocoderDotUS",
     "GeocodeFarm",
     "GeoNames",
@@ -95,6 +96,7 @@ __all__ = (
 from geopy.geocoders.arcgis import ArcGIS
 from geopy.geocoders.baidu import Baidu
 from geopy.geocoders.bing import Bing
+from geopy.geocoders.databc import DataBC
 from geopy.geocoders.dot_us import GeocoderDotUS
 from geopy.geocoders.geocodefarm import GeocodeFarm
 from geopy.geocoders.geonames import GeoNames
@@ -117,6 +119,7 @@ SERVICE_TO_GEOCODER = {
     "arcgis": ArcGIS,
     "baidu": Baidu,
     "bing": Bing,
+    "databc": DataBC,
     "google": GoogleV3,
     "googlev3": GoogleV3,
     "geocoderdotus": GeocoderDotUS,

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -1,0 +1,103 @@
+"""
+:class:`.DataBC` geocoder.
+"""
+
+import json
+from geopy.compat import urlencode, Request
+
+from geopy.geocoders.base import Geocoder, DEFAULT_SCHEME, DEFAULT_TIMEOUT
+from geopy.exc import GeocoderQueryError
+from geopy.location import Location
+from geopy.util import logger
+
+
+__all__ = ("DataBC", )
+
+
+class DataBC(Geocoder):
+    """
+    Geocoder using the Physical Address Geocoder from DataBC. Documentation at:
+        http://www.data.gov.bc.ca/dbc/geographic/locate/geocoding.page
+    """
+
+    def __init__(self, scheme=DEFAULT_SCHEME, timeout=DEFAULT_TIMEOUT, proxies=None):
+        """
+        Create a DataBC-based geocoder.
+
+        :param string scheme: Desired scheme.
+
+        :param int timeout: Time, in seconds, to wait for the geocoding service
+            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
+            exception.
+
+        :param dict proxies: If specified, routes this geocoder's requests
+            through the specified proxy. E.g., {"https": "192.0.2.0"}. For
+            more information, see documentation on
+            :class:`urllib2.ProxyHandler`.
+        """
+        super(DataBC, self).__init__(
+            scheme=scheme, timeout=timeout, proxies=proxies
+        )
+        self.api = '%s://apps.gov.bc.ca/pub/geocoder/addresses.geojson' % self.scheme
+
+    def geocode(self, query, max_results = 25, set_back = 0, location_descriptor = 'any', exactly_one=True, timeout=None):
+        """
+        Geocode a location query.
+
+        :param string query: The address or query you wish to geocode.
+
+        :param int max_results: The maximum number of resutls to request.
+        
+        :param float set_back: The distance to move the accessPoint away 
+            from the curb (in meters) and towards the interior of the parcel.
+            location_descriptor must be set to accessPoint for set_back to 
+            take effect.
+
+        :param string location_descriptor: The type of point requested. It
+            can be any, accessPoint, frontDoorPoint, parcelPoint,
+            rooftopPoint and routingPoint.
+
+        :param bool exactly_one: Return one result or a list of results, if
+            available.
+
+        :param int timeout: Time, in seconds, to wait for the geocoding service
+            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
+            exception. Set this only if you wish to override, on this call
+            only, the value set during the geocoder's initialization.
+        """
+        params = {'addressString': query}
+        if set_back != 0:
+            params['setBack'] = set_back
+        if location_descriptor not in ['any',
+                                       'accessPoint',
+                                       'frontDoorPoint',
+                                       'parcelPoint',
+                                       'rooftopPoint',
+                                       'routingPoint']:
+            raise GeocoderQueryError("""You did not provided a location_descriptor
+            the webservice can consume. It should be any, accessPoint,
+            frontDoorPoint, parcelPoint, rooftopPoint or routingPoint.""")
+        params['locationDescriptor'] = location_descriptor
+        if exactly_one is True:
+            max_results = 1
+        params['maxResults'] = max_results
+
+        url = "?".join((self.api, urlencode(params)))
+        logger.debug("%s.geocode: %s", self.__class__.__name__, url)
+        response = self._call_geocoder(url, timeout=timeout)
+
+        # Success; convert from GeoJSON
+        if not len(response['features']):
+            return None
+        geocoded = []
+        for feature in response['features']:
+            geocoded.append(self._parse_feature(feature))
+        if exactly_one is True:
+            return geocoded[0]
+        return geocoded
+
+    @staticmethod
+    def _parse_feature(feature):
+        properties = feature['properties']
+        coordinates = feature['geometry']['coordinates']
+        return Location(properties['fullAddress'], (coordinates[1], coordinates[0]), properties)

--- a/test/geocoders/__init__.py
+++ b/test/geocoders/__init__.py
@@ -3,6 +3,7 @@ from .arcgis import ArcGISTestCase, ArcGISAuthenticatedTestCase
 from .baidu import BaiduTestCase
 from .base import GeocoderTestCase
 from .bing import BingTestCase
+from .databc import DataBCTestCase
 from .dotus import GeocoderDotUSTestCase
 from .geocodefarm import GeocodeFarmTestCase
 from .geonames import GeoNamesTestCase

--- a/test/geocoders/databc.py
+++ b/test/geocoders/databc.py
@@ -1,0 +1,74 @@
+
+import unittest
+
+from geopy.compat import u
+from geopy.point import Point
+from geopy.exc import GeocoderQueryError
+from geopy.geocoders import DataBC
+from test.geocoders.util import GeocoderTestBase, env
+
+
+class DataBCTestCase(GeocoderTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.geocoder = DataBC()
+
+    def test_geocode(self):
+        """
+        DataBC.geocode
+        """
+        res = self._make_request(
+            self.geocoder.geocode,
+            "135 North Pym Road, Parksville"
+        )
+        self.assertAlmostEqual(res.latitude, 49.321, delta=self.delta)
+        self.assertAlmostEqual(res.longitude, -124.337, delta=self.delta)
+
+    def test_unicode_name(self):
+        """
+        DataBC.geocode unicode
+        """
+        res = self._make_request(
+            self.geocoder.geocode,
+            u("Barri\u00e8re"),
+        )
+        self.assertAlmostEqual(res.latitude, 51.179, delta=self.delta)
+        self.assertAlmostEqual(res.longitude, -120.123, delta=self.delta)
+
+    def test_multiple_results(self):
+        """
+        DataBC.geocode with multiple results
+        """
+        res = self._make_request(
+            self.geocoder.geocode,
+            "1st St",
+            exactly_one=False
+        )
+
+        self.assertGreater(len(res), 1)
+
+    def test_optional_params(self):
+        """
+        DataBC.geocode using optional params
+        """
+
+        res = self._make_request(
+            self.geocoder.geocode,
+            "5670 malibu terrace nanaimo bc",
+            location_descriptor="accessPoint",
+            set_back=100
+        )
+        self.assertAlmostEqual(res.latitude, 49.2299, delta=self.delta)
+        self.assertAlmostEqual(res.longitude, -124.0163, delta=self.delta)
+
+    def test_query_error(self):
+        """
+        DataBC.geocode with bad query parameters
+        """
+        with self.assertRaises(GeocoderQueryError):
+          res = self._make_request(
+              self.geocoder.geocode,
+              "1 Main St, Vancouver",
+              location_descriptor="access_Point",
+          )


### PR DESCRIPTION
Adding support for forward geocoding from the BC government's Physical Address Online Geocoder: http://www.data.gov.bc.ca/dbc/geographic/locate/geocoding.page (shortened as DataBC).

Test cases included. 