### PR TITLE
Update ArcGIS to latest API

### DIFF
--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -109,7 +109,7 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
         )
         return self._base_call_geocoder(request, timeout=timeout)
 
-    def geocode(self, query, exactly_one=True, timeout=None):
+    def geocode(self, query, exactly_one=True, out_fields=None, timeout=None):
         """
         Geocode a location query.
 
@@ -117,6 +117,9 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
 
         :param bool exactly_one: Return one result or a list of results, if
             available.
+
+        :param string out_fields: Comma-separated list of output fields to be returned in the
+            attributes field of the raw data.
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
@@ -126,6 +129,8 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
         params = {'singleLine': query, 'f': 'json'}
         if exactly_one is True:
             params['maxLocations'] = 1
+        if out_fields is not None:
+            params['outFields'] = out_fields
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
         response = self._call_geocoder(url, timeout=timeout)

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -90,7 +90,7 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
 
         self.api = (
             '%s://geocode.arcgis.com/arcgis/rest/services/'
-            'World/GeocodeServer/find' % self.scheme
+            'World/GeocodeServer/findAddressCandidates' % self.scheme
         )
         self.reverse_api = (
             '%s://geocode.arcgis.com/arcgis/rest/services/'
@@ -123,7 +123,7 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
         """
-        params = {'text': query, 'f': 'json'}
+        params = {'singleLine': query, 'f': 'json'}
         if exactly_one is True:
             params['maxLocations'] = 1
         url = "?".join((self.api, urlencode(params)))
@@ -141,14 +141,14 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
             raise GeocoderServiceError(str(response['error']))
 
         # Success; convert from the ArcGIS JSON format.
-        if not len(response['locations']):
+        if not len(response['candidates']):
             return None
         geocoded = []
-        for resource in response['locations']:
-            geometry = resource['feature']['geometry']
+        for resource in response['candidates']:
+            geometry = resource['location']
             geocoded.append(
                 Location(
-                    resource['name'], (geometry['y'], geometry['x']), resource
+                    resource['address'], (geometry['y'], geometry['x']), resource
                 )
             )
         if exactly_one is True:
@@ -224,11 +224,11 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
             'expiration': self.token_lifetime,
             'f': 'json'
         }
