### PR TITLE
Fix incorrect unit conversion with starting units of feet

### DIFF
--- a/geopy/units.py
+++ b/geopy/units.py
@@ -61,7 +61,7 @@ def kilometers(meters=0, miles=0, feet=0, nautical=0): # pylint: disable=W0621
     if meters:
         ret += meters / 1000.
     if feet:
-        miles += feet / ft(1.)
+        ret += feet / ft(1.)
     if nautical:
         ret += nautical / nm(1.)
     ret += miles * 1.609344
@@ -81,7 +81,7 @@ def miles(kilometers=0, meters=0, feet=0, nautical=0): # pylint: disable=W0621
     if nautical:
         kilometers += nautical / nm(1.)
     if feet:
-        ret += feet / ft(1.)
+        kilometers += feet / ft(1.)
     if meters:
         kilometers += meters / 1000.
     ret += kilometers / 1.609344
@@ -107,7 +107,7 @@ def nautical(kilometers=0, meters=0, miles=0, feet=0): # pylint: disable=W0621
     """
     ret = 0.
     if feet:
-        miles += feet / ft(1.)
+        kilometers += feet / ft(1.)
     if miles:
         kilometers += km(miles=miles)
     if meters:

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -145,6 +145,19 @@ class CommonConversionCases:
     def test_should_convert_to_nautical_miles_with_abbrevation(self):
         assert_almost_equal(self.cls(1.0).nm, 0.539956803)
 
+    def test_should_convert_from_meters(self):
+        assert(self.cls(meters=1.0).km == 0.001)
+
+    def test_should_convert_from_feet(self):
+        assert_almost_equal(self.cls(feet=1.0).km, 0.0003048, 8)
+
+    def test_should_convert_from_miles(self):
+        assert_almost_equal(self.cls(miles=1.0).km, 1.6093440)
+
+    def test_should_convert_from_nautical_miles(self):
+        assert_almost_equal(self.cls(nautical=1.0).km, 1.8520000)
+
+
 
 class CommonDistanceCases(CommonDistanceComputationCases,
                           CommonMathematicalOperatorCases,


### PR DESCRIPTION
Found bug when starting with distance in units of feet.  Feet were being converted to miles using the conversion factor for ft to km.  Added unit tests to check converting from each unit to km and corrected conversion.
