### PR TITLE
Coverage 4.0 doesn't support Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
     - "3.4"
     - "pypy"
     - "pypy3"
+install:
+    # Coveralls 4.0 doesn't support Python 3.2
+    - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
+    - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
 script:
     - pip install nose-cov requests-oauthlib pytz
     - make test


### PR DESCRIPTION
On Python 3.2, use earlier version of coverage (v3.7.1)

Fixes #178.

see https://bitbucket.org/ned/coveragepy/issues/407/coverage-failing-on-python-325-using