### PR TITLE
Add support for Photon geocoder

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,9 @@ Geocoders
 .. autoclass:: geopy.geocoders.OpenMapQuest
     :members: __init__, geocode
 
+.. autoclass:: geopy.geocoders.Photon
+    :members: __init__, geocode
+
 .. autoclass:: geopy.geocoders.YahooPlaceFinder
     :members: __init__, geocode
 

--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -90,6 +90,7 @@ __all__ = (
     "LiveAddress",
     'Yandex',
     "What3Words",
+    "Photon",
 )
 
 
@@ -110,6 +111,7 @@ from geopy.geocoders.smartystreets import LiveAddress
 from geopy.geocoders.what3words import What3Words
 from geopy.geocoders.yandex import Yandex
 from geopy.geocoders.ignfrance import IGNFrance
+from geopy.geocoders.photon import Photon
 
 
 from geopy.exc import GeocoderNotFound
@@ -135,6 +137,7 @@ SERVICE_TO_GEOCODER = {
     "what3words": What3Words,
     "yandex": Yandex,
     "ignfrance": IGNFrance,
+    "photon": Photon
 }
 
 

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -64,9 +64,14 @@ class Photon(Geocoder):  # pylint: disable=W0223
         self.api = "%s://%s/api" % (self.scheme, self.domain)
         self.reverse_api = "%s://%s/reverse" % (self.scheme, self.domain)
 
-    def geocode(self, query, exactly_one=True,
-                timeout=None, location_bias=None,
-                language=False):  # pylint: disable=W0221
+    def geocode(
+        self,
+        query,
+        exactly_one=True,
+        timeout=None,
+        location_bias=None,
+        language=False
+    ):  # pylint: disable=W0221
         """
         Geocode a location query.
 
@@ -112,8 +117,13 @@ class Photon(Geocoder):  # pylint: disable=W0223
             exactly_one
         )
 
-    def reverse(self, query, exactly_one=True,
-                timeout=None, language=False):  # pylint: disable=W0221
+    def reverse(
+        self,
+        query,
+        exactly_one=True,
+        timeout=None,
+        language=False
+    ):  # pylint: disable=W0221
         """
         Returns a reverse geocoded location.
 
