### PR TITLE
Make OpenMapQuest tests conditional on environment variable

### DIFF
--- a/test/geocoders/openmapquest.py
+++ b/test/geocoders/openmapquest.py
@@ -5,6 +5,15 @@ from test.geocoders.util import GeocoderTestBase, env
 import unittest
 
 
+class OpenMapQuestNoNetTestCase(GeocoderTestBase):  # pylint: disable=R0904,C0111
+
+    def test_user_agent_custom(self):
+        geocoder = OpenMapQuest(
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
+
 @unittest.skipUnless(  # pylint: disable=R0904,C0111
     bool(env.get('OPENMAPQUEST_APIKEY')),
     "No OPENMAPQUEST_APIKEY env variable set"
@@ -13,14 +22,9 @@ class OpenMapQuestTestCase(GeocoderTestBase):  # pylint: disable=R0904,C0111
 
     @classmethod
     def setUpClass(cls):
-        cls.geocoder = OpenMapQuest(scheme='http', timeout=3, api_key=env['OPENMAPQUEST_APIKEY'])
+        cls.geocoder = OpenMapQuest(scheme='http', timeout=3,
+                                    api_key=env.get('OPENMAPQUEST_APIKEY'))
         cls.delta = 0.04
-
-    def test_user_agent_custom(self):
-        geocoder = OpenMapQuest(
-            user_agent='my_user_agent/1.0'
-        )
-        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
 
     def test_geocode(self):
         """

--- a/test/geocoders/openmapquest.py
+++ b/test/geocoders/openmapquest.py
@@ -1,14 +1,19 @@
 
 from geopy.compat import u
 from geopy.geocoders import OpenMapQuest
-from test.geocoders.util import GeocoderTestBase
+from test.geocoders.util import GeocoderTestBase, env
+import unittest
 
 
-class OpenMapQuestTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
+@unittest.skipUnless(  # pylint: disable=R0904,C0111
+    bool(env.get('OPENMAPQUEST_APIKEY')),
+    "No OPENMAPQUEST_APIKEY env variable set"
+)
+class OpenMapQuestTestCase(GeocoderTestBase):  # pylint: disable=R0904,C0111
 
     @classmethod
     def setUpClass(cls):
-        cls.geocoder = OpenMapQuest(scheme='http', timeout=3)
+        cls.geocoder = OpenMapQuest(scheme='http', timeout=3, api_key=env['OPENMAPQUEST_APIKEY'])
         cls.delta = 0.04
 
     def test_user_agent_custom(self):


### PR DESCRIPTION
Tests seem to recently fail due to OpenMapQuest no longer accepting key-less API requests.