### PR TITLE
Fix for OpenMapQuest issue geopy/geopy#168

### DIFF
--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -65,7 +65,7 @@ class OpenMapQuest(Geocoder): # pylint: disable=W0223
         )
         self.api_key = api_key or ''
         self.api = "%s://open.mapquestapi.com/nominatim/v1/search" \
-                    "?format=json" % self.scheme
+                   "?key=%s&format=json" % (self.scheme, self.api_key)
 
     def geocode(self, query, exactly_one=True, timeout=None): # pylint: disable=W0221
         """

--- a/test/geocoders/util.py
+++ b/test/geocoders/util.py
@@ -33,6 +33,7 @@ except IOError:
         'IGNFRANCE_USERNAME',
         'IGNFRANCE_PASSWORD',
         'IGNFRANCE_REFERER',
+        'OPENMAPQUEST_APIKEY',
     )
     env = {key: os.environ.get(key, None) for key in keys}
 


### PR DESCRIPTION
Added missing OPENMAPQUEST_APIKEY to util.py key list so it can be read from the environment; And added use of that api key within OpenMapQuest base api URL.
