### PR TITLE
Convert What3Words Geocoder to the v2 API.

### DIFF
--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -38,7 +38,7 @@ class What3Words(Geocoder):
             user_agent=None,
     ):
         """
-        Initialize a What3Words geocoder with 3-word or OneWord-address and
+        Initialize a What3Words geocoder with 3-word address and
         What3Words API key.
 
             .. versionadded:: 1.5.0
@@ -52,7 +52,9 @@ class What3Words(Geocoder):
 
         :param string scheme: Use 'https' or 'http' as the API URL's scheme.
             Default is https. Note that SSL connections' certificates are not
-            verified. As of API v2 only 'https' is supported.
+            verified.  As of API v2 only 'https' is supported - this parameter
+            remains for backwards compatibility (setting to 'http' will stop
+            this geocoder working).
 
 
         :param int timeout: Time, in seconds, to wait for the geocoding service

--- a/test/geocoders/what3words.py
+++ b/test/geocoders/what3words.py
@@ -31,7 +31,7 @@ class What3WordsTestCase(GeocoderTestBase):
 
     def test_geocode(self):
         """
-        What3Words.geocode - '3 Words' and 'OneWord'
+        What3Words.geocode - '3 Words'
         """
         self.geocode_run(
             {"query": u("piped.gains.jangle")},
@@ -87,7 +87,7 @@ class What3WordsTestCase(GeocoderTestBase):
 
     def test_check_query(self):
         """
-        What3Wors.check_query - '3 Words' regex
+        What3Words.check_query - '3 Words' regex
         """
         result_check_threeword_query = self.geocoder._check_query(
             u(

--- a/test/geocoders/what3words.py
+++ b/test/geocoders/what3words.py
@@ -23,7 +23,7 @@ class What3WordsTestCase(GeocoderTestBase):
     def setUpClass(cls):
         cls.geocoder = What3Words(
             env['WHAT3WORDS_KEY'],
-            scheme='http',
+            scheme='https',
             timeout=3
 
         )
@@ -36,11 +36,6 @@ class What3WordsTestCase(GeocoderTestBase):
         self.geocode_run(
             {"query": u("piped.gains.jangle")},
             {"latitude": 53.037611, "longitude": 11.565012},
-        )
-
-        self.geocode_run(
-            {"query": u("*LibertyTech")},
-            {"latitude": 51.512573, "longitude": -0.144879},
         )
 
 
@@ -75,16 +70,6 @@ class What3WordsTestCase(GeocoderTestBase):
             {"latitude": 53.037611, "longitude": 11.565012},
         )
 
-        self.geocode_run(
-            {
-                "query": u(
-                    "\u002a\u004c\u0069\u0062\u0065\u0072\u0074"
-                    "\u0079\u0054\u0065\u0063\u0068"
-                )
-            },
-            {"latitude": 51.512573, "longitude": -0.144879},
-        )
-
     def test_result_language(self):
         """
         What3Words.geocode result language
@@ -102,9 +87,8 @@ class What3WordsTestCase(GeocoderTestBase):
 
     def test_check_query(self):
         """
-        What3Wors.check_query - 'OneWord' and '3 Words' regex
+        What3Wors.check_query - '3 Words' regex
         """
-        result_check_oneword_query = self.geocoder._check_query("*LibertyTech")
         result_check_threeword_query = self.geocoder._check_query(
             u(
                 "\u0066\u0061\u0068\u0072\u0070\u0072"
@@ -114,11 +98,4 @@ class What3WordsTestCase(GeocoderTestBase):
             )
         )
 
-        self.assertTrue(result_check_oneword_query)
         self.assertTrue(result_check_threeword_query)
-
-
-
-
-
-


### PR DESCRIPTION
Also remove the OneWord functionality that has been deprecated by
What3Words.
