### PR TITLE
Make OpenMapQuest extend Nominatim

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -179,6 +179,8 @@ OpenMapQuest
 
 .. autoclass:: geopy.geocoders.OpenMapQuest
    :members:
+   :inherited-members:
+   :show-inheritance:
 
    .. automethod:: __init__
 

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -14,7 +14,7 @@ _DEFAULT_NOMINATIM_DOMAIN = 'nominatim.openstreetmap.org'
 
 
 class Nominatim(Geocoder):
-    """Nominatim geocoder for OpenStreetMap servers.
+    """Nominatim geocoder for OpenStreetMap data.
 
     Documentation at:
         https://wiki.openstreetmap.org/wiki/Nominatim
@@ -45,6 +45,9 @@ class Nominatim(Geocoder):
         'postalcode',
     }
 
+    geocode_path = '/search'
+    reverse_path = '/reverse'
+
     def __init__(
             self,
             format_string=None,
@@ -73,12 +76,12 @@ class Nominatim(Geocoder):
             .. versionchanged:: 1.15.0
                Previously only a list of stringified coordinates was supported.
 
-        :param str country_bias: Bias results to this country.
-
         :param bool bounded: Restrict the results to only items contained
             within the bounding view_box.
 
             .. versionadded:: 1.15.0
+
+        :param str country_bias: Bias results to this country.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -86,9 +89,8 @@ class Nominatim(Geocoder):
         :param dict proxies:
             See :attr:`geopy.geocoders.options.default_proxies`.
 
-        :param str domain: Should be the localized Openstreetmap domain to
-            connect to. The default is ``'nominatim.openstreetmap.org'``,
-            but you can change it to a domain of your own.
+        :param str domain: Domain where the target Nominatim service
+            is hosted.
 
             .. versionadded:: 1.8.2
 
@@ -138,8 +140,8 @@ class Nominatim(Geocoder):
                 UserWarning
             )
 
-        self.api = "%s://%s/search" % (self.scheme, self.domain)
-        self.reverse_api = "%s://%s/reverse" % (self.scheme, self.domain)
+        self.api = "%s://%s%s" % (self.scheme, self.domain, self.geocode_path)
+        self.reverse_api = "%s://%s%s" % (self.scheme, self.domain, self.reverse_path)
 
     def _construct_url(self, base_api, params):
         """
@@ -356,7 +358,7 @@ class Nominatim(Geocoder):
         latitude = place.get('lat', None)
         longitude = place.get('lon', None)
         placename = place.get('display_name', None)
-        if latitude and longitude:
+        if latitude is not None and longitude is not None:
             latitude = float(latitude)
             longitude = float(longitude)
         return Location(placename, (latitude, longitude), place)

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -237,7 +237,7 @@ class Nominatim(Geocoder):
 
         if exactly_one:
             params['limit'] = 1
-        elif limit:
+        elif limit is not None:
             limit = int(limit)
             if limit < 1:
                 raise ValueError("Limit cannot be less than 1")
@@ -364,12 +364,10 @@ class Nominatim(Geocoder):
         return Location(placename, (latitude, longitude), place)
 
     def _parse_json(self, places, exactly_one):
-        if places is None:
+        if not places:
             return None
         if not isinstance(places, list):
             places = [places]
-        if not len(places):
-            return None
         if exactly_one:
             return self.parse_code(places[0])
         else:

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -14,6 +14,9 @@ class PickPoint(Nominatim):
 
     """
 
+    geocode_path = '/v1/forward'
+    reverse_path = '/v1/reverse'
+
     def __init__(
             self,
             api_key,
@@ -49,9 +52,8 @@ class PickPoint(Nominatim):
         :param dict proxies:
             See :attr:`geopy.geocoders.options.default_proxies`.
 
-        :param str domain: Should be the localized Openstreetmap domain to
-            connect to. The default is ``'api.pickpoint.io'``, but you
-            can change it to a domain of your own.
+        :param str domain: Domain where the target Nominatim service
+            is hosted.
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -79,12 +81,10 @@ class PickPoint(Nominatim):
             ssl_context=ssl_context,
         )
         self.api_key = api_key
