### PR TITLE
Dont import twice

### DIFF
--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -8,7 +8,6 @@ import hmac
 from geopy.compat import urlencode
 from geopy.geocoders.base import Geocoder, DEFAULT_TIMEOUT, DEFAULT_SCHEME
 from geopy.exc import (
-    GeocoderQueryError,
     GeocoderQuotaExceeded,
     ConfigurationError,
     GeocoderParseError,


### PR DESCRIPTION
`GeocoderQueryError` is imported twice in `googlev3`

Change:
- Remove one import