### PR TITLE
Added possibility to add a custom http request user agent header

### DIFF
--- a/geopy/__init__.py
+++ b/geopy/__init__.py
@@ -13,4 +13,4 @@ from geopy.location import Location
 from geopy.geocoders import * # pylint: disable=W0401
 
 
-__version__ = "1.10.0"
+from geopy.version import GEOPY_VERSION as __version__

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -29,7 +29,8 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
 
     def __init__(self, username=None, password=None, referer=None, # pylint: disable=R0913
                  token_lifetime=60, scheme=DEFAULT_SCHEME,
-                 timeout=DEFAULT_TIMEOUT, proxies=None):
+                 timeout=DEFAULT_TIMEOUT, proxies=None,
+                user_agent=None):
         """
         Create a ArcGIS-based geocoder.
 
@@ -63,7 +64,7 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
             :class:`urllib2.ProxyHandler`.
         """
         super(ArcGIS, self).__init__(
-            scheme=scheme, timeout=timeout, proxies=proxies
+            scheme=scheme, timeout=timeout, proxies=proxies, user_agent=user_agent
         )
         if username or password or referer:
             if not (username and password and referer):

--- a/geopy/geocoders/baidu.py
+++ b/geopy/geocoders/baidu.py
@@ -28,6 +28,7 @@ class Baidu(Geocoder):
             scheme='http',
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            user_agent=None
         ):
         """
         Initialize a customized Baidu geocoder using the v2 API.
@@ -47,7 +48,7 @@ class Baidu(Geocoder):
             :class:`urllib2.ProxyHandler`.
         """
         super(Baidu, self).__init__(
-            scheme=scheme, timeout=timeout, proxies=proxies
+            scheme=scheme, timeout=timeout, proxies=proxies, user_agent=user_agent
         )
         self.api_key = api_key
         self.scheme = scheme

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -45,10 +45,7 @@ DEFAULT_FORMAT_STRING = '%s'
 DEFAULT_SCHEME = 'https'
 DEFAULT_TIMEOUT = 1
 DEFAULT_WKID = 4326
-
-
-def get_default_user_agent():
-    return "geopy/" + gu.get_version()
+DEFAULT_USER_AGENT = "geopy/" + gu.get_version()
 
 
 ERROR_CODE_MAP = {
@@ -91,7 +88,7 @@ class Geocoder(object): # pylint: disable=R0921
             )
         self.proxies = proxies
         self.timeout = timeout
