### PR TITLE
Add restricting results via bounded parameter in Nominatim

### DIFF
--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -38,6 +38,7 @@ class Nominatim(Geocoder):
             self,
             format_string=DEFAULT_FORMAT_STRING,
             view_box=None,
+            bounded=False,
             country_bias=None,
             timeout=DEFAULT_TIMEOUT,
             proxies=None,
@@ -52,6 +53,9 @@ class Nominatim(Geocoder):
             is just '%s'.
 
         :param tuple view_box: Coordinates to restrict search within.
+
+        :param bool bounded: Restrict the results to only items contained
+            with the bounding view_box.
 
         :param string country_bias: Bias results to this country.
 
@@ -80,6 +84,7 @@ class Nominatim(Geocoder):
         self.country_bias = country_bias
         self.format_string = format_string
         self.view_box = view_box
+        self.bounded = bounded
         self.domain = domain.strip('/')
 
         self.api = "%s://%s/search" % (self.scheme, self.domain)
@@ -161,6 +166,9 @@ class Nominatim(Geocoder):
         # `viewbox` apparently replaces `view_box`
         if self.view_box:
             params['viewbox'] = ','.join(self.view_box)
+
+        if self.bounded:
+            params['bounded'] = 1
 
         if self.country_bias:
             params['countrycodes'] = self.country_bias


### PR DESCRIPTION
Viewbox area is **preferred** area to find search results.
The goal of adding bounded parameter is guaranteed restricting results to the bounding box.

For example
[query without bounded](http://nominatim.openstreetmap.org/search.php?q=строитель томск&viewbox=84.719353,56.588456,85.296822,56.437293)
geolocator = Nominatim(format_string='%s,Томск', view_box=('84.719353','56.588456','85.296822','56.437293')) - I want to get coords from Tomsk/Tomsk district etc excluding cities/villages south of the Tomsk

so [query with bounded](http://nominatim.openstreetmap.org/search.php?q=строитель томск&viewbox=84.719353,56.588456,85.296822,56.437293&bounded=1) is what I need

geolocator = Nominatim(format_string='%s,Томск', view_box=('84.719353','56.588456','85.296822','56.437293'), bounded=True) 
