### PR TITLE
Add Geoclient support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,9 @@ Geocoders
 
 .. autoclass:: geopy.geocoders.DataBC
     :members: __init__, geocode
+    
+.. autoclass:: geopy.geocoders.Geoclient
+    :members: __init__, geocode
 
 .. autoclass:: geopy.geocoders.GeocodeFarm
     :members: __init__, geocode, reverse

--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -91,6 +91,7 @@ __all__ = (
     'Yandex',
     "What3Words",
     "Photon",
+    "Geoclient",
 )
 
 
@@ -112,6 +113,7 @@ from geopy.geocoders.what3words import What3Words
 from geopy.geocoders.yandex import Yandex
 from geopy.geocoders.ignfrance import IGNFrance
 from geopy.geocoders.photon import Photon
+from geopy.geocoders.geoclient import Geoclient
 
 
 from geopy.exc import GeocoderNotFound
@@ -137,7 +139,8 @@ SERVICE_TO_GEOCODER = {
     "what3words": What3Words,
     "yandex": Yandex,
     "ignfrance": IGNFrance,
-    "photon": Photon
+    "photon": Photon,
+    "geoclient": Geoclient,
 }
 
 

--- a/geopy/geocoders/geoclient.py
+++ b/geopy/geocoders/geoclient.py
@@ -5,7 +5,7 @@
 from geopy.compat import urlencode
 from geopy.location import Location
 from geopy.util import logger
-from geopy.geocoders.base import Geocoder, DEFAULT_TIMEOUT
+from geopy.geocoders.base import Geocoder, DEFAULT_TIMEOUT, DEFAULT_SCHEME
 
 from geopy.exc import ConfigurationError
 
@@ -29,6 +29,7 @@ class Geoclient(Geocoder):
             self,
             app_id=None,
             app_key=None,
+            scheme=DEFAULT_SCHEME,
             domain=DEFAULT_DOMAIN,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
@@ -75,7 +76,7 @@ class Geoclient(Geocoder):
                     )
         
         '''use SFS (Single-field search) endpoint'''
