### PR TITLE
GoogleV3: allow `geocode` call with just `components`

### DIFF
--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -159,7 +159,7 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
 
     def geocode(
             self,
-            query,
+            query=None,
             exactly_one=True,
             timeout=DEFAULT_SENTINEL,
             bounds=None,
@@ -171,7 +171,14 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
         """
         Geocode a location query.
 
-        :param str query: The address or query you wish to geocode.
+        :param str query: The address or query you wish to geocode. Optional,
+            if ``components`` param is set::
+
+                >>> g = GoogleV3()
+                >>> g.geocode(components={"city": "Paris", "country": "FR"})
+
+            .. versionchanged:: 1.14.0
+               Now ``query`` is optional if ``components`` param is set.
 
         :param bool exactly_one: Return one result or a list of results, if
             available.
@@ -197,9 +204,12 @@ class GoogleV3(Geocoder):  # pylint: disable=R0902
             device with a location sensor.
         """
         params = {
-            'address': self.format_string % query,
             'sensor': str(sensor).lower()
         }
+        if query is None and not components:
+            raise ValueError('Either `query` or `components` must be set.`')
+        if query is not None:
+            params['address'] = self.format_string % query
         if self.api_key:
             params['key'] = self.api_key
         if bounds:

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -131,7 +131,7 @@ class GoogleV3TestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
             {"latitude": 39.916, "longitude": 116.390},
         )
 
-    def test_geocode_components(self):
+    def test_geocode_with_conflicting_components(self):
         """
         GoogleV3.geocode returns None on conflicting components
         """
@@ -159,6 +159,14 @@ class GoogleV3TestCase(GeocoderTestBase): # pylint: disable=R0904,C0111
                 }
             },
             {"latitude": 28.4636296, "longitude": -16.2518467},
+        )
+
+    def test_components_without_query(self):
+        self.geocode_run(
+            {
+                "components": {"city": "Paris", "country": "FR"},
+            },
+            {"latitude": 46.227638, "longitude": 2.213749},
         )
 
     def test_reverse_string(self):


### PR DESCRIPTION
Rationale: #130 
Closes #130 