-        self.headers = {'User-Agent': user_agent or get_default_user_agent()}
+        self.headers = {'User-Agent': user_agent or DEFAULT_USER_AGENT}
 
         if self.proxies:
             install_opener(

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -29,7 +29,7 @@ from geopy.exc import (
     GeocoderUnavailable,
     GeocoderParseError,
 )
-from geopy.util import decode_page, get_version
+import geopy.util as gu
 
 
 __all__ = (
@@ -45,7 +45,11 @@ DEFAULT_FORMAT_STRING = '%s'
 DEFAULT_SCHEME = 'https'
 DEFAULT_TIMEOUT = 1
 DEFAULT_WKID = 4326
-DEFAULT_USER_AGENT = 'geopy/' + get_version()
+
+
+def get_default_user_agent():
+    return "geopy/" + gu.get_version()
+
 
 ERROR_CODE_MAP = {
     400: GeocoderQueryError,
@@ -73,7 +77,7 @@ class Geocoder(object): # pylint: disable=R0921
             scheme=DEFAULT_SCHEME,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
-            user_agent=DEFAULT_USER_AGENT
+            user_agent=None
         ):
         """
         Mostly-common geocoder validation, proxies, &c. Not all geocoders
@@ -87,7 +91,7 @@ class Geocoder(object): # pylint: disable=R0921
             )
         self.proxies = proxies
         self.timeout = timeout
-        self.headers = {'User-Agent': user_agent }
+        self.headers = {'User-Agent': user_agent or get_default_user_agent()}
 
         if self.proxies:
             install_opener(
@@ -172,12 +176,12 @@ class Geocoder(object): # pylint: disable=R0921
         else:
             status_code = None
         if status_code in ERROR_CODE_MAP:
-            raise ERROR_CODE_MAP[page.status_code]("\n%s" % decode_page(page))
+            raise ERROR_CODE_MAP[page.status_code]("\n%s" % gu.decode_page(page))
 
         if raw:
             return page
 
-        page = decode_page(page)
+        page = gu.decode_page(page)
 
         if deserializer is not None:
             try:

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -15,6 +15,7 @@ from geopy.compat import (
     ProxyHandler,
     URLError,
     install_opener,
+    Request,
 )
 from geopy.point import Point
 from geopy.exc import (
@@ -28,7 +29,7 @@ from geopy.exc import (
     GeocoderUnavailable,
     GeocoderParseError,
 )
-from geopy.util import decode_page
+from geopy.util import decode_page, get_version
 
 
 __all__ = (
@@ -44,6 +45,7 @@ DEFAULT_FORMAT_STRING = '%s'
 DEFAULT_SCHEME = 'https'
 DEFAULT_TIMEOUT = 1
 DEFAULT_WKID = 4326
+DEFAULT_USER_AGENT = 'geopy/' + get_version()
 
 ERROR_CODE_MAP = {
     400: GeocoderQueryError,
@@ -70,7 +72,8 @@ class Geocoder(object): # pylint: disable=R0921
             format_string=DEFAULT_FORMAT_STRING,
             scheme=DEFAULT_SCHEME,
             timeout=DEFAULT_TIMEOUT,
-            proxies=None
+            proxies=None,
+            user_agent=DEFAULT_USER_AGENT
         ):
         """
         Mostly-common geocoder validation, proxies, &c. Not all geocoders
@@ -84,6 +87,7 @@ class Geocoder(object): # pylint: disable=R0921
             )
         self.proxies = proxies
         self.timeout = timeout
+        self.headers = {'User-Agent': user_agent }
 
         if self.proxies:
             install_opener(
@@ -129,7 +133,9 @@ class Geocoder(object): # pylint: disable=R0921
         requester = requester or self.urlopen
 
         try:
-            page = requester(url, timeout=(timeout or self.timeout), **kwargs)
+            req = Request(url=url, headers=self.headers)
+            print req.headers
+            page = requester(req, timeout=(timeout or self.timeout), **kwargs)
         except Exception as error: # pylint: disable=W0703
             message = (
                 str(error) if not py3k

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -138,7 +138,6 @@ class Geocoder(object): # pylint: disable=R0921
 
         try:
             req = Request(url=url, headers=self.headers)
-            print req.headers
             page = requester(req, timeout=(timeout or self.timeout), **kwargs)
         except Exception as error: # pylint: disable=W0703
             message = (

--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -40,6 +40,7 @@ class Bing(Geocoder):
             scheme=DEFAULT_SCHEME,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            user_agent=None,
         ):  # pylint: disable=R0913
         """Initialize a customized Bing geocoder with location-specific
         address information and your Bing Maps API key.
@@ -70,7 +71,7 @@ class Bing(Geocoder):
 
             .. versionadded:: 0.96
         """
-        super(Bing, self).__init__(format_string, scheme, timeout, proxies)
+        super(Bing, self).__init__(format_string, scheme, timeout, proxies, user_agent=user_agent)
         self.api_key = api_key
         self.api = "%s://dev.virtualearth.net/REST/v1/Locations" % self.scheme
 

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -19,7 +19,7 @@ class DataBC(Geocoder):
         http://www.data.gov.bc.ca/dbc/geographic/locate/geocoding.page
     """
 
-    def __init__(self, scheme=DEFAULT_SCHEME, timeout=DEFAULT_TIMEOUT, proxies=None):
+    def __init__(self, scheme=DEFAULT_SCHEME, timeout=DEFAULT_TIMEOUT, proxies=None, user_agent=None):
         """
         Create a DataBC-based geocoder.
 
@@ -35,7 +35,7 @@ class DataBC(Geocoder):
             :class:`urllib2.ProxyHandler`.
         """
         super(DataBC, self).__init__(
-            scheme=scheme, timeout=timeout, proxies=proxies
+            scheme=scheme, timeout=timeout, proxies=proxies, user_agent=user_agent
         )
         self.api = '%s://apps.gov.bc.ca/pub/geocoder/addresses.geojson' % self.scheme
 

--- a/geopy/geocoders/dot_us.py
+++ b/geopy/geocoders/dot_us.py
@@ -33,6 +33,7 @@ class GeocoderDotUS(Geocoder):  # pylint: disable=W0223
             format_string=DEFAULT_FORMAT_STRING,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            user_agent=None,
         ):  # pylint: disable=R0913
         """
         :param string username:
@@ -58,7 +59,7 @@ class GeocoderDotUS(Geocoder):  # pylint: disable=W0223
             .. versionadded:: 0.96
         """
         super(GeocoderDotUS, self).__init__(
-            format_string=format_string, timeout=timeout, proxies=proxies
+            format_string=format_string, timeout=timeout, proxies=proxies, user_agent=user_agent
         )
         if username or password:
             if not (username and password):

--- a/geopy/geocoders/geocodefarm.py
+++ b/geopy/geocoders/geocodefarm.py
@@ -26,6 +26,7 @@ class GeocodeFarm(Geocoder):
             format_string=DEFAULT_FORMAT_STRING,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            user_agent=None,
         ):  # pylint: disable=R0913
         """
         Create a geocoder for GeocodeFarm.
@@ -46,7 +47,7 @@ class GeocodeFarm(Geocoder):
             :class:`urllib2.ProxyHandler`.
         """
         super(GeocodeFarm, self).__init__(
-            format_string, 'https', timeout, proxies
+            format_string, 'https', timeout, proxies, user_agent=user_agent
         )
         self.api_key = api_key
         self.format_string = format_string

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -31,7 +31,8 @@ class GeoNames(Geocoder): # pylint: disable=W0223
             country_bias=None,
             username=None,
             timeout=DEFAULT_TIMEOUT,
-            proxies=None
+            proxies=None,
+            user_agent=None,
         ):
         """
         :param string country_bias:
@@ -52,7 +53,7 @@ class GeoNames(Geocoder): # pylint: disable=W0223
             .. versionadded:: 0.96
         """
         super(GeoNames, self).__init__(
-            scheme='http', timeout=timeout, proxies=proxies
+            scheme='http', timeout=timeout, proxies=proxies, user_agent=user_agent
         )
         if username == None:
             raise ConfigurationError(

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -44,7 +44,8 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
             client_id=None,
             secret_key=None,
             timeout=DEFAULT_TIMEOUT,
-            proxies=None
+            proxies=None,
+            user_agent=None,
         ):  # pylint: disable=R0913
         """
         Initialize a customized Google geocoder.
@@ -80,7 +81,7 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
             .. versionadded:: 0.96
         """
         super(GoogleV3, self).__init__(
-            scheme=scheme, timeout=timeout, proxies=proxies
+            scheme=scheme, timeout=timeout, proxies=proxies, user_agent=user_agent
         )
         if client_id and not secret_key:
             raise ConfigurationError('Must provide secret_key with client_id.')

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -50,6 +50,7 @@ class IGNFrance(Geocoder):   # pylint: disable=W0223
             scheme=DEFAULT_SCHEME,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            user_agent=None,
     ):  # pylint: disable=R0913
         """
         Initialize a customized IGN France geocoder.
@@ -88,7 +89,7 @@ class IGNFrance(Geocoder):   # pylint: disable=W0223
 
         """
         super(IGNFrance, self).__init__(
-            scheme=scheme, timeout=timeout, proxies=proxies
+            scheme=scheme, timeout=timeout, proxies=proxies, user_agent=user_agent
         )
 
         # Catch if no api key with username and password

--- a/geopy/geocoders/navidata.py
+++ b/geopy/geocoders/navidata.py
@@ -29,6 +29,7 @@ class NaviData(Geocoder):  # pylint: disable=W0223
             domain='api.navidata.pl',
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            user_agent=None,
     ):
         """
             .. versionadded:: 1.8.0
@@ -49,7 +50,7 @@ class NaviData(Geocoder):  # pylint: disable=W0223
 
         """
         super(NaviData, self).__init__(
-            scheme="http", timeout=timeout, proxies=proxies
+            scheme="http", timeout=timeout, proxies=proxies, user_agent=user_agent
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -30,6 +30,7 @@ class OpenCage(Geocoder):
             scheme=DEFAULT_SCHEME,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            user_agent=None,
     ):  # pylint: disable=R0913
         """
         Initialize a customized Open Cage Data geocoder.
@@ -52,7 +53,7 @@ class OpenCage(Geocoder):
 
         """
         super(OpenCage, self).__init__(
-            scheme=scheme, timeout=timeout, proxies=proxies
+            scheme=scheme, timeout=timeout, proxies=proxies, user_agent=user_agent
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -29,6 +29,7 @@ class OpenMapQuest(Geocoder): # pylint: disable=W0223
             scheme=DEFAULT_SCHEME,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            user_agent=None,
         ):  # pylint: disable=R0913
         """
         Initialize an Open MapQuest geocoder with location-specific
@@ -60,7 +61,7 @@ class OpenMapQuest(Geocoder): # pylint: disable=W0223
             .. versionadded:: 0.96
         """
         super(OpenMapQuest, self).__init__(
-            format_string, scheme, timeout, proxies
+            format_string, scheme, timeout, proxies, user_agent=user_agent
         )
         self.api_key = api_key or ''
         self.api = "%s://open.mapquestapi.com/nominatim/v1/search" \

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -156,7 +156,8 @@ class Nominatim(Geocoder):
             params = {'q': self.format_string % query}
 
         params.update({
-            'view_box': self.view_box,
+            # `viewbox` apparently replaces `view_box`
+            'viewbox': self.view_box,
             'format': 'json'
         })
 

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -6,8 +6,7 @@ from geopy.geocoders.base import (
     Geocoder,
     DEFAULT_FORMAT_STRING,
     DEFAULT_TIMEOUT,
-    DEFAULT_SCHEME,
-    DEFAULT_USER_AGENT
+    DEFAULT_SCHEME
 )
 from geopy.compat import urlencode
 from geopy.location import Location
@@ -44,7 +43,7 @@ class Nominatim(Geocoder):
             proxies=None,
             domain='nominatim.openstreetmap.org',
             scheme=DEFAULT_SCHEME,
-            user_agent=DEFAULT_USER_AGENT
+            user_agent=None
     ):  # pylint: disable=R0913
         """
         :param string format_string: String containing '%s' where the

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -6,7 +6,8 @@ from geopy.geocoders.base import (
     Geocoder,
     DEFAULT_FORMAT_STRING,
     DEFAULT_TIMEOUT,
-    DEFAULT_SCHEME
+    DEFAULT_SCHEME,
+    DEFAULT_USER_AGENT
 )
 from geopy.compat import urlencode
 from geopy.location import Location
@@ -42,7 +43,8 @@ class Nominatim(Geocoder):
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
             domain='nominatim.openstreetmap.org',
-            scheme=DEFAULT_SCHEME
+            scheme=DEFAULT_SCHEME,
+            user_agent=DEFAULT_USER_AGENT
     ):  # pylint: disable=R0913
         """
         :param string format_string: String containing '%s' where the
@@ -74,7 +76,7 @@ class Nominatim(Geocoder):
             .. versionadded:: 1.8.2
         """
         super(Nominatim, self).__init__(
-            format_string, scheme, timeout, proxies
+            format_string, scheme, timeout, proxies, user_agent=user_agent
         )
         self.country_bias = country_bias
         self.format_string = format_string

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -86,7 +86,6 @@ class Nominatim(Geocoder):
         self.api = "%s://%s/search" % (self.scheme, self.domain)
         self.reverse_api = "%s://%s/reverse" % (self.scheme, self.domain)
 
-
     def geocode(
             self,
             query,
@@ -157,8 +156,7 @@ class Nominatim(Geocoder):
             params = {'q': self.format_string % query}
 
         params.update({
-            # `viewbox` apparently replaces `view_box`
-            'viewbox': self.view_box,
+            'view_box': self.view_box,
             'format': 'json'
         })
 

--- a/geopy/geocoders/placefinder.py
+++ b/geopy/geocoders/placefinder.py
@@ -29,7 +29,8 @@ class YahooPlaceFinder(Geocoder): # pylint: disable=W0223
             consumer_key,
             consumer_secret,
             timeout=DEFAULT_TIMEOUT,
-            proxies=None
+            proxies=None,
+            user_agent=None,
         ):  # pylint: disable=R0913
         """
         :param string consumer_key: Key provided by Yahoo.
@@ -54,7 +55,7 @@ class YahooPlaceFinder(Geocoder): # pylint: disable=W0223
                 ' Install with `pip install geopy -e ".[placefinder]"`.'
             )
         super(YahooPlaceFinder, self).__init__(
-            timeout=timeout, proxies=proxies
+            timeout=timeout, proxies=proxies, user_agent=user_agent
         )
         self.consumer_key = (
             unicode(consumer_key)
@@ -138,7 +139,6 @@ class YahooPlaceFinder(Geocoder): # pylint: disable=W0223
             min_quality=0,
             reverse=False,
             valid_country_codes=None,
-            with_timezone=False,
         ):  # pylint: disable=W0221,R0913
         """
         Geocode a location query.
@@ -154,9 +154,6 @@ class YahooPlaceFinder(Geocoder): # pylint: disable=W0223
 
         :param valid_country_codes:
         :type valid_country_codes: list or tuple
-
-        :param bool with_timezone: Include the timezone in the response's
-            `raw` dictionary (as `timezone`).
         """
         params = {
             "location": query,
@@ -167,8 +164,6 @@ class YahooPlaceFinder(Geocoder): # pylint: disable=W0223
             params["gflags"] = "R"
         if exactly_one is True:
             params["count"] = "1"
-        if with_timezone is True:
-            params['flags'] += 'T' #Return timezone
 
         response = self._call_geocoder(
             self.api,

--- a/geopy/geocoders/placefinder.py
+++ b/geopy/geocoders/placefinder.py
@@ -139,6 +139,7 @@ class YahooPlaceFinder(Geocoder): # pylint: disable=W0223
             min_quality=0,
             reverse=False,
             valid_country_codes=None,
+            with_timezone=False,
         ):  # pylint: disable=W0221,R0913
         """
         Geocode a location query.
@@ -154,6 +155,9 @@ class YahooPlaceFinder(Geocoder): # pylint: disable=W0223
 
         :param valid_country_codes:
         :type valid_country_codes: list or tuple
+
+        :param bool with_timezone: Include the timezone in the response's
+            `raw` dictionary (as `timezone`).
         """
         params = {
             "location": query,
@@ -164,6 +168,8 @@ class YahooPlaceFinder(Geocoder): # pylint: disable=W0223
             params["gflags"] = "R"
         if exactly_one is True:
             params["count"] = "1"
+        if with_timezone is True:
+            params['flags'] += 'T' #Return timezone
 
         response = self._call_geocoder(
             self.api,

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -25,7 +25,8 @@ class LiveAddress(Geocoder):  # pylint: disable=W0223
             candidates=1,
             scheme=DEFAULT_SCHEME,
             timeout=DEFAULT_TIMEOUT,
-            proxies=None
+            proxies=None,
+            user_agent=None,
         ):  # pylint: disable=R0913
         """
         Initialize a customized SmartyStreets LiveAddress geocoder.
@@ -64,7 +65,7 @@ class LiveAddress(Geocoder):  # pylint: disable=W0223
             .. versionadded:: 0.96
         """
         super(LiveAddress, self).__init__(
-            timeout=timeout, proxies=proxies
+            timeout=timeout, proxies=proxies, user_agent=user_agent
         )
         if scheme == "http":
             raise ConfigurationError("LiveAddress now requires `https`.")

--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -36,6 +36,7 @@ class What3Words(Geocoder):
             scheme=DEFAULT_SCHEME,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
+            user_agent=None,
     ):
         """
         Initialize a What3Words geocoder with 3-word or OneWord-address and
@@ -69,7 +70,8 @@ class What3Words(Geocoder):
             format_string,
             scheme,
             timeout,
-            proxies
+            proxies,
+            user_agent=user_agent,
         )
         self.api_key = api_key
         self.api = (

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -27,7 +27,8 @@ class Yandex(Geocoder): # pylint: disable=W0223
             api_key=None,
             lang=None,
             timeout=DEFAULT_TIMEOUT,
-            proxies=None
+            proxies=None,
+            user_agent=None,
         ):
         """
         Create a Yandex-based geocoder.
@@ -50,7 +51,7 @@ class Yandex(Geocoder): # pylint: disable=W0223
             :class:`urllib2.ProxyHandler`.
         """
         super(Yandex, self).__init__(
-            scheme='http', timeout=timeout, proxies=proxies
+            scheme='http', timeout=timeout, proxies=proxies, user_agent=user_agent
         )
         self.api_key = api_key
         self.lang = lang

--- a/geopy/util.py
+++ b/geopy/util.py
@@ -83,6 +83,7 @@ else:
 
 
 def get_version():
-    #from geopy import geopy
-    #return str(geopy.__version__)
-    return "0.0"
+    import geopy
+    return str(geopy.__version__)
+
+

--- a/geopy/util.py
+++ b/geopy/util.py
@@ -83,7 +83,7 @@ else:
 
 
 def get_version():
-    import geopy
-    return str(geopy.__version__)
+    from geopy.version import GEOPY_VERSION
+    return str(GEOPY_VERSION)
 
 

--- a/geopy/util.py
+++ b/geopy/util.py
@@ -80,3 +80,9 @@ else:
         else: # requests?
             encoding = page.headers.get("charset") or "utf-8"
             return str(page.content, encoding=encoding)
+
+
+def get_version():
+    #from geopy import geopy
+    #return str(geopy.__version__)
+    return "0.0"

--- a/geopy/version.py
+++ b/geopy/version.py
@@ -1,0 +1,3 @@
+__author__ = 'neubauer'
+
+GEOPY_VERSION = "1.9.1"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ INSTALL_REQUIRES = []
 TESTS_REQUIRES = [
     'nose-cov',
     'pylint',
-    'tox'
+    'tox',
+    'mock'
 ]
 
 

--- a/test/geocoders/arcgis.py
+++ b/test/geocoders/arcgis.py
@@ -7,6 +7,14 @@ from geopy.point import Point
 from geopy.geocoders import ArcGIS
 from test.geocoders.util import GeocoderTestBase, env
 
+class ArcGISTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = ArcGIS(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
 
 @unittest.skipUnless(  # pylint: disable=R0904,C0111
     bool(env.get('ARCGIS_USERNAME')),

--- a/test/geocoders/baidu.py
+++ b/test/geocoders/baidu.py
@@ -7,6 +7,16 @@ from geopy.geocoders import Baidu
 from test.geocoders.util import GeocoderTestBase, env
 
 
+class BaiduTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = Baidu(
+            api_key='DUMMYKEY1234',
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
+
 @unittest.skipUnless(  # pylint: disable=R0904,C0111
     bool(env.get('BAIDU_KEY')),
     "No BAIDU_KEY env variable set"

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -5,7 +5,7 @@ from mock import patch
 from geopy.point import Point
 from geopy.exc import GeocoderNotFound
 from geopy.geocoders import get_geocoder_for_service, GoogleV3
-from geopy.geocoders.base import Geocoder, DEFAULT_TIMEOUT
+from geopy.geocoders.base import Geocoder, DEFAULT_TIMEOUT, get_default_user_agent
 
 
 class GetGeocoderTestCase(unittest.TestCase):
@@ -53,9 +53,17 @@ class GeocoderTestCase(unittest.TestCase):
 
     @patch('geopy.util.get_version')
     def test_user_agent_default(self, mocked_getversion):
-        from geopy.geocoders.base import DEFAULT_USER_AGENT
         mocked_getversion.return_value = '1.2.3'
-        self.assertEqual(DEFAULT_USER_AGENT, 'geopy/1.2.3')
+        #mmh mocking doesn't work at the moment
+        self.assertEqual(get_default_user_agent(), 'geopy/1.2.3')
+        geocoder = Geocoder()
+        self.assertEqual(geocoder.headers['User-Agent'], 'geopy/1.2.3')
+
+    def test_user_agent_custom(self):
+        geocoder = Geocoder(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
 
     def test_point_coercion_point(self):
         """

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -5,8 +5,8 @@ from mock import patch
 from geopy.point import Point
 from geopy.exc import GeocoderNotFound
 from geopy.geocoders import get_geocoder_for_service, GoogleV3
-from geopy.geocoders.base import Geocoder, DEFAULT_TIMEOUT, get_default_user_agent
-
+from geopy.geocoders.base import Geocoder, DEFAULT_TIMEOUT
+import geopy.geocoders.base
 
 class GetGeocoderTestCase(unittest.TestCase):
 
@@ -51,13 +51,11 @@ class GeocoderTestCase(unittest.TestCase):
         for attr in ('format_string', 'scheme', 'timeout', 'proxies'):
             self.assertEqual(locals()[attr], getattr(geocoder, attr))
 
-    @patch('geopy.util.get_version')
-    def test_user_agent_default(self, mocked_getversion):
-        mocked_getversion.return_value = '1.2.3'
-        #mmh mocking doesn't work at the moment
-        self.assertEqual(get_default_user_agent(), 'geopy/1.2.3')
-        geocoder = Geocoder()
-        self.assertEqual(geocoder.headers['User-Agent'], 'geopy/1.2.3')
+    def test_user_agent_default(self):
+        with patch('geopy.geocoders.base.DEFAULT_USER_AGENT', 'mocked_user_agent/0.0.0'):
+            self.assertEqual(geopy.geocoders.base.DEFAULT_USER_AGENT, 'mocked_user_agent/0.0.0')
+            geocoder = Geocoder()
+            self.assertEqual(geocoder.headers['User-Agent'], 'mocked_user_agent/0.0.0')
 
     def test_user_agent_custom(self):
         geocoder = Geocoder(

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -1,5 +1,6 @@
 
 import unittest
+from mock import patch
 
 from geopy.point import Point
 from geopy.exc import GeocoderNotFound
@@ -49,6 +50,12 @@ class GeocoderTestCase(unittest.TestCase):
         )
         for attr in ('format_string', 'scheme', 'timeout', 'proxies'):
             self.assertEqual(locals()[attr], getattr(geocoder, attr))
+
+    @patch('geopy.util.get_version')
+    def test_user_agent_default(self, mocked_getversion):
+        from geopy.geocoders.base import DEFAULT_USER_AGENT
+        mocked_getversion.return_value = '1.2.3'
+        self.assertEqual(DEFAULT_USER_AGENT, 'geopy/1.2.3')
 
     def test_point_coercion_point(self):
         """

--- a/test/geocoders/bing.py
+++ b/test/geocoders/bing.py
@@ -7,6 +7,16 @@ from geopy.geocoders import Bing
 from test.geocoders.util import GeocoderTestBase, env
 
 
+class BingTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = Bing(
+            api_key='DUMMYKEY1234',
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
+
 @unittest.skipUnless(  # pylint: disable=R0904,C0111
     bool(env.get('BING_KEY')),
     "No BING_KEY env variable set"

--- a/test/geocoders/databc.py
+++ b/test/geocoders/databc.py
@@ -14,6 +14,12 @@ class DataBCTestCase(GeocoderTestBase):
     def setUpClass(cls):
         cls.geocoder = DataBC()
 
+    def test_user_agent_custom(self):
+        geocoder = DataBC(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
     def test_geocode(self):
         """
         DataBC.geocode

--- a/test/geocoders/dotus.py
+++ b/test/geocoders/dotus.py
@@ -6,6 +6,16 @@ from geopy.compat import py3k
 from geopy.geocoders import GeocoderDotUS
 from test.geocoders.util import GeocoderTestBase, env
 
+
+class GeocoderDotUSTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = GeocoderDotUS(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
+
 @unittest.skipUnless(  # pylint: disable=R0904,C0111
     bool(env.get('GEOCODERDOTUS_USERNAME')) and \
     bool(env.get('GEOCODERDOTUS_PASSWORD')),

--- a/test/geocoders/geocodefarm.py
+++ b/test/geocoders/geocodefarm.py
@@ -26,6 +26,12 @@ class GeocodeFarmTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
         # Restore the original _call_geocoder in case we replaced it with a mock
         self.geocoder._call_geocoder = self._original_call_geocoder
 
+    def test_user_agent_custom(self):
+        geocoder = GeocodeFarm(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
     def test_geocode(self):
         """
         GeocodeFarm.geocode

--- a/test/geocoders/geonames.py
+++ b/test/geocoders/geonames.py
@@ -6,6 +6,16 @@ from geopy.geocoders import GeoNames
 from test.geocoders.util import GeocoderTestBase, env
 
 
+class GeoNamesTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = GeoNames(
+            username='DUMMYUSER_NORBERT',
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
+
 @unittest.skipUnless(  # pylint: disable=R0904,C0111
     bool(env.get('GEONAMES_USERNAME')),
     "No GEONAMES_USERNAME env variable set"

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -17,6 +17,12 @@ class GoogleV3TestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
         cls.new_york_point = Point(40.75376406311989, -73.98489005863667)
         cls.america_new_york = timezone("America/New_York")
 
+    def test_user_agent_custom(self):
+        geocoder = GoogleV3(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
     def test_configuration_error(self):
         """
         GoogleV3 raises configuration errors on invalid auth params

--- a/test/geocoders/ignfrance.py
+++ b/test/geocoders/ignfrance.py
@@ -11,6 +11,18 @@ credentials = bool((env.get('IGNFRANCE_KEY') and
          (env.get('IGNFRANCE_KEY') and
           env.get('IGNFRANCE_REFERER')))
 
+
+class IGNFranceTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = IGNFrance(
+            api_key='DUMMYKEY1234',
+            username='MUSTERMANN',
+            password='tops3cr3t',
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
 @unittest.skipUnless(  # pylint: disable=R0904,C0111
     credentials,
     "One or more of the env variables IGNFRANCE_KEY, IGNFRANCE_USERNAME \

--- a/test/geocoders/navidata.py
+++ b/test/geocoders/navidata.py
@@ -13,6 +13,12 @@ class NaviDataTestCase(GeocoderTestBase):
     def setUpClass(cls):
         cls.delta = 0.04
 
+    def test_user_agent_custom(self):
+        geocoder = NaviData(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
     def test_unicode_name(self):
         """
         NaviData.geocode unicode

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -33,11 +33,10 @@ class NominatimTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
             {"latitude": 39.916, "longitude": 116.390},
         )
 
-    @patch('geopy.util.get_version')
-    def test_user_agent_default(self, mocked_getversion):
-        mocked_getversion.return_value = '1.2.3'
-        geocoder = Nominatim()
-        self.assertEqual(geocoder.headers['User-Agent'], 'geopy/1.2.3')
+    def test_user_agent_default(self):
+        with patch('geopy.geocoders.base.DEFAULT_USER_AGENT', 'mocked_user_agent/0.0.0'):
+            geocoder = Nominatim()
+            self.assertEqual(geocoder.headers['User-Agent'], 'mocked_user_agent/0.0.0')
 
     def test_user_agent_custom(self):
         geocoder = Nominatim(

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -1,4 +1,4 @@
-
+from mock import patch
 from geopy.compat import u
 from geopy.point import Point
 from geopy.geocoders import Nominatim
@@ -32,6 +32,18 @@ class NominatimTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
             {"query": u("\u6545\u5bab")},
             {"latitude": 39.916, "longitude": 116.390},
         )
+
+    @patch('geopy.util.get_version')
+    def test_user_agent_default(self, mocked_getversion):
+        mocked_getversion.return_value = '1.2.3'
+        geocoder = Nominatim()
+        self.assertEqual(geocoder.headers['User-Agent'], 'geopy/1.2.3')
+
+    def test_user_agent_custom(self):
+        geocoder = Nominatim(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
 
     def test_reverse_string(self):
         """

--- a/test/geocoders/opencage.py
+++ b/test/geocoders/opencage.py
@@ -6,6 +6,16 @@ from geopy.geocoders import OpenCage
 from test.geocoders.util import GeocoderTestBase, env
 
 
+class OpenCageTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = OpenCage(
+            api_key='DUMMYKEY1234',
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
+
 @unittest.skipUnless(  # pylint: disable=R0904,C0111
     bool(env.get('OPENCAGE_KEY')),
     "No OPENCAGE_KEY env variables set"

--- a/test/geocoders/openmapquest.py
+++ b/test/geocoders/openmapquest.py
@@ -11,6 +11,12 @@ class OpenMapQuestTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
         cls.geocoder = OpenMapQuest(scheme='http', timeout=3)
         cls.delta = 0.04
 
+    def test_user_agent_custom(self):
+        geocoder = OpenMapQuest(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
     def test_geocode(self):
         """
         OpenMapQuest.geocode

--- a/test/geocoders/placefinder.py
+++ b/test/geocoders/placefinder.py
@@ -7,6 +7,17 @@ from geopy.geocoders import YahooPlaceFinder
 from test.geocoders.util import GeocoderTestBase, env
 
 
+class YahooPlaceFinderTestCaseUnitTest(GeocoderTestBase): # pylint: disable=R0904,C0111
+
+    def test_user_agent_custom(self):
+        geocoder = YahooPlaceFinder(
+            consumer_key='DUMMYKEY1234',
+            consumer_secret='DUMMYSECRET',
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
+
 @unittest.skipUnless(  # pylint: disable=R0904,C0111
     bool(env.get('YAHOO_KEY')) and bool(env.get('YAHOO_SECRET')),
     "YAHOO_KEY and YAHOO_SECRET env variables not set"

--- a/test/geocoders/smartystreets.py
+++ b/test/geocoders/smartystreets.py
@@ -5,6 +5,16 @@ from geopy.geocoders import LiveAddress
 from geopy.exc import ConfigurationError, GeocoderAuthenticationFailure
 from test.geocoders.util import GeocoderTestBase, env
 
+class LiveAddressTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = LiveAddress(
+            auth_id='DUMMY12345',
+            auth_token='DUMMY67890',
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
 
 @unittest.skipUnless( # pylint: disable=R0904,C0111
     'LIVESTREETS_AUTH_ID' in env and 'LIVESTREETS_AUTH_TOKEN' in env,

--- a/test/geocoders/what3words.py
+++ b/test/geocoders/what3words.py
@@ -5,6 +5,16 @@ from geopy.geocoders import What3Words
 from test.geocoders.util import GeocoderTestBase, env
 
 
+class What3WordsTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = What3Words(
+            api_key='DUMMYKEY1234',
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
+
 @unittest.skipUnless(bool(env.get('WHAT3WORDS_KEY')),
                      "No WHAT3WORDS_KEY env variable set"
 )

--- a/test/geocoders/yandex.py
+++ b/test/geocoders/yandex.py
@@ -11,6 +11,12 @@ class YandexTestCase(GeocoderTestBase):
     def setUpClass(cls):
         cls.delta = 0.04
 
+    def test_user_agent_custom(self):
+        geocoder = Yandex(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
     def test_unicode_name(self):
         """
         Yandex.geocode unicode

--- a/tox.ini
+++ b/tox.ini
@@ -8,15 +8,18 @@ deps=
     nose-cov
     requests-oauthlib
     pytz
+    mock
 
 [testenv:py32]
 deps=
     nose-cov
     requests-oauthlib
     pytz
+    mock
 
 [testenv:py34]
 deps=
     nose-cov
     requests-oauthlib
     pytz
+    mock


### PR DESCRIPTION
My application that uses geopy was blocked by Nominatim as geopy uses the standard user agent header for requests provided by urllib (Python-urllib/2.7). Nominatim requires to add an identifying user agent header per application in order to be able to track and block requests if needed. 

I now added in this PR a default header in the base geocoder class:
User-Agent: geopy/#version
where #version is the current geopy version (e.g "geopy/1.9.1")

This is now added to every request and every geocoder inheriting from the 'Geocoder' base class.
This should be much better, as it is much easier for services to be able to track which request come from where. Now every service is able to distinguish geopy requests from non geopy requests.

In addition I added the possibility to pass in a custom user agent string to the Nominatim geocoder class:
```python
        geocoder = Nominatim(
            user_agent='my_user_agent/1.0'
        )
        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
```
This should help to prevent quite some blockings`and bans from Nominatim, as now they are able to distinguish bad requests from good request based on the user agent headers and only block those, which have e.g a standard user agent like "geopy/1.9.1" or even "Python-urllib/2.7" and spare those requests identifying with a specific user agent like "GoodApp/0.1" as long as all "GoodApp/0.1" requests respect the Nominatim terms of usage.

I also added tests for it and thereby fixed the tests for ignfrance which were not able to pass tests without api key credentials even they should be skipped in that case.