### PR TITLE
clarify OpenCage's bounds parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ The various geocoder classes are located in `geopy.geocoders`_.
 .. _Mapzen Search: https://mapzen.com/projects/search/
 .. _OpenMapQuest: http://developer.mapquest.com/web/products/open/geocoding-service
 .. _What3Words: http://what3words.com/api/reference
-.. _OpenCage: http://geocoder.opencagedata.com/api.html
+.. _OpenCage: https://geocoder.opencagedata.com/
 .. _SmartyStreets: https://smartystreets.com/products/liveaddress-api
 .. _geocoder.us: http://geocoder.us/
 .. _GeocodeFarm: https://www.geocodefarm.com/

--- a/geopy/distance.py
+++ b/geopy/distance.py
@@ -482,7 +482,7 @@ class vincenty(Distance):
             delta_sigma = B * sin_sigma * (
                 cos2_sigma_m + B / 4. * (
                     cos_sigma * (
-                        -1 + 2 * cos2_sigma_m
+                        -1 + 2 * cos2_sigma_m ** 2
                     ) - B / 6. * cos2_sigma_m * (
                         -3 + 4 * sin_sigma ** 2
                     ) * (

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -90,9 +90,10 @@ class OpenCage(Geocoder):
             but will not restrict the possible results to the supplied
             region. The bounds parameter should be specified as 4
             coordinate points forming the south-west and north-east
-            corners of a bounding box. For example,
-            `bounds=-0.563160,51.280430,0.278970,51.683979`.
-            (min lon, min lat, max lon, max lat)
+            corners of a bounding box. The order of the coordinates is
+            `longitude,latitude,longitude,latitude`. For example,
+            `bounds=-0.563160,51.280430,0.278970,51.683979`
+            
 
         :param string country: Provides the geocoder with a hint to the
             country that the query resides in. This value will help the

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -92,6 +92,7 @@ class OpenCage(Geocoder):
             coordinate points forming the south-west and north-east
             corners of a bounding box. For example,
             `bounds=-0.563160,51.280430,0.278970,51.683979`.
+            (min lon, min lat, max lon, max lat)
 
         :param string country: Provides the geocoder with a hint to the
             country that the query resides in. This value will help the

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -17,8 +17,8 @@ __all__ = ("OpenCage", )
 
 class OpenCage(Geocoder):
     """
-    Geocoder using the Open Cage Data API. Documentation at:
-        http://geocoder.opencagedata.com/api.html
+    Geocoder using the OpenCageData API. Documentation at:
+        https://geocoder.opencagedata.com/api
 
     ..versionadded:: 1.1.0
     """
@@ -33,11 +33,11 @@ class OpenCage(Geocoder):
             user_agent=None,
     ):  # pylint: disable=R0913
         """
-        Initialize a customized Open Cage Data geocoder.
+        Initialize a customized OpenCageData geocoder.
 
-        :param string api_key: The API key required by Open Cage Data
+        :param string api_key: The API key required by OpenCageData
             to perform geocoding requests. You can get your key here:
-            https://developer.opencagedata.com/
+            https://geocoder.opencagedata.com/
 
         :param string domain: Currently it is 'api.opencagedata.com', can
             be changed for testing purposes.

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -190,6 +190,12 @@ class TestWhenComputingVincentyDistance(CommonDistanceCases):
         assert_almost_equal(destination.latitude, 0, 0)
         assert_almost_equal(destination.longitude, -180, 0)
 
+    def test_should_compute_same_destination_as_other_libraries(self):
+        distance = self.cls(54.972271)
+        destination = distance.destination((-37.95103, 144.42487), 306.86816)
+        assert_almost_equal(destination.latitude, -37.6528177174, 10)
+        assert_almost_equal(destination.longitude, 143.9264976682, 10)
+
     def test_should_get_distinct_results_for_different_ellipsoids(self):
         results = []
         for ellipsoid_name in ELLIPSOIDS.keys():


### PR DESCRIPTION
Fixes https://github.com/geopy/geopy/issues/127
Documentation says "south-west and north-east corners" which is easy to read as lat,lon,lat,lon while the OpenCage API expects lon,lat,lon,lat.