### PR TITLE
Fix docstring with misleading/wrong order of latitude and longitude in geopy/point.py

### DIFF
--- a/geopy/point.py
+++ b/geopy/point.py
@@ -56,12 +56,12 @@ class Point(object):
 
     Points can be created in a number of ways...
 
-    With longitude, latitude, and altitude::
+    With latitude, longitude, and altitude::
 
         >>> p1 = Point(41.5, -81, 0)
         >>> p2 = Point(latitude=41.5, longitude=-81)
 
-    With a sequence of 0 to 3 values (longitude, latitude, altitude)::
+    With a sequence of 0 to 3 values (latitude, longitude, altitude)::
 
         >>> p1 = Point([41.5, -81, 0])
         >>> p2 = Point((41.5, -81))


### PR DESCRIPTION
I stumbled upon a tiny glitch in `geopy/point.py` in [line 59](https://github.com/geopy/geopy/blob/master/geopy/point.py#L59) and [line 64](https://github.com/geopy/geopy/blob/master/geopy/point.py#L64). Looks like someone accidentally swapped `latitude` and `longitude` in the `Point` class' docstring. If you're reading the [documentation on readthedocs](http://geopy.readthedocs.io/en/latest/#geopy.point.Point) (as I did) this can be quite misleading. This pull request swaps the two parameters back into the right order, hence it does not touch any code, just the docstring.

Nevertheless thanks for your patience and your excellent work so far !

Cheers,
Stephan