-        token_request_arguments = "&".join([
-            "%s=%s" % (key, val)
-            for key, val
-            in token_request_arguments.items()
-        ])
+        token_request_arguments = urlencode(token_request_arguments) #"&".join([
+        #    "%s=%s" % (key, val)
+        #    for key, val
+        #    in token_request_arguments.items()
+        #])
         url = "&".join((
             "?".join((self.auth_api, token_request_arguments)),
             urlencode({'referer': self.referer})

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -4,7 +4,7 @@
 
 import json
 from time import time
-from geopy.compat import urlencode, Request
+from geopy.compat import urlencode, Request, string_compare
 
 from geopy.geocoders.base import Geocoder, DEFAULT_SCHEME, DEFAULT_TIMEOUT, \
     DEFAULT_WKID
@@ -121,7 +121,10 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
         :param out_fields:
         :type out_fields: A list of output fields to be returned in the
             attributes field of the raw data. This can be either a python
-            list/tuple of fields or a comma-separated string.
+            list/tuple of fields or a comma-separated string. See
+            https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm
+            for a list of supported output fields. If you want to return all
+            supported output fields, set out_fields="*".
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
@@ -132,10 +135,7 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
         if exactly_one is True:
             params['maxLocations'] = 1
         if out_fields is not None:
-            # Python 2/3 compatibility
-            if 'basestring' not in globals():
-                basestring = str
-            if isinstance(out_fields, basestring):
+            if isinstance(out_fields, string_compare):
                 params['outFields'] = out_fields
             else:
                 params['outFields'] = ",".join(out_fields)

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -224,11 +224,7 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
             'expiration': self.token_lifetime,
             'f': 'json'
         }
-        token_request_arguments = urlencode(token_request_arguments) #"&".join([
-        #    "%s=%s" % (key, val)
-        #    for key, val
-        #    in token_request_arguments.items()
-        #])
+        token_request_arguments = urlencode(token_request_arguments)
         url = "&".join((
             "?".join((self.auth_api, token_request_arguments)),
             urlencode({'referer': self.referer})

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -222,13 +222,11 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
             'username': self.username,
             'password': self.password,
             'expiration': self.token_lifetime,
-            'f': 'json'
+            'f': 'json',
+            'referer': self.referer
         }
-        token_request_arguments = urlencode(token_request_arguments)
-        url = "&".join((
-            "?".join((self.auth_api, token_request_arguments)),
-            urlencode({'referer': self.referer})
-        ))
+        url = "?".join((self.auth_api, urlencode(token_request_arguments)))
+
         logger.debug(
             "%s._refresh_authentication_token: %s",
             self.__class__.__name__, url

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -118,8 +118,10 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
-        :param string out_fields: Comma-separated list of output fields to be returned in the
-            attributes field of the raw data.
+        :param out_fields:
+        :type out_fields: A list of output fields to be returned in the
+            attributes field of the raw data. This can be either a python list/tuple
+            or a comma-separated string.
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
@@ -130,7 +132,13 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
         if exactly_one is True:
             params['maxLocations'] = 1
         if out_fields is not None:
-            params['outFields'] = out_fields
+            # Python 2/3 compatibility
+            if 'basestring' not in globals():
+                basestring = str
+            if isinstance(out_fields, basestring):
+                params['outFields'] = out_fields
+            else:
+                params['outFields'] = ",".join(out_fields)
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
         response = self._call_geocoder(url, timeout=timeout)

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -120,8 +120,8 @@ class ArcGIS(Geocoder):  # pylint: disable=R0921,R0902,W0223
 
         :param out_fields:
         :type out_fields: A list of output fields to be returned in the
-            attributes field of the raw data. This can be either a python list/tuple
-            or a comma-separated string.
+            attributes field of the raw data. This can be either a python
+            list/tuple of fields or a comma-separated string.
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`

--- a/test/geocoders/arcgis.py
+++ b/test/geocoders/arcgis.py
@@ -63,6 +63,34 @@ class ArcGISTestCase(GeocoderTestBase):
             {"latitude": 39.916, "longitude": 116.390},
         )
 
+    def test_geocode_with_out_fields_string(self):
+        """
+        ArcGIS.geocode with outFields string
+        """
+        self.geocode_run(
+            {"query": "Heathrow Airport", "out_fields":"Country"},
+            {"raw": {
+                u'attributes': {u'Country': u'GBR'},
+                u'score': 100, u'location': {u'y': 51.47114986100047, u'x': -0.45648655399958216},
+                u'extent': {u'xmin': -0.481488, u'ymin': 51.44615, u'ymax': 51.49615, u'xmax': -0.431488},
+                u'address': u'London Heathrow Airport'}}
+        )
+
+    def test_geocode_with_out_fields_list(self):
+        """
+        ArcGIS.geocode with outFields list
+        """
+        self.geocode_run(
+            {"query": "Heathrow Airport", "out_fields":["City","Type"]},
+            {"raw": {
+                u'attributes': {u'City': u'Hillingdon', u'Type': u'Airport'},
+                u'score': 100, u'location': {u'y': 51.47114986100047, u'x': -0.45648655399958216},
+                u'extent': {u'xmin': -0.481488, u'ymin': 51.44615, u'ymax': 51.49615, u'xmax': -0.431488},
+                u'address': u'London Heathrow Airport'
+                }
+            }
+        )
+
     def test_reverse_point(self):
         """
         ArcGIS.reverse using point

--- a/test/geocoders/arcgis.py
+++ b/test/geocoders/arcgis.py
@@ -68,12 +68,12 @@ class ArcGISTestCase(GeocoderTestBase):
         ArcGIS.geocode with outFields string
         """
         self.geocode_run(
-            {"query": "Heathrow Airport", "out_fields":"Country"},
+            {"query": "Trafalgar Square, London", "out_fields":"Country"},
             {"raw": {
                 u'attributes': {u'Country': u'GBR'},
-                u'score': 100, u'location': {u'y': 51.47114986100047, u'x': -0.45648655399958216},
-                u'extent': {u'xmin': -0.481488, u'ymin': 51.44615, u'ymax': 51.49615, u'xmax': -0.431488},
-                u'address': u'London Heathrow Airport'}}
+                u'score': 100, u'location': {u'y': 51.50769561800047, u'x': -0.1273497609995502},
+                u'extent': {u'xmin': -0.137351, u'ymin': 51.497696, u'ymax': 51.517696, u'xmax': -0.117351}, u'address': u'Trafalgar Square'}
+            }
         )
 
     def test_geocode_with_out_fields_list(self):
@@ -81,13 +81,11 @@ class ArcGISTestCase(GeocoderTestBase):
         ArcGIS.geocode with outFields list
         """
         self.geocode_run(
-            {"query": "Heathrow Airport", "out_fields":["City","Type"]},
+            {"query": "Trafalgar Square, London", "out_fields":["City","Type"]},
             {"raw": {
-                u'attributes': {u'City': u'Hillingdon', u'Type': u'Airport'},
-                u'score': 100, u'location': {u'y': 51.47114986100047, u'x': -0.45648655399958216},
-                u'extent': {u'xmin': -0.481488, u'ymin': 51.44615, u'ymax': 51.49615, u'xmax': -0.431488},
-                u'address': u'London Heathrow Airport'
-                }
+                u'attributes': {u'City': u'London', u'Type': u'Tourist Attraction'},
+                u'score': 100, u'location': {u'y': 51.50769561800047, u'x': -0.1273497609995502},
+                u'extent': {u'xmin': -0.137351, u'ymin': 51.497696, u'ymax': 51.517696, u'xmax': -0.117351}, u'address': u'Trafalgar Square'}
             }
         )
 


### PR DESCRIPTION
As per
https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-
address-candidates.htm the `find` operation has been deprecated. This
migrates to the `findAddressCandidates` operation but utilising the
`singleLine` functionality which mirrors the old `find` operation.
