### PR TITLE
Proxies: add proper support for HTTP_PROXY env vars, update docs

### DIFF
--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -183,18 +183,20 @@ class Geocoder(object):
         self.ssl_context = (ssl_context if ssl_context is not DEFAULT_SENTINEL
                             else options.default_ssl_context)
 
-        if self.proxies:
-            if isinstance(self.proxies, string_compare):
-                self.proxies = {'http': self.proxies, 'https': self.proxies}
+        if isinstance(self.proxies, string_compare):
+            self.proxies = {'http': self.proxies, 'https': self.proxies}
 
-            opener = build_opener_with_context(
-                self.ssl_context,
-                ProxyHandler(self.proxies),
-            )
-        else:
-            opener = build_opener_with_context(
-                self.ssl_context,
-            )
+        # `ProxyHandler` should be present even when actually there're
+        # no proxies. `build_opener` contains it anyway. By specifying
+        # it here explicitly we can disable system proxies (i.e.
+        # from HTTP_PROXY env var) by setting `self.proxies` to `{}`.
+        # Otherwise, if we didn't specify ProxyHandler for empty
+        # `self.proxies` here, build_opener would have used one internally
+        # which could have unwillingly picked up the system proxies.
+        opener = build_opener_with_context(
+            self.ssl_context,
+            ProxyHandler(self.proxies),
+        )
         self.urlopen = opener.open
 
     @staticmethod

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -63,11 +63,46 @@ class options(object):
             calls only. For example: ``'%s, Mountain View, CA'``.
 
         default_proxies
-            If specified, tunnel requests through the specified proxy.
-            E.g., ``{"https": "192.0.2.0"}``. For more information, see
+            Tunnel requests through HTTP proxy.
+
+            By default the system proxies are respected (e.g.
+            `HTTP_PROXY` and `HTTPS_PROXY` env vars or platform-specific
+            proxy settings, such as macOS or Windows native
+            preferences -- see :class:`urllib.request.ProxyHandler` for
+            more details). The `proxies` value for using system proxies
+            is ``None``.
+
+            To disable system proxies and issue requests directly,
+            explicitly pass an empty dict as a value for `proxies`: ``{}``.
+
+            To use a custom HTTP proxy location, pass a string.
+            Valid examples are:
+
+            - ``"192.0.2.0:8080"``
+            - ``"john:passw0rd@192.0.2.0:8080"``
+            - ``"http://john:passw0rd@192.0.2.0:8080"``
+
+            Please note:
+
+            - Scheme part (``http://``) of the proxy is ignored.
+            - Only `http` proxy is supported. Even if the proxy scheme
+              is `https`, it will be ignored, and the connection between
+              client and proxy would still be unencrypted.
+              However, `https` requests via `http` proxy are still
+              supported (via `HTTP CONNECT` method).
+
+
+            Raw urllib-style `proxies` dict might be provided instead of
+            a string:
+
+            - ``{"https": "192.0.2.0:8080"}`` -- means that HTTP proxy
+              would be used only for requests having `https` scheme.
+              String `proxies` value is automatically used for both
+              schemes, and is provided as a shorthand for the urllib-style
+              `proxies` dict.
+
+            For more information, see
             documentation on :class:`urllib.request.ProxyHandler`.
-            Can be sent as a string ``"https://192.0.2.0"``, this will
-            automatically set the scheme to the ``https``
 
         default_scheme
             Use ``'https'`` or ``'http'`` as the API URL's scheme.

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -6,11 +6,22 @@ import ssl
 import unittest
 from test.proxy_server import ProxyServerThread
 
+try:
+    from urllib.request import getproxies
+except ImportError:  # py2
+    from urllib2 import getproxies
+
 from geopy.compat import urlopen
 from geopy.exc import GeocoderServiceError
 from geopy.geocoders.base import Geocoder
 
 CERT_SELFSIGNED_CA = os.path.join(os.path.dirname(__file__), 'selfsigned_ca.pem')
+
+# Are system proxies set? System proxies are set in:
+# - Environment variables (HTTP_PROXY/HTTPS_PROXY) on Unix;
+# - System Configuration Framework on macOS;
+# - Registry's Internet Settings section on Windows.
+WITH_SYSTEM_PROXIES = bool(getproxies())
 
 
 class DummyGeocoder(Geocoder):
@@ -89,7 +100,60 @@ class ProxyTestCase(unittest.TestCase):
         )
         self.assertEqual(1, len(self.proxy_server.requests))
 
-    def test_geocoder_constructor_have_both_schemes_proxy(self):
+    def test_geocoder_constructor_has_both_schemes_proxy(self):
         g = DummyGeocoder(proxies=self.proxy_url, scheme='http')
         self.assertDictEqual(g.proxies, {'http': self.proxy_url,
                                          'https': self.proxy_url})
+
+
+@unittest.skipUnless(not WITH_SYSTEM_PROXIES,
+                     "There're active system proxies")
+class SystemProxiesTestCase(unittest.TestCase):
+    remote_website_http = "http://example.org/"
+    timeout = 5
+
+    def setUp(self):
+        self.proxy_server = ProxyServerThread(timeout=self.timeout)
+        self.proxy_server.start()
+        self.proxy_url = self.proxy_server.get_proxy_url()
+
+        self.assertIsNone(os.environ.get('http_proxy'))
+        self.assertIsNone(os.environ.get('https_proxy'))
+        os.environ['http_proxy'] = self.proxy_url
+        os.environ['https_proxy'] = self.proxy_url
+
+    def tearDown(self):
+        self.proxy_server.stop()
+        self.proxy_server.join()
+
+        os.environ.pop('http_proxy', None)
+        os.environ.pop('https_proxy', None)
+
+    def test_system_proxies_are_respected_by_default(self):
+        geocoder_dummy = DummyGeocoder(timeout=self.timeout)
+        self.assertEqual(0, len(self.proxy_server.requests))
+        geocoder_dummy.geocode(self.remote_website_http)
+        self.assertEqual(1, len(self.proxy_server.requests))
+
+    def test_system_proxies_are_respected_with_none(self):
+        # proxies=None means "use system proxies", e.g. from the ENV.
+        geocoder_dummy = DummyGeocoder(proxies=None, timeout=self.timeout)
+        self.assertEqual(0, len(self.proxy_server.requests))
+        geocoder_dummy.geocode(self.remote_website_http)
+        self.assertEqual(1, len(self.proxy_server.requests))
+
+    def test_system_proxies_are_reset_with_empty_dict(self):
+        geocoder_dummy = DummyGeocoder(proxies={}, timeout=self.timeout)
+        self.assertEqual(0, len(self.proxy_server.requests))
+        geocoder_dummy.geocode(self.remote_website_http)
+        self.assertEqual(0, len(self.proxy_server.requests))
+
+    def test_string_value_overrides_system_proxies(self):
+        os.environ['http_proxy'] = '127.0.0.1:1'
+        os.environ['https_proxy'] = '127.0.0.1:1'
+
+        geocoder_dummy = DummyGeocoder(proxies=self.proxy_url,
+                                       timeout=self.timeout)
+        self.assertEqual(0, len(self.proxy_server.requests))
+        geocoder_dummy.geocode(self.remote_website_http)
+        self.assertEqual(1, len(self.proxy_server.requests))


### PR DESCRIPTION
The following has been done there:
- Added tests (and hence the support) for system proxies (i.e. `HTTP_PROXY` env var)
- Fixed `proxies={}` being ignored (which should reset system proxies)
- Updated proxies docstring with more details and examples

Closes #301