### PR TITLE
Adding support for extra parameters

### DIFF
--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -192,7 +192,6 @@ class Nominatim(Geocoder):
 
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        print self._call_geocoder
         return self._parse_json(
             self._call_geocoder(url, timeout=timeout), exactly_one
         )

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -42,7 +42,8 @@ class Nominatim(Geocoder):
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
             domain='nominatim.openstreetmap.org',
-            scheme=DEFAULT_SCHEME
+            scheme=DEFAULT_SCHEME,
+            extra_params={}
     ):  # pylint: disable=R0913
         """
         :param string format_string: String containing '%s' where the
@@ -82,9 +83,12 @@ class Nominatim(Geocoder):
         self.country_bias = country_bias
         self.domain = domain.strip('/')
 
+        if not isinstance(extra_params, dict):
+            raise ValueError("extra_params: expected dict, got: {}".format(type(extra_params)))
+
+        self.extra_params = extra_params
         self.api = "%s://%s/search" % (self.scheme, self.domain)
         self.reverse_api = "%s://%s/reverse" % (self.scheme, self.domain)
-
 
     def geocode(
             self,
@@ -155,11 +159,11 @@ class Nominatim(Geocoder):
         else:
             params = {'q': self.format_string % query}
 
-        params.update({
+        params.update(dict(self.extra_params,
             # `viewbox` apparently replaces `view_box`
-            'viewbox': self.view_box,
-            'format': 'json'
-        })
+            viewbox=self.view_box,
+            format='json'
+        ))
 
         if self.country_bias:
             params['countrycodes'] = self.country_bias
@@ -188,6 +192,7 @@ class Nominatim(Geocoder):
 
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
+        print self._call_geocoder
         return self._parse_json(
             self._call_geocoder(url, timeout=timeout), exactly_one
         )
@@ -239,6 +244,7 @@ class Nominatim(Geocoder):
             'lon': lon,
             'format': 'json',
         }
+        params.update(self.extra_params)
         if language:
             params['accept-language'] = language
         url = "?".join((self.reverse_api, urlencode(params)))

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -1,8 +1,19 @@
+import unittest
+from nose.tools import assert_raises
+from contextlib import contextmanager
 
 from geopy.compat import u
 from geopy.point import Point
 from geopy.geocoders import Nominatim
 from test.geocoders.util import GeocoderTestBase
+
+
+@contextmanager
+def patch(obj, method, replacement):
+    original_method = getattr(obj, method)
+    setattr(obj, method, replacement)
+    yield replacement
+    setattr(obj, method, original_method)
 
 
 class NominatimTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
@@ -165,3 +176,42 @@ class NominatimTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
             result_geocode.raw['geojson'].get('type'),
             'MultiPolygon'
         )
+
+class MockMethod(object):
+    def __init__(self, return_value=None):
+        self.called = False
+        self.call_args = []
+        self.return_value = return_value
+
+    def __call__(self, *args, **kwargs):
+        self.call_args.append([args, kwargs])
+        self.called = True
+        return self.return_value
+
+
+class NominatimExtraParamsTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.geocoder = Nominatim(extra_params={'key': 'my_access_token'})
+
+    def test_reverse_extra_params(self):
+        with patch(self.geocoder, '_call_geocoder', MockMethod()) as _call_geocoder:
+            self.geocoder.reverse("64.0, 0.0")
+            url = _call_geocoder.call_args[0][0][0]
+            assert 'my_access_token' in url
+            assert 'key' in url
+
+    def test_geocode_extra_params(self):
+        with patch(self.geocoder, '_call_geocoder', MockMethod(return_value={})) as _call_geocoder:
+            self.geocoder.geocode(query="Reykjavik, Iceland")
+            print _call_geocoder.call_args
+            url = _call_geocoder.call_args[0][0][0]
+            assert 'my_access_token' in url
+            assert 'key' in url
+
+    def test_constructor_accepts_and_sets_extra_params(self):
+        geocoder = Nominatim(extra_params={'param': 'value'})
+        assert geocoder.extra_params == {'param': 'value'}
+
+    def test_constructor_rejects_non_dict_extra_params(self):
+        assert_raises(ValueError, lambda: Nominatim(extra_params="string"))

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -204,7 +204,6 @@ class NominatimExtraParamsTestCase(unittest.TestCase):
     def test_geocode_extra_params(self):
         with patch(self.geocoder, '_call_geocoder', MockMethod(return_value={})) as _call_geocoder:
             self.geocoder.geocode(query="Reykjavik, Iceland")
-            print _call_geocoder.call_args
             url = _call_geocoder.call_args[0][0][0]
             assert 'my_access_token' in url
             assert 'key' in url


### PR DESCRIPTION
This way we can use third party services like PickPoint like so:

```
>>> from geopy import geocoders
>>> g = geocoders.Nominatim(domain='pickpoint.io/api/v1',
extra_params={'key': '....'})
>>> g.reverse("64.0, 0.0")
Location((0.0, 0.0, 0.0))
```