### PR TITLE
Nominatim: show a warning when default user_agent is used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ To geolocate a query to an address and coordinates:
 .. code:: python
 
     >>> from geopy.geocoders import Nominatim
-    >>> geolocator = Nominatim()
+    >>> geolocator = Nominatim(user_agent="specify_your_app_name_here")
     >>> location = geolocator.geocode("175 5th Avenue NYC")
     >>> print(location.address)
     Flatiron Building, 175, 5th Avenue, Flatiron, New York, NYC, New York, ...
@@ -88,7 +88,7 @@ To find the address corresponding to a set of coordinates:
 .. code:: python
 
     >>> from geopy.geocoders import Nominatim
-    >>> geolocator = Nominatim()
+    >>> geolocator = Nominatim(user_agent="specify_your_app_name_here")
     >>> location = geolocator.reverse("52.509669, 13.376294")
     >>> print(location.address)
     Potsdamer Platz, Mitte, Berlin, 10117, Deutschland, European Union

--- a/geopy/distance.py
+++ b/geopy/distance.py
@@ -79,7 +79,7 @@ calculate the length of a path::
 
     >>> from geopy import Nominatim
     >>> d = distance.distance
-    >>> g = Nominatim()
+    >>> g = Nominatim(user_agent="specify_your_app_name_here")
     >>> _, wa = g.geocode('Washington, DC')
     >>> _, pa = g.geocode('Palo Alto, CA')
     >>> print((d(ne, cl) + d(cl, wa) + d(wa, pa)).miles)

--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -10,7 +10,7 @@ locale, during its initialization.
 To geolocate a query to an address and coordinates:
 
     >>> from geopy.geocoders import Nominatim
-    >>> geolocator = Nominatim()
+    >>> geolocator = Nominatim(user_agent="specify_your_app_name_here")
     >>> location = geolocator.geocode("175 5th Avenue NYC")
     >>> print(location.address)
     Flatiron Building, 175, 5th Avenue, Flatiron, New York, NYC, New York, ...
@@ -23,7 +23,7 @@ To geolocate a query to an address and coordinates:
 To find the address corresponding to a set of coordinates:
 
     >>> from geopy.geocoders import Nominatim
-    >>> geolocator = Nominatim()
+    >>> geolocator = Nominatim(user_agent="specify_your_app_name_here")
     >>> location = geolocator.reverse("52.509669, 13.376294")
     >>> print(location.address)
     Potsdamer Platz, Mitte, Berlin, 10117, Deutschland, European Union

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -32,6 +32,8 @@ __all__ = (
     "options",
 )
 
+_DEFAULT_USER_AGENT = "geopy/%s" % __version__
+
 
 class options(object):
     """The `options` object contains default configuration values for
@@ -165,7 +167,7 @@ class options(object):
     default_scheme = 'https'
     default_ssl_context = None
     default_timeout = 1
-    default_user_agent = "geopy/%s" % __version__
+    default_user_agent = _DEFAULT_USER_AGENT
 
 
 # Create an object which `repr` returns 'DEFAULT_SENTINEL'. Sphinx (docs) uses

--- a/test/geocoders/pickpoint.py
+++ b/test/geocoders/pickpoint.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from geopy.geocoders import PickPoint
 from test.geocoders.nominatim import BaseNominatimTestCase
@@ -15,3 +16,9 @@ class PickPointTestCase(BaseNominatimTestCase, GeocoderTestBase):
     def make_geocoder(cls, **kwargs):
         return PickPoint(api_key=env['PICKPOINT_KEY'],
                          timeout=3, **kwargs)
+
+    def test_no_nominatim_user_agent_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            PickPoint(api_key=env['PICKPOINT_KEY'])
+            self.assertEqual(0, len(w))


### PR DESCRIPTION
[Nominatim's Usage Policy](https://operations.osmfoundation.org/policies/nominatim/) says that each application must provide their own user_agent. geopy allowed to use Nominatim with stock geopy's user_agent, but lately people started to report receiving 403 HTTP errors (see #314), probably caused by someone bombing Nominatim with requests using the stock geopy user-agent.

This PR adds a warning when stock user-agent is used against `nominatim.openstreetmap.org`. In geopy 2.0 this will be an exception instead of a warning. Also all examples have been updated to include the custom user_agent.

cc @xmedeko 

Closes #314 