### PR TITLE
Mark the default exactly_one value deprecated in some geocoders

### DIFF
--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -1,6 +1,7 @@
 """
 :class:`GeoNames` geocoder.
 """
+import warnings
 
 from geopy.compat import urlencode
 from geopy.exc import (
@@ -107,7 +108,7 @@ class GeoNames(Geocoder): # pylint: disable=W0223
     def reverse(
             self,
             query,
-            exactly_one=False,
+            exactly_one=DEFAULT_SENTINEL,
             timeout=DEFAULT_SENTINEL,
     ):
         """
@@ -123,12 +124,26 @@ class GeoNames(Geocoder): # pylint: disable=W0223
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
+            .. versionchanged:: 1.14.0
+               Default value for ``exactly_one`` was ``False``, which differs
+               from the conventional default across geopy. Please always pass
+               this argument explicitly, otherwise you would get a warning.
+               In geopy 2.0 the default value will become ``True``.
+
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
 
         """
+        if exactly_one is DEFAULT_SENTINEL:
+            warnings.warn('%s.reverse: default value for `exactly_one` '
+                          'argument will become True in geopy 2.0. '
+                          'Specify `exactly_one=False` as the argument '
+                          'explicitly to get rid of this warning.' % type(self).__name__,
+                          DeprecationWarning)
+            exactly_one = False
+
         try:
             lat, lng = [
                 x.strip() for x in

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -5,6 +5,7 @@
 import base64
 import hashlib
 import hmac
+import warnings
 
 from geopy.compat import urlencode
 from geopy.exc import (
@@ -228,7 +229,7 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
     def reverse(
             self,
             query,
-            exactly_one=False,
+            exactly_one=DEFAULT_SENTINEL,
             timeout=DEFAULT_SENTINEL,
             language=None,
             sensor=False,
@@ -244,6 +245,12 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
+            .. versionchanged:: 1.14.0
+               Default value for ``exactly_one`` was ``False``, which differs
+               from the conventional default across geopy. Please always pass
+               this argument explicitly, otherwise you would get a warning.
+               In geopy 2.0 the default value will become ``True``.
+
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
             exception. Set this only if you wish to override, on this call
@@ -254,6 +261,14 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
         :param bool sensor: Whether the geocoding request comes from a
             device with a location sensor.
         """
+        if exactly_one is DEFAULT_SENTINEL:
+            warnings.warn('%s.reverse: default value for `exactly_one` '
+                          'argument will become True in geopy 2.0. '
+                          'Specify `exactly_one=False` as the argument '
+                          'explicitly to get rid of this warning.' % type(self).__name__,
+                          DeprecationWarning)
+            exactly_one = False
+
         params = {
             'latlng': self._coerce_point_to_string(query),
             'sensor': str(sensor).lower()

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -1,7 +1,7 @@
 """
 :class:`.IGNFrance` is the IGN France Geocoder.
 """
-
+import warnings
 import xml.etree.ElementTree as ET
 
 from geopy.compat import (HTTPBasicAuthHandler, HTTPPasswordMgrWithDefaultRealm, Request,
@@ -238,7 +238,7 @@ class IGNFrance(Geocoder):   # pylint: disable=W0223
             reverse_geocode_preference=('StreetAddress', ),
             maximum_responses=25,
             filtering='',
-            exactly_one=False,
+            exactly_one=DEFAULT_SENTINEL,
             timeout=DEFAULT_SENTINEL,
     ):
         """
@@ -263,12 +263,25 @@ class IGNFrance(Geocoder):   # pylint: disable=W0223
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
+            .. versionchanged:: 1.14.0
+               Default value for ``exactly_one`` was ``False``, which differs
+               from the conventional default across geopy. Please always pass
+               this argument explicitly, otherwise you would get a warning.
+               In geopy 2.0 the default value will become ``True``.
+
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
 
         """
+        if exactly_one is DEFAULT_SENTINEL:
+            warnings.warn('%s.reverse: default value for `exactly_one` '
+                          'argument will become True in geopy 2.0. '
+                          'Specify `exactly_one=False` as the argument '
+                          'explicitly to get rid of this warning.' % type(self).__name__,
+                          DeprecationWarning)
+            exactly_one = False
 
         sub_request = """
             <ReverseGeocodeRequest>

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -1,6 +1,7 @@
 """
 :class:`.OpenCage` is the Opencagedata geocoder.
 """
+import warnings
 
 from geopy.compat import urlencode
 from geopy.exc import GeocoderQueryError, GeocoderQuotaExceeded
@@ -137,7 +138,7 @@ class OpenCage(Geocoder):
             self,
             query,
             language=None,
-            exactly_one=False,
+            exactly_one=DEFAULT_SENTINEL,
             timeout=DEFAULT_SENTINEL,
     ):
         """
@@ -153,12 +154,26 @@ class OpenCage(Geocoder):
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
+            .. versionchanged:: 1.14.0
+               Default value for ``exactly_one`` was ``False``, which differs
+               from the conventional default across geopy. Please always pass
+               this argument explicitly, otherwise you would get a warning.
+               In geopy 2.0 the default value will become ``True``.
+
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
 
         """
+        if exactly_one is DEFAULT_SENTINEL:
+            warnings.warn('%s.reverse: default value for `exactly_one` '
+                          'argument will become True in geopy 2.0. '
+                          'Specify `exactly_one=False` as the argument '
+                          'explicitly to get rid of this warning.' % type(self).__name__,
+                          DeprecationWarning)
+            exactly_one = False
+
         params = {
             'key': self.api_key,
             'q': self._coerce_point_to_string(query),

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -1,6 +1,7 @@
 """
 :class:`Yandex` geocoder.
 """
+import warnings
 
 from geopy.compat import urlencode
 from geopy.exc import GeocoderParseError, GeocoderServiceError
@@ -107,7 +108,7 @@ class Yandex(Geocoder): # pylint: disable=W0223
     def reverse(
             self,
             query,
-            exactly_one=False,
+            exactly_one=DEFAULT_SENTINEL,
             timeout=DEFAULT_SENTINEL,
             kind=None,
     ):
@@ -122,6 +123,12 @@ class Yandex(Geocoder): # pylint: disable=W0223
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
+            .. versionchanged:: 1.14.0
+               Default value for ``exactly_one`` was ``False``, which differs
+               from the conventional default across geopy. Please always pass
+               this argument explicitly, otherwise you would get a warning.
+               In geopy 2.0 the default value will become ``True``.
+
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
             exception. Set this only if you wish to override, on this call
@@ -132,6 +139,14 @@ class Yandex(Geocoder): # pylint: disable=W0223
 
             .. versionadded:: 1.14.0
         """
+        if exactly_one is DEFAULT_SENTINEL:
+            warnings.warn('%s.reverse: default value for `exactly_one` '
+                          'argument will become True in geopy 2.0. '
+                          'Specify `exactly_one=False` as the argument '
+                          'explicitly to get rid of this warning.' % type(self).__name__,
+                          DeprecationWarning)
+            exactly_one = False
+
         try:
             lat, lng = [
                 x.strip() for x in

--- a/test/geocoders/geonames.py
+++ b/test/geocoders/geonames.py
@@ -44,6 +44,6 @@ class GeoNamesTestCase(GeocoderTestBase):
         # work around ConfigurationError raised in GeoNames init
         self.geocoder = GeoNames(username=env['GEONAMES_USERNAME'])
         self.reverse_run(
-            {"query": "40.75376406311989, -73.98489005863667"},
+            {"query": "40.75376406311989, -73.98489005863667", "exactly_one": True},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667},
         )

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -166,7 +166,7 @@ class GoogleV3TestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
         GoogleV3.reverse string
         """
         self.reverse_run(
-            {"query": "40.75376406311989, -73.98489005863667"},
+            {"query": "40.75376406311989, -73.98489005863667", "exactly_one": True},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667},
         )
 
@@ -175,7 +175,7 @@ class GoogleV3TestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
         GoogleV3.reverse Point
         """
         self.reverse_run(
-            {"query": self.new_york_point},
+            {"query": self.new_york_point, "exactly_one": True},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667},
         )
 

--- a/test/geocoders/ignfrance.py
+++ b/test/geocoders/ignfrance.py
@@ -253,6 +253,7 @@ class IGNFranceTestCase(GeocoderTestBase):
         res = self._make_request(
             self.geocoder.reverse,
             query='47.229554,-1.541519',
+            exactly_one=False,
             reverse_geocode_preference=['StreetAddress', 'PositionOfInterest']
         )
         self.assertEqual(
@@ -278,12 +279,14 @@ class IGNFranceTestCase(GeocoderTestBase):
         res_call_radius = self._make_request(
             self.geocoder.reverse,
             query='48.8033333,2.3241667',
+            exactly_one=False,
             maximum_responses=10,
             filtering=spatial_filtering_radius)
 
         res_call = self._make_request(
             self.geocoder.reverse,
             query='48.8033333,2.3241667',
+            exactly_one=False,
             maximum_responses=10
         )
 

--- a/test/geocoders/util.py
+++ b/test/geocoders/util.py
@@ -56,7 +56,8 @@ class GeocoderTestBase(unittest.TestCase): # pylint: disable=R0904
                 self.fail('No result found')
             else:
                 return
-        self._verify_request(result, **expected)
+        self._verify_request(result, exactly_one=payload.get('exactly_one', True),
+                             **expected)
         return result
 
     def reverse_run(self, payload, expected, expect_failure=False):
@@ -69,7 +70,8 @@ class GeocoderTestBase(unittest.TestCase): # pylint: disable=R0904
                 self.fail('No result found')
             else:
                 return
-        self._verify_request(result, **expected)
+        self._verify_request(result, exactly_one=payload.get('exactly_one', True),
+                             **expected)
         return result
 
     @staticmethod
@@ -94,11 +96,12 @@ class GeocoderTestBase(unittest.TestCase): # pylint: disable=R0904
             latitude=EMPTY,
             longitude=EMPTY,
             address=EMPTY,
-        ):
+            exactly_one=True,
+    ):
         """
         Verifies that a a result matches the kwargs given.
         """
-        item = result[0] if isinstance(result, (tuple, list)) else result
+        item = result if exactly_one else result[0]
 
         if raw is not EMPTY:
             self.assertEqual(item.raw, raw)

--- a/test/geocoders/yandex.py
+++ b/test/geocoders/yandex.py
@@ -64,7 +64,7 @@ class YandexTestCase(GeocoderTestBase):
         """
         self.geocoder = Yandex()
         self.reverse_run(
-            {"query": "40.75376406311989, -73.98489005863667"},
+            {"query": "40.75376406311989, -73.98489005863667", "exactly_one": True},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667},
         )
 


### PR DESCRIPTION
`Geocoder.reverse` has `exactly_one=True`, but some geocoders define `False` as a default value for `exactly_one`. This is wrong, it should match the base method's default.

This PR adds warnings and docs, encouraging to always pass this attribute explicitly.

As switching the default is a breaking change, it's postponed until geopy 2.0 (see #292).