-        self.geocode_api = 'https://%s/search.json' % (self.domain)
+        self.geocode_api = '%s://%s/search.json' % (DEFAULT_SCHEME, self.domain)
 
     def geocode(
             self,

--- a/geopy/geocoders/geoclient.py
+++ b/geopy/geocoders/geoclient.py
@@ -1,0 +1,143 @@
+"""
+:class:`.Geoclient` geocoder.
+"""
+
+from geopy.compat import urlencode
+from geopy.location import Location
+from geopy.util import logger
+from geopy.geocoders.base import Geocoder, DEFAULT_TIMEOUT
+
+from geopy.exc import ConfigurationError
+
+
+__all__ = ("Geoclient", )
+
+
+class Geoclient(Geocoder):
+    """
+    Geocoder using the Geoclient API. Documentation at:
+
+        https://api.cityofnewyork.us/geoclient/v1/doc
+
+     to get access, go to:
+
+        https://developer.cityofnewyork.us/api/geoclient-api   
+    """
+
+    def __init__(
+            self,
+            app_id=None,
+            app_key=None,
+            domain='api.cityofnewyork.us/geoclient/v1',
+            timeout=DEFAULT_TIMEOUT,
+            proxies=None,
+            user_agent=None,
+    ):
+        """
+        Initialize Geoclient geocoder. Please note that 'scheme' parameter is
+        not supported: at present state, all Geoclient traffic use https.
+
+        :param string appd_id: The application ID.
+
+        :param string app_key: The application key. 
+
+        :param string domain: Currently it is 'api.cityofnewyork.us/geoclient/v1', can
+            be changed if you have an on-premise Geoclient instance.
+
+        :param dict proxies: If specified, routes this geocoder's requests
+            through the specified proxy. E.g., {"https": "192.0.2.0"}. For
+            more information, see documentation on
+            :class:`urllib2.ProxyHandler`.
+
+        """
+        super(Geoclient, self).__init__(
+            scheme="https", timeout=timeout, proxies=proxies, user_agent=user_agent
+        )
+
+        self.app_id = app_id
+        self.app_key = app_key
+        
+        if not app_id:
+            raise ConfigurationError(
+                'No app_id given, required for api access.  If you do not '
+                'have a Geoclient app_id, sign up here: '
+                'https://developer.cityofnewyork.us/api/geoclient-api'
+                )
+        
+        if not app_key:
+            raise ConfigurationError(
+                'No app_key given, required for api access.  If you do not '
+                'have a Geoclient app_key, sign up here: '
+                'https://developer.cityofnewyork.us/api/geoclient-api'
+                )
+        
+        self.domain = domain.strip('/')
+        
+        '''use SFS (Single-field search) endpoint'''
+        self.geocode_api = 'https://%s/search.json' % (self.domain)
+
+    def geocode(
+            self,
+            query,
+            exactly_one=True,
+            timeout=None,
+            addressdetails=False,
+        ):
+        """
+        Geocode a location query.
+
+        :param string query: The query string to be geocoded; this must
+            be URL encoded.
+
+        :param bool exactly_one: Return one result or a list of results, if
+            available.
+
+        :param int timeout: Time, in seconds, to wait for the geocoding service
+            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
+            exception. Set this only if you wish to override, on this call
+            only, the value set during the geocoder's initialization.
+
+        :param bool addressdetails: If you want in *Location.raw* to include
+            addressdetails such as BIN#, community district, etc set it to True
+
+        """
+        params = {
+            'input': self.format_string % query,
+        }
+
+        if self.app_key is not None:
+            params["app_key"] = self.app_key
+
+        if self.app_id is not None:
+            params["app_id"] = self.app_id
+
+        url = "?".join((self.geocode_api, urlencode(params)))
+
+        logger.debug("%s.geocode: %s", self.__class__.__name__, url)
+        return self._parse_json_geocode(
+            self._call_geocoder(url, timeout=timeout), exactly_one, addressdetails
+        )
+
+
+    @staticmethod
+    def _parse_json_geocode(page, exactly_one=True, addressdetails=False):
+        '''Returns location from Geoclient response.'''
+
+        places = page['results']
+
+        if not len(places):
+            return None
+
+        def parse_place(place):
+            '''Get the location, lat, lon from a single json result.'''
+            '''Return normalized street address in location, and the entire Geoclient response is also returned'''
+            '''should the user want to parse extended location information'''
+            location = place.get('houseNumber') + ' ' + place.get('boePreferredStreetName') + ', ' + place.get('firstBoroughName') + ', NY ' + place.get('zipCode')
+            latitude = place.get('latitude')
+            longitude = place.get('longitude')
+            return Location(location, (latitude, longitude), place if addressdetails else {})
+
+        if exactly_one:
+            return parse_place(places[0]['response'])
+        else:
+            return [parse_place(place['response']) for place in places]

--- a/geopy/geocoders/geoclient.py
+++ b/geopy/geocoders/geoclient.py
@@ -131,7 +131,7 @@ class Geoclient(Geocoder):
         def parse_place(place):
             '''Get the location, lat, lon from a single json result.'''
             '''Return normalized street address in location, and the entire Geoclient response is also returned'''
-            '''should the user want to parse extended location information'''
+            '''if addressdetails is set to true should the user want to parse extended location information'''
             location = place.get('houseNumber') + ' ' + place.get('boePreferredStreetName') + ', ' + place.get('firstBoroughName') + ', NY ' + place.get('zipCode')
             latitude = place.get('latitude')
             longitude = place.get('longitude')

--- a/geopy/geocoders/geoclient.py
+++ b/geopy/geocoders/geoclient.py
@@ -131,12 +131,26 @@ class Geoclient(Geocoder):
             '''Get the location, lat, lon from a single json result.'''
             '''Return normalized street address in location, and the entire Geoclient response is also returned'''
             '''if addressdetails is set to true should the user want to parse extended location information'''
-            location = place.get('houseNumber') + ' ' + place.get('boePreferredStreetName') + ', ' + place.get('firstBoroughName') + ', NY ' + place.get('zipCode')
-            latitude = place.get('latitude')
-            longitude = place.get('longitude')
+            
+            request_type = place.get('request').split(' ', 1)[0]
+            
+            response_info = place['response']
+            
+            if request_type == 'address':
+                location = response_info.get('houseNumber') + ' ' + \
+                    response_info.get('boePreferredStreetName') + ', ' + \
+                    response_info.get('firstBoroughName') + ', NY ' + \
+                    response_info.get('zipCode')
+            else:
+                '''for BBL, BIN, BLOCKFACE and INTERSECTION request types, just pass through the request value'''
+                location = place.get('request')
+                
+            latitude = response_info.get('latitudeInternalLabel', 0.0)
+            longitude = response_info.get('longitudeInternalLabel', 0.0)
+            
             return Location(location, (latitude, longitude), place if addressdetails else {})
 
         if exactly_one:
-            return parse_place(places[0]['response'])
+            return parse_place(places[0])
         else:
-            return [parse_place(place['response']) for place in places]
+            return [parse_place(place) for place in places]

--- a/geopy/geocoders/geoclient.py
+++ b/geopy/geocoders/geoclient.py
@@ -147,8 +147,8 @@ class Geoclient(Geocoder):
                 '''for BBL, BIN, BLOCKFACE and INTERSECTION request types, just pass through the request value'''
                 location = place.get('request', '')
                 
-            latitude = response_info.get('latitudeInternalLabel', None)
-            longitude = response_info.get('longitudeInternalLabel', None)
+            latitude = response_info.get('latitude', None)
+            longitude = response_info.get('longitude', None)
             
             if latitude and longitude:
                 latitude = float(latitude)

--- a/geopy/geocoders/geoclient.py
+++ b/geopy/geocoders/geoclient.py
@@ -88,7 +88,7 @@ class Geoclient(Geocoder):
 
         :param string query: The query string to be geocoded using SFS syntax;
             this must be URL encoded. Documentation at:
-            https://api.cityofnewyork.us/geoclient/v1/doc#section-1.3.1 
+            https://api.cityofnewyork.us/geoclient/v1/doc#section-1.3
 
         :param bool exactly_one: Return one result or a list of results, if
             available.

--- a/geopy/geocoders/geoclient.py
+++ b/geopy/geocoders/geoclient.py
@@ -86,8 +86,9 @@ class Geoclient(Geocoder):
         """
         Geocode a location query.
 
-        :param string query: The query string to be geocoded; this must
-            be URL encoded.
+        :param string query: The query string to be geocoded using SFS syntax;
+            this must be URL encoded. Documentation at:
+            https://api.cityofnewyork.us/geoclient/v1/doc#section-1.3.1 
 
         :param bool exactly_one: Return one result or a list of results, if
             available.
@@ -98,18 +99,16 @@ class Geoclient(Geocoder):
             only, the value set during the geocoder's initialization.
 
         :param bool addressdetails: If you want in *Location.raw* to include
-            addressdetails such as BIN#, community district, etc set it to True
+            address details such as BIN#, community district, etc set it to True.
+            Data Dictionary documenting all available fields at:
+            https://api.cityofnewyork.us/geoclient/v1/doc#section-3.0
 
         """
         params = {
             'input': self.format_string % query,
+            'app_key': self.app_key,
+            'app_id': self.app_id,
         }
-
-        if self.app_key is not None:
-            params["app_key"] = self.app_key
-
-        if self.app_id is not None:
-            params["app_id"] = self.app_id
 
         url = "?".join((self.geocode_api, urlencode(params)))
 

--- a/test/geocoders/__init__.py
+++ b/test/geocoders/__init__.py
@@ -18,4 +18,4 @@ from .yandex import YandexTestCase
 from .ignfrance import IGNFranceTestCase
 from .navidata import NaviDataTestCase
 from .photon import PhotonTestCase
-
+from .geoclient import GeoclientTestCase

--- a/test/geocoders/geoclient.py
+++ b/test/geocoders/geoclient.py
@@ -1,0 +1,40 @@
+
+import unittest
+
+from geopy.geocoders import Geoclient
+from test.geocoders.util import GeocoderTestBase, env
+
+class GeoclientTestCaseUnitTest(GeocoderTestBase):
+
+    def test_user_agent_custom(self):
+        geocoder = Geoclient(
+            app_id='DUMMY12345',
+            app_key='DUMMY67890',
+            user_agent='my_user_agent/1.0'
+        )
+        self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
+
+
+@unittest.skipUnless(
+    'GEOCLIENT_APP_ID' in env and 'GEOCLIENT_APP_KEY' in env,
+    "No GEOCLIENT_APP_ID AND GEOCLIENT_APP_KEY env variables set"
+)
+class GeoclientTestCase(GeocoderTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.geocoder = Geoclient(
+            app_id=env['GEOCLIENT_APP_ID'],
+            app_key=env['GEOCLIENT_APP_KEY'],
+        )
+        cls.delta = 0.04
+
+    def test_geocode(self):
+        """
+        Geoclient.geocode
+        """
+        self.geocode_run(
+            {"query": "85 Fifth Ave, Manhattan, NY"},
+            {"latitude": 40.737415391891616, "longitude": -73.9925809709183},  
+        )
+

--- a/test/geocoders/geoclient.py
+++ b/test/geocoders/geoclient.py
@@ -24,8 +24,8 @@ class GeoclientTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
     @classmethod
     def setUpClass(cls):
         cls.geocoder = Geoclient(
-            app_id=env.get['GEOCLIENT_APP_ID'],
-            app_key=env.get['GEOCLIENT_APP_KEY'],
+            app_id=env.get('GEOCLIENT_APP_ID'),
+            app_key=env.get('GEOCLIENT_APP_KEY'),
         )
         cls.delta = 0.04
 

--- a/test/geocoders/geoclient.py
+++ b/test/geocoders/geoclient.py
@@ -16,8 +16,8 @@ class GeoclientTestCaseUnitTest(GeocoderTestBase):
 
 
 @unittest.skipUnless(
-    'GEOCLIENT_APP_ID' in env and 'GEOCLIENT_APP_KEY' in env,
-    "No GEOCLIENT_APP_ID AND GEOCLIENT_APP_KEY env variables set"
+    bool(env.get('GEOCLIENT_APP_ID')) and bool(env.get('GEOCLIENT_APP_KEY')),
+    "No GEOCLIENT_APP_ID and GEOCLIENT_APP_KEY env variables set"
 )
 class GeoclientTestCase(GeocoderTestBase):
 

--- a/test/geocoders/geoclient.py
+++ b/test/geocoders/geoclient.py
@@ -35,6 +35,6 @@ class GeoclientTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
         """
         self.geocode_run(
             {"query": "85 Fifth Ave, Manhattan, NY"},
-            {"latitude": 40.737415391891616, "longitude": -73.9925809709183},  
+            {"latitude": 40.73727812604426, "longitude": -73.99215518677124}
         )
 

--- a/test/geocoders/geoclient.py
+++ b/test/geocoders/geoclient.py
@@ -15,11 +15,11 @@ class GeoclientTestCaseUnitTest(GeocoderTestBase):
         self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
 
 
-@unittest.skipUnless(
+@unittest.skipUnless( # pylint: disable=R0904,C0111
     bool(env.get('GEOCLIENT_APP_ID')) and bool(env.get('GEOCLIENT_APP_KEY')),
     "No GEOCLIENT_APP_ID and GEOCLIENT_APP_KEY env variables set"
 )
-class GeoclientTestCase(GeocoderTestBase):
+class GeoclientTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
 
     @classmethod
     def setUpClass(cls):

--- a/test/geocoders/geoclient.py
+++ b/test/geocoders/geoclient.py
@@ -24,17 +24,35 @@ class GeoclientTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
     @classmethod
     def setUpClass(cls):
         cls.geocoder = Geoclient(
-            app_id=env['GEOCLIENT_APP_ID'],
-            app_key=env['GEOCLIENT_APP_KEY'],
+            app_id=env.get['GEOCLIENT_APP_ID'],
+            app_key=env.get['GEOCLIENT_APP_KEY'],
         )
         cls.delta = 0.04
 
-    def test_geocode(self):
+    def test_geocode_address(self):
         """
         Geoclient.geocode
         """
         self.geocode_run(
             {"query": "85 Fifth Ave, Manhattan, NY"},
             {"latitude": 40.73727812604426, "longitude": -73.99215518677124}
+        )
+
+    def test_geocode_bin(self):
+        """
+        Geoclient.geocode Building ID Number
+        """
+        self.geocode_run(
+            {"query": "1079043"},
+            {"latitude": 40.7086585249236, "longitude": -74.00798211500157}
+        )
+        
+    def test_geocode_intersection(self):
+        """
+        Geoclient.geocode Intersection
+        """
+        self.geocode_run(
+            {"query": "Broadway and W 100 St"},
+            {"latitude": 40.797216857686585, "longitude": -73.96991438209491}
         )
 


### PR DESCRIPTION
Add support for New York City's official geocoder - Geoclient 

 https://api.cityofnewyork.us/geoclient/v1/doc

Geoclient returns high-quality, authoritative location information in addition to latitude, longitude - e.g. community district, building identification number, neighborhood tabulation area, borough/block/lot, etc. for all valid addresses in NYC.

cc @mlipper @colinreilly