### PR TITLE
Add check for a NO_RESULT to GeocodeFarm

### DIFF
--- a/geopy/geocoders/geocodefarm.py
+++ b/geopy/geocoders/geocodefarm.py
@@ -146,8 +146,6 @@ class GeocodeFarm(Geocoder):
         geocoding_results = api_result["geocoding_results"]
         self._check_for_api_errors(geocoding_results)
 
-        if "NO_RESULTS" in geocoding_results.get("STATUS", {}).get("status", ""): return None
-
         places = self.parse_code(geocoding_results)
         if exactly_one is True:
             return places[0]
@@ -161,7 +159,6 @@ class GeocodeFarm(Geocoder):
         in the api response.
         """
         status_result = geocoding_results.get("STATUS", {})
-        if "NO_RESULTS" in status_result.get("status", ""): return
         api_call_success = status_result.get("status", "") == "SUCCESS"
         if not api_call_success:
             access_error = status_result.get("access")

--- a/geopy/geocoders/geocodefarm.py
+++ b/geopy/geocoders/geocodefarm.py
@@ -146,6 +146,8 @@ class GeocodeFarm(Geocoder):
         geocoding_results = api_result["geocoding_results"]
         self._check_for_api_errors(geocoding_results)
 
+        if "NO_RESULTS" in geocoding_results.get("STATUS", {}).get("status", ""): return None
+
         places = self.parse_code(geocoding_results)
         if exactly_one is True:
             return places[0]
@@ -159,6 +161,7 @@ class GeocodeFarm(Geocoder):
         in the api response.
         """
         status_result = geocoding_results.get("STATUS", {})
+        if "NO_RESULTS" in status_result.get("status", ""): return
         api_call_success = status_result.get("status", "") == "SUCCESS"
         if not api_call_success:
             access_error = status_result.get("access")

--- a/test/geocoders/geocodefarm.py
+++ b/test/geocoders/geocodefarm.py
@@ -97,10 +97,6 @@ class GeocodeFarmTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
             self.geocoder.geocode('435 north michigan ave, chicago il 60611')
 
     def test_no_results(self):
-        """
-        GeocodeFarm unhandled error
-        """
-
         def mock_call_geocoder(*args, **kwargs):
             """
             Mock API call to return bad response.

--- a/test/geocoders/geocodefarm.py
+++ b/test/geocoders/geocodefarm.py
@@ -96,6 +96,35 @@ class GeocodeFarmTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
         with self.assertRaises(exc.GeocoderQuotaExceeded):
             self.geocoder.geocode('435 north michigan ave, chicago il 60611')
 
+    def test_no_results(self):
+        """
+        GeocodeFarm unhandled error
+        """
+
+        def mock_call_geocoder(*args, **kwargs):
+            """
+            Mock API call to return bad response.
+            """
+            return {
+                "geocoding_results": {
+                    "STATUS": {
+                        "access": "KEY_VALID, ACCESS_GRANTED",
+                        "status": "FAILED, NO_RESULTS"
+                    }
+                }
+            }
+
+        self.geocoder._call_geocoder = types.MethodType(
+            mock_call_geocoder,
+            self.geocoder
+        )
+
+        self.geocode_run(
+            {"query": "435 north michigan ave, tampa fl 60611 usa"},
+            None,
+            expect_failure=True
+        )
+
     def test_unhandled_api_error(self):
         """
         GeocodeFarm unhandled error


### PR DESCRIPTION
Issue  #239

Added two lines to check for the `NO_RESULTS` status from webservice and return `None` instead of an exception.