### PR TITLE
Fix error in Vincenty destination function, closes #186.

### DIFF
--- a/geopy/distance.py
+++ b/geopy/distance.py
@@ -482,7 +482,7 @@ class vincenty(Distance):
             delta_sigma = B * sin_sigma * (
                 cos2_sigma_m + B / 4. * (
                     cos_sigma * (
-                        -1 + 2 * cos2_sigma_m
+                        -1 + 2 * cos2_sigma_m ** 2
                     ) - B / 6. * cos2_sigma_m * (
                         -3 + 4 * sin_sigma ** 2
                     ) * (

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -190,6 +190,12 @@ class TestWhenComputingVincentyDistance(CommonDistanceCases):
         assert_almost_equal(destination.latitude, 0, 0)
         assert_almost_equal(destination.longitude, -180, 0)
 
+    def test_should_compute_same_destination_as_other_libraries(self):
+        distance = self.cls(54.972271)
+        destination = distance.destination((-37.95103, 144.42487), 306.86816)
+        assert_almost_equal(destination.latitude, -37.6528177174, 10)
+        assert_almost_equal(destination.longitude, 143.9264976682, 10)
+
     def test_should_get_distinct_results_for_different_ellipsoids(self):
         results = []
         for ellipsoid_name in ELLIPSOIDS.keys():


### PR DESCRIPTION
The test uses the same example as given by movable-type.co.uk and mozilla/ichnaea and matches the output of geographiclib's geosolve online calculator. The test fails without the fix.

@jqnatividad any comments?
