### PR TITLE
Fix for extreme longitudes in Vincenty.

### DIFF
--- a/geopy/distance.py
+++ b/geopy/distance.py
@@ -365,7 +365,7 @@ class vincenty(Distance):
         iter_limit = self.iterations
 
         i = 0
-        while abs(lambda_lng - lambda_prime) > 10e-12 and i <= iter_limit:
+        while (abs(lambda_lng - lambda_prime) > 10e-12 and i <= iter_limit) or (i == 0):
             i += 1
 
             sin_lambda_lng, cos_lambda_lng = sin(lambda_lng), cos(lambda_lng)


### PR DESCRIPTION
In some weird edge cases (generated by Hypothesis), the while-loop in the Vincenty code never runs.

Below, difference between the two longitudes is very close to 2π, so the condition
`abs(lambda_lng - lambda_prime) > 10e-12` is not true.

``` python
from geopy.distance import vincenty
vincenty((-80, -179.999999999999), (-80.0, 180.0))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../geopy/distance.py", line 322, in __init__
    super(vincenty, self).__init__(*args, **kwargs)
  File ".../geopy/distance.py", line 115, in __init__
    kilometers += self.measure(a, b)
  File ".../geopy/distance.py", line 414, in measure
    u_sq = cos_sq_alpha * (major ** 2 - minor ** 2) / minor ** 2
UnboundLocalError: local variable 'cos_sq_alpha' referenced before assignment
```