-        self.api = "%s://%s/v1/forward" % (self.scheme, self.domain)
-        self.reverse_api = "%s://%s/v1/reverse" % (self.scheme, self.domain)
 
     def _construct_url(self, base_api, params):
         """
-        Construct geocoding request url. Overriden.
+        Construct geocoding request url. Overridden.
 
         :param string base_api: Geocoding function base address - self.api
             or self.reverse_api.

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -37,6 +37,26 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
             {"latitude": 39.916, "longitude": 116.390},
         )
 
+    def test_geocode_empty_result(self):
+        self.geocode_run(
+            {"query": "dsadjkasdjasd"},
+            {},
+            expect_failure=True,
+        )
+
+    def test_limit(self):
+        with self.assertRaises(ValueError):  # non-positive limit
+            self.geocode_run(
+                {"query": "does not matter", "limit": 0, "exactly_one": False},
+                {}
+            )
+
+        result = self.geocode_run(
+            {"query": "second street", "limit": 4, "exactly_one": False},
+            {}
+        )
+        self.assertEqual(4, len(result))
+
     @patch.object(geopy.geocoders.options, 'default_user_agent',
                   'mocked_user_agent/0.0.0')
     def test_user_agent_default(self):

--- a/test/geocoders/openmapquest.py
+++ b/test/geocoders/openmapquest.py
@@ -1,6 +1,6 @@
-
-from geopy.compat import u
 from geopy.geocoders import OpenMapQuest
+from geopy.exc import ConfigurationError
+from test.geocoders.nominatim import BaseNominatimTestCase
 from test.geocoders.util import GeocoderTestBase, env
 import unittest
 
@@ -14,37 +14,18 @@ class OpenMapQuestNoNetTestCase(GeocoderTestBase):
         )
         self.assertEqual(geocoder.headers['User-Agent'], 'my_user_agent/1.0')
 
+    def test_raises_without_apikey(self):
+        with self.assertRaises(ConfigurationError):
+            OpenMapQuest()
+
 
 @unittest.skipUnless(
     bool(env.get('OPENMAPQUEST_APIKEY')),
     "No OPENMAPQUEST_APIKEY env variable set"
 )
-class OpenMapQuestTestCase(GeocoderTestBase):
+class OpenMapQuestTestCase(BaseNominatimTestCase, GeocoderTestBase):
 
     @classmethod
-    def setUpClass(cls):
-        # setUpClass is still called even if test is skipped.
-        # OpenMapQuest raises ConfigurationError when api_key is empty,
-        # so don't try to create the instance when api_key is empty.
-        if env.get('OPENMAPQUEST_APIKEY'):
-            cls.geocoder = OpenMapQuest(scheme='http', timeout=3,
-                                        api_key=env['OPENMAPQUEST_APIKEY'])
-        cls.delta = 0.04
-
-    def test_geocode(self):
-        """
-        OpenMapQuest.geocode
-        """
-        self.geocode_run(
-            {"query": "435 north michigan ave, chicago il 60611 usa"},
-            {"latitude": 41.890, "longitude": -87.624},
-        )
-
-    def test_unicode_name(self):
-        """
-        OpenMapQuest.geocode unicode
-        """
-        self.geocode_run(
-            {"query": u("\u6545\u5bab")},
-            {"latitude": 39.916, "longitude": 116.390},
-        )
+    def make_geocoder(cls, **kwargs):
+        return OpenMapQuest(api_key=env['OPENMAPQUEST_APIKEY'],
+                            timeout=3, **kwargs)

--- a/test/geocoders/util.py
+++ b/test/geocoders/util.py
@@ -125,26 +125,40 @@ class GeocoderTestBase(unittest.TestCase):
     def _verify_request(
             self,
             result,
-            raw=EMPTY,
             latitude=EMPTY,
             longitude=EMPTY,
             address=EMPTY,
             exactly_one=True,
+            delta=None,
     ):
         """
-        Verifies that a a result matches the kwargs given.
+        Verifies that result matches the kwargs given.
         """
         item = result if exactly_one else result[0]
+        delta = delta or self.delta
+        exceptions = []
 
-        if raw is not EMPTY:
-            self.assertEqual(item.raw, raw)
         if latitude is not EMPTY:
-            self.assertAlmostEqual(
-                item.latitude, latitude, delta=self.delta
-            )
+            try:
+                self.assertAlmostEqual(
+                    item.latitude, latitude, delta=delta,
+                    msg="latitude differs",
+                )
+            except AssertionError as e:
+                exceptions.append(e)
         if longitude is not EMPTY:
-            self.assertAlmostEqual(
-                item.longitude, longitude, delta=self.delta
-            )
+            try:
+                self.assertAlmostEqual(
+                    item.longitude, longitude, delta=delta,
+                    msg="longitude differs",
+                )
+            except AssertionError as e:
+                exceptions.append(e)
         if address is not EMPTY:
-            self.assertEqual(item.address, address)
+            try:
+                self.assertEqual(item.address, address,
+                                 msg="address differs")
+            except AssertionError as e:
+                exceptions.append(e)
+
+        self.assertFalse(exceptions)


### PR DESCRIPTION
OpenMapQuest API is basically an older version of Nominatim [[1]] [[2]], so the OpenMapQuest class should extend Nominatim as well. This PR does exactly that.

This consequently adds more parameters to OpenMapQuest + adds the reverse geocoding method.

Closes #174

[1]: https://developer.mapquest.com/documentation/open/nominatim-search/
[2]: https://developer.mapquest.com/forum/differences-between-openmaquestcom-and-nominatimopenstreetmaporg