### PR TITLE
Add Python 3.6 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ python:
     - "2.7"
     - "3.4"
     - "3.5"
+    - "3.6"
     - "pypy"
     - "pypy3"
-install:
-    # Coveralls 4.0 doesn't support Python 3.2
-    - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
-    - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
-script:
-    - pip install nose-cov requests-oauthlib pytz
-    - nosetests --verbose --with-cover --cover-erase --cover-package=geopy
+install: coverage nose-cov requests-oauthlib pytz
+script: nosetests --verbose --with-cover --cover-erase --cover-package=geopy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ python:
     - "3.6"
     - "pypy"
     - "pypy3"
-install: coverage nose-cov requests-oauthlib pytz
+install: pip install coverage nose-cov requests-oauthlib pytz
 script: nosetests --verbose --with-cover --cover-erase --cover-package=geopy

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ envlist=py{27,34,35,36,py,py3},lint
 [testenv]
 deps=
     nose-cov
+    mock
     requests-oauthlib
     pytz
-    mock
 
 commands=nosetests --verbose
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py32,py34,py35,pypy,pypy3,lint
+envlist=py{27,34,35,36,py,py3},lint
 
 [testenv]
 deps=


### PR DESCRIPTION
This pull-request removes some definitions that were left over in travis config from python 3.2 test environments. It also adds python 3.6 support on travis and tox config files.