### PR TITLE
Add address details for reverse Nominatim

### DIFF
--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -236,7 +236,7 @@ class Nominatim(Geocoder):
             exactly_one=True,
             timeout=None,
             language=False,
-            addressdetails=False
+            addressdetails=True
     ):  # pylint: disable=W0221
         """
         Returns a reverse geocoded location.

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -236,6 +236,7 @@ class Nominatim(Geocoder):
             exactly_one=True,
             timeout=None,
             language=False,
+            addressdetails=False
     ):  # pylint: disable=W0221
         """
         Returns a reverse geocoded location.
@@ -263,6 +264,9 @@ class Nominatim(Geocoder):
 
             .. versionadded:: 1.0.0
 
+        :param bool addressdetails: Whether or not to include address details,
+        such as city, county, state, etc. in *Location.raw*
+
         """
         try:
             lat, lon = [
@@ -278,6 +282,8 @@ class Nominatim(Geocoder):
         }
         if language:
             params['accept-language'] = language
+
+        params['addressdetails'] = 1 if addressdetails else 0
 
         url = self._construct_url(self.reverse_api, params)
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -265,7 +265,9 @@ class Nominatim(Geocoder):
             .. versionadded:: 1.0.0
 
         :param bool addressdetails: Whether or not to include address details,
-        such as city, county, state, etc. in *Location.raw*
+            such as city, county, state, etc. in *Location.raw*
+
+            .. versionadded:: 1.14.0
 
         """
         try:

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -189,3 +189,17 @@ class NominatimTestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
             result_geocode.raw['geojson'].get('type'),
             'Polygon'
         )
+
+    def test_missing_reverse_details(self):
+        """
+        Nominatim.reverse without address details
+        """
+        res = self._make_request(
+            self.geocoder.reverse,
+            query=(46.46131, 6.84311),
+            addressdetails=False
+        )
+        self.assertNotIn(
+            'address',
+            res
+        )


### PR DESCRIPTION
Quick PR for #284 

Actually forward geocoding already had the feature, but for some reason reverse geocoding always includes full address details. The default is now set to False.