### PR TITLE
Add input validation warnings to Point

### DIFF
--- a/geopy/compat.py
+++ b/geopy/compat.py
@@ -36,6 +36,16 @@ if py3k:
 else:
     cmp = cmp  # builtin in py2
 
+
+if py3k:
+    from math import isfinite
+else:
+    from math import isinf, isnan
+
+    def isfinite(x):
+        return not isinf(x) and not isnan(x)
+
+
 if py3k: # pragma: no cover
     from urllib.parse import (urlencode, quote, # pylint: disable=W0611,F0401,W0611,E0611
                               urlparse, parse_qs)

--- a/geopy/point.py
+++ b/geopy/point.py
@@ -77,8 +77,11 @@ def _normalize_coordinates(latitude, longitude, altitude):
         warnings.warn('Latitude has been normalized, because its '
                       'absolute value was more than 90. This is probably '
                       'not what was meant, because the normalized value '
-                      'is on a different pole.  This will cause a '
-                      'ValueError exception in the future versions of geopy.',
+                      'is on a different pole. If you pass coordinates as '
+                      'positional args, please make sure that the order is '
+                      '(latitude, longitude) or (y, x) in Cartesian terms.  '
+                      'This will cause a ValueError exception in the future '
+                      'versions of geopy.',
                       UserWarning)
         latitude = _normalize_angle(latitude, 90.0)
 


### PR DESCRIPTION
This PR adds coordinates validation and issues warnings when they're invalid (or error-prone).

TODO:
- [x] maybe don't restrict longitude range? See discussion below
- [x] add warnings to the Point constructor https://github.com/geopy/geopy/issues/242#issuecomment-377886172
- [x] error messages and comments should be grammar-checked and refined a bit

~~Regarding performance degradation – it's \~1.2 times slower with Points and \~1.9 times slower with tuples for me. IMO it's tolerable.~~
 
Related discussions: #245 #242 #202