### PR TITLE
Removing python 3.2 from tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "2.7"
-    - "3.2"
     - "3.4"
     - "pypy"
     - "pypy3"


### PR DESCRIPTION
Requests library does not support python 3.2

http://stackoverflow.com/questions/38957513/hi-i-just-installed-requests-with-pip-but-i-cant-import-it