### PR TITLE
add api key to param for OpenMapQuest Geocoder

### DIFF
--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -84,7 +84,8 @@ class OpenMapQuest(Geocoder): # pylint: disable=W0223
             .. versionadded:: 0.97
         """
         params = {
-            'q': self.format_string % query
+            'q': self.format_string % query,
+            'key': self.api_key
         }
         if exactly_one:
             params['maxResults'] = 1

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -19,7 +19,7 @@ __all__ = ("OpenMapQuest", )
 class OpenMapQuest(Geocoder): # pylint: disable=W0223
     """
     Geocoder using MapQuest Open Platform Web Services. Documentation at:
-        http://developer.mapquest.com/web/products/open/geocoding-service
+        http://www.mapquestapi.com/geocoding/
     """
 
     def __init__(
@@ -35,6 +35,8 @@ class OpenMapQuest(Geocoder): # pylint: disable=W0223
         Initialize an Open MapQuest geocoder with location-specific
         address information. No API Key is needed by the Nominatim based
         platform.
+
+        :param string api_key: Your api key provided by MapQuest.
 
         :param string format_string: String containing '%s' where
             the string to geocode should be interpolated before querying


### PR DESCRIPTION
api key is now a mandatory param (http://open.mapquestapi.com/geocoding/) so just send it to the api request :tada:. 
Doesn't works any more without this param since MapQuest licensing structure change (http://devblog.mapquest.com/2014/11/17/are-you-a-community-edition-licensed-data-user/).
