### PR TITLE
Fix bug in OpenCage geocoder.

### DIFF
--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -109,9 +109,9 @@ class OpenCage(Geocoder):
         }
         if bounds:
             params['bounds'] = bounds
-        if bounds:
+        if language:
             params['language'] = language
-        if bounds:
+        if country:
             params['country'] = country
 
         url = "?".join((self.api, urlencode(params)))


### PR DESCRIPTION
The OpenCage geocoder ignores language and country settings at the moment and wrongfully only sets them when bounds is not None.
Seems to be a copy'n'paste bug.