### PR TITLE
Change default coordinates BD09 to standard WGS84

### DIFF
--- a/geopy/geocoders/baidu.py
+++ b/geopy/geocoders/baidu.py
@@ -118,6 +118,7 @@ class Baidu(Geocoder):
             'ak': self.api_key,
             'output': 'json',
             'location': self._coerce_point_to_string(query),
+            'coordtype': 'wgs84ll',
         }
 
         url = "?".join((self.api, urlencode(params)))


### PR DESCRIPTION
This a bugfix, because GPS coordinates don't work with BD09.
Code has been tested with some beijing GPS lat/lon pairs.