@@ -171,8 +181,10 @@ class Photon(Geocoder):  # pylint: disable=W0223
         Return location and coordinates tuple from dict.
         """
         name = [resource['properties'].get('name'),
+                resource['properties'].get('housenumber'),
                 resource['properties'].get('street'),
                 resource['properties'].get('postcode'),
+                resource['properties'].get('city'),
                 resource['properties'].get('state'),
                 resource['properties'].get('country')]
         name = [n for n in name if n is not None]

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -1,0 +1,188 @@
+"""
+:class:`.Photon` geocoder.
+"""
+
+from geopy.compat import urlencode
+from geopy.geocoders.base import (
+    Geocoder,
+    DEFAULT_FORMAT_STRING,
+    DEFAULT_TIMEOUT,
+    DEFAULT_SCHEME
+)
+from geopy.location import Location
+from geopy.util import logger
+
+
+__all__ = ("Photon", )
+
+
+class Photon(Geocoder):  # pylint: disable=W0223
+    """
+    Geocoder using Photon geocoding service (data based on OpenStreetMap and
+    service provided by Komoot on https://photon.komoot.de).
+    Documentation at https://github.com/komoot/photon
+    """
+
+    def __init__(
+            self,
+            format_string=DEFAULT_FORMAT_STRING,
+            scheme=DEFAULT_SCHEME,
+            timeout=DEFAULT_TIMEOUT,
+            proxies=None,
+            domain='photon.komoot.de'
+    ):   # pylint: disable=R0913
+        """
+        Initialize a Photon/Komoot geocoder with location-specific
+        address information. No API Key is needed by the platform.
+
+        :param string format_string: String containing '%s' where
+            the string to geocode should be interpolated before querying
+            the geocoder. For example: '%s, Mountain View, CA'. The default
+            is just '%s'.
+
+        :param string scheme: Use 'https' or 'http' as the API URL's scheme.
+            Default is https. Note that SSL connections' certificates are not
+            verified.
+
+        :param int timeout: Time, in seconds, to wait for the geocoding service
+            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
+            exception.
+
+        :param dict proxies: If specified, routes this geocoder's requests
+            through the specified proxy. E.g., {"https": "192.0.2.0"}. For
+            more information, see documentation on
+            :class:`urllib2.ProxyHandler`.
+
+        :param string domain: Should be the localized Photon domain to
+            connect to. The default is 'photon.komoot.de', but you
+            can change it to a domain of your own.
+        """
+        super(Photon, self).__init__(
+            format_string, scheme, timeout, proxies
+        )
+        self.domain = domain.strip('/')
+        self.api = "%s://%s/api" % (self.scheme, self.domain)
+        self.reverse_api = "%s://%s/reverse" % (self.scheme, self.domain)
+
+    def geocode(self, query, exactly_one=True,
+                timeout=None, location_bias=None,
+                language=False):  # pylint: disable=W0221
+        """
+        Geocode a location query.
+
+        :param string query: The address or query you wish to geocode.
+
+        :param bool exactly_one: Return one result or a list of results, if
+            available.
+
+        :param int timeout: Time, in seconds, to wait for the geocoding service
+            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
+            exception. Set this only if you wish to override, on this call
+            only, the value set during the geocoder's initialization.
+
+        :param location_bias: The coordinates to used as location bias.
+        :type query: :class:`geopy.point.Point`, list or tuple of (latitude,
+            longitude), or string as "%(latitude)s, %(longitude)s"
+
+        :param string language: Preferred language in which to return results.
+
+        """
+        params = {
+            'q': self.format_string % query
+        }
+        if exactly_one:
+            params['limit'] = 1
+        if language:
+            params['lang'] = language
+        if location_bias:
+            try:
+                lat, lon = [x.strip() for x
+                            in self._coerce_point_to_string(location_bias)
+                            .split(',')]
+                params['lon'] = lon
+                params['lat'] = lat
+            except ValueError:
+                raise ValueError("Must be a coordinate pair or Point")
+
+        url = "?".join((self.api, urlencode(params)))
+
+        logger.debug("%s.geocode: %s", self.__class__.__name__, url)
+        return self._parse_json(
+            self._call_geocoder(url, timeout=timeout),
+            exactly_one
+        )
+
+    def reverse(self, query, exactly_one=True,
+                timeout=None, language=False):  # pylint: disable=W0221
+        """
+        Returns a reverse geocoded location.
+
+        :param query: The coordinates for which you wish to obtain the
+            closest human-readable addresses.
+        :type query: :class:`geopy.point.Point`, list or tuple of (latitude,
+            longitude), or string as "%(latitude)s, %(longitude)s"
+
+        :param bool exactly_one: Return one result or a list of results, if
+            available.
+
+        :param int timeout: Time, in seconds, to wait for the geocoding service
+            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
+            exception. Set this only if you wish to override, on this call
+            only, the value set during the geocoder's initialization.
+
+        :param string language: Preferred language in which to return results.
+
+        """
+        try:
+            lat, lon = [x.strip() for x in
+                        self._coerce_point_to_string(query).split(',')]
+        except ValueError:
+            raise ValueError("Must be a coordinate pair or Point")
+        params = {
+            'lat': lat,
+            'lon': lon,
+        }
+        if exactly_one:
+            params['limit'] = 1
+        if language:
+            params['lang'] = language
+        url = "?".join((self.reverse_api, urlencode(params)))
+        logger.debug("%s.reverse: %s", self.__class__.__name__, url)
+        return self._parse_json(
+            self._call_geocoder(url, timeout=timeout), exactly_one
+        )
+
+    @classmethod
+    def _parse_json(cls, resources, exactly_one=True):
+        """
+        Parse display name, latitude, and longitude from a JSON response.
+        """
+        if not len(resources):  # pragma: no cover
+            return None
+        if exactly_one:
+            return cls.parse_resource(resources['features'][0])
+        else:
+            return [cls.parse_resource(resource) for resource
+                    in resources['features']]
+
+    @classmethod
+    def parse_resource(cls, resource):
+        """
+        Return location and coordinates tuple from dict.
+        """
+        name = [resource['properties'].get('name'),
+                resource['properties'].get('street'),
+                resource['properties'].get('postcode'),
+                resource['properties'].get('state'),
+                resource['properties'].get('country')]
+        name = [n for n in name if n is not None]
+        location = ', '.join(name)
+        location = location.replace(' ,', '')
+
+        latitude = resource['geometry']['coordinates'][1] or None
+        longitude = resource['geometry']['coordinates'][0] or None
+        if latitude and longitude:
+            latitude = float(latitude)
+            longitude = float(longitude)
+
+        return Location(location, (latitude, longitude), resource)

--- a/test/geocoders/__init__.py
+++ b/test/geocoders/__init__.py
@@ -17,4 +17,5 @@ from .what3words import What3WordsTestCase
 from .yandex import YandexTestCase
 from .ignfrance import IGNFranceTestCase
 from .navidata import NaviDataTestCase
+from .photon import PhotonTestCase
 

--- a/test/geocoders/photon.py
+++ b/test/geocoders/photon.py
@@ -1,0 +1,90 @@
+
+from geopy.compat import u
+from geopy.point import Point
+from geopy.geocoders import Photon
+from test.geocoders.util import GeocoderTestBase
+
+
+class PhotonTestCase(GeocoderTestBase):  # pylint: disable=R0904,C0111
+
+    @classmethod
+    def setUpClass(cls):
+        cls.geocoder = Photon()
+        cls.known_country_it = "Francia"
+        cls.known_country_fr = "France"
+
+    def test_geocode(self):
+        """
+        Photon.geocode
+        """
+        self.geocode_run(
+            {"query": "14 rue pelisson villeurbanne"},
+            {"latitude": 45.7733963, "longitude": 4.88612369},
+        )
+
+    def test_unicode_name(self):
+        """
+        Photon.geocode unicode
+        """
+        self.geocode_run(
+            {"query": u("\u6545\u5bab")},
+            {"latitude": 39.916, "longitude": 116.390},
+        )
+
+    def test_reverse_string(self):
+        """
+        Photon.reverse string
+        """
+        self.reverse_run(
+            {"query": "45.7733105, 4.8869339"},
+            {"latitude": 45.7733105, "longitude": 4.8869339}
+        )
+
+    def test_reverse_point(self):
+        """
+        Photon.reverse Point
+        """
+        self.reverse_run(
+            {"query": Point(45.7733105, 4.8869339)},
+            {"latitude": 45.7733105, "longitude": 4.8869339}
+        )
+
+    def test_geocode_language_parameter(self):
+        """
+        Photon.geocode using `language`
+        """
+        result_geocode = self._make_request(
+            self.geocoder.geocode,
+            self.known_country_fr,
+            language="it",
+        )
+        self.assertEqual(
+            result_geocode.raw['properties']['country'],
+            self.known_country_it
+        )
+
+    def test_reverse_language_parameter(self):
+        """
+        Photon.reverse using `language`
+        """
+        result_reverse_it = self._make_request(
+            self.geocoder.reverse,
+            "45.7733105, 4.8869339",
+            exactly_one=True,
+            language="it",
+        )
+        self.assertEqual(
+            result_reverse_it.raw['properties']['country'],
+            self.known_country_it
+        )
+
+        result_reverse_fr = self._make_request(
+            self.geocoder.reverse,
+            "45.7733105, 4.8869339",
+            exactly_one=True,
+            language="fr"
+        )
+        self.assertEqual(
+            result_reverse_fr.raw['properties']['country'],
+            self.known_country_fr
+        )


### PR DESCRIPTION
I added the support to the [Photon geocoder](https://github.com/komoot/photon) (this service is provided by [komoot](http://photon.komoot.de/) and is based on OpenStreetMap data and ElasticSearch engine, and the developers offers some dump of the database/index, thus allowing us to easily run a local instance without the long preparation of Nominatim).

Anyway, my add support the __main api__ (with _language_ option and _location bias_ option) as well as the __reverse api__ (with _language_ option too) from Photon.
I also included some unittest, following the same pattern as in the others geocoder.

Tell me if you think that can be merged (or if it will need some changes).  

```
mthh@mthh:~$ python3 -m unittest test.geocoders.photon
......
----------------------------------------------------------------------
Ran 6 tests in 5.176s

OK
```

```python
In [1]: from geopy.geocoders import Photon

In [2]: a = Photon()

In [3]: a.geocode('12 rue des frigos 75013 PARIS')
Out[3]: Location(12, Rue des Frigos, 75013, Paris, Ile-de-France, France, (48.8309131, 2.3800015, 0.0))

In [4]: a.reverse("52.509669, 13.376294")
Out[4]: Location(Potsdamer Platz, 10785, Berlin, Berlin, Germany, (52.5095861, 13.3763864, 0.0))
```