### PR TITLE
Add geopy.Timezone -- a timezone wrapper

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -287,10 +287,13 @@ Data
 ~~~~
 
 .. autoclass:: geopy.location.Location
-    :members: __init__, address, latitude, longitude, altitude, point, raw
+    :members: address, latitude, longitude, altitude, point, raw
 
 .. autoclass:: geopy.point.Point
     :members: __new__, from_string, from_sequence, from_point
+
+.. autoclass:: geopy.timezone.Timezone
+    :members: pytz_timezone, raw
 
 Exceptions
 ~~~~~~~~~~

--- a/geopy/__init__.py
+++ b/geopy/__init__.py
@@ -11,9 +11,13 @@ PyPy3. geopy does not and will not support CPython 2.6.
 
 from geopy.location import Location  # noqa
 from geopy.point import Point  # noqa
+from geopy.timezone import Timezone  # noqa
 from geopy.util import __version__  # noqa
 
 from geopy.geocoders import *  # noqa
 # geopy.geocoders.options must not be importable as `geopy.options`,
 # because that is ambiguous (which options are that).
 del options  # noqa
+
+# `__all__` is intentionally not defined in order to not duplicate
+# the same list of geocoders as in `geopy.geocoders` package.

--- a/geopy/timezone.py
+++ b/geopy/timezone.py
@@ -1,0 +1,91 @@
+from geopy.compat import text_type
+from geopy.exc import GeocoderParseError
+
+try:
+    import pytz
+    pytz_available = True
+except ImportError:
+    pytz_available = False
+
+
+def ensure_pytz_is_installed():
+    if not pytz_available:
+        raise ImportError(
+            'pytz must be installed in order to locate timezones. '
+            ' Install with `pip install geopy -e ".[timezone]"`.'
+        )
+
+
+def from_timezone_name(timezone_name, raw=None):
+    ensure_pytz_is_installed()
+    try:
+        pytz_timezone = pytz.timezone(timezone_name)
+    except pytz.UnknownTimeZoneError:
+        raise GeocoderParseError(
+            "pytz could not parse the timezone identifier (%s) "
+            "returned by the service." % timezone_name
+        )
+    except KeyError:
+        raise GeocoderParseError(
+            "geopy could not find a timezone in this response: %s" %
+            raw
+        )
+    return Timezone(pytz_timezone, raw)
+
+
+class Timezone(object):
+    """
+    Contains a parsed response for a timezone request, which is
+    implemented in few geocoders which provide such lookups.
+
+    .. versionadded:: 1.18.0
+    """
+
+    __slots__ = ("_pytz_timezone", "_raw")
+
+    def __init__(self, pytz_timezone, raw=None):
+        self._pytz_timezone = pytz_timezone
+        self._raw = raw
+
+    @property
+    def pytz_timezone(self):
+        """
+        pytz timezone instance.
+
+        :rtype: :class:`pytz.tzinfo.BaseTzInfo`
+        """
+        return self._pytz_timezone
+
+    @property
+    def raw(self):
+        """
+        Timezone's raw, unparsed geocoder response. For details on this,
+        consult the service's documentation.
+
+        :rtype: dict or None
+        """
+        return self._raw
+
+    def __unicode__(self):
+        return text_type(self._pytz_timezone)
+
+    __str__ = __unicode__
+
+    def __repr__(self):
+        return "Timezone(%s)" % repr(self.pytz_timezone)
+
+    def __getstate__(self):
+        return self._pytz_timezone, self._raw
+
+    def __setstate__(self, state):
+        self._pytz_timezone, self._raw = state
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, Timezone) and
+            self._pytz_timezone == other._pytz_timezone and
+            self.raw == other.raw
+        )
+
+    def __ne__(self, other):
+        return not (self == other)

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -204,14 +204,34 @@ class GoogleV3TestCase(GeocoderTestBase):
             self.america_new_york,
         )
 
+    def test_timezone_at_time_normalization(self):
+        utc_naive_dt = datetime(2010, 1, 1, 0, 0, 0)
+        utc_timestamp = 1262304000
+        self.assertEqual(
+            utc_timestamp, self.geocoder._normalize_timezone_at_time(utc_naive_dt)
+        )
+
+        self.assertLess(
+            utc_timestamp, self.geocoder._normalize_timezone_at_time(None)
+        )
+
+        tz = timezone("Etc/GMT-2")
+        local_aware_dt = tz.localize(datetime(2010, 1, 1, 2, 0, 0))
+        self.assertEqual(
+            utc_timestamp, self.geocoder._normalize_timezone_at_time(local_aware_dt)
+        )
+
     def test_timezone_integer(self):
         """
         GoogleV3.timezone returns pytz object from epoch integer
         """
-        self.timezone_run(
-            {"location": self.new_york_point, "at_time": 0},
-            self.america_new_york,
-        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self.timezone_run(
+                {"location": self.new_york_point, "at_time": 0},
+                self.america_new_york,
+            )
+            assert len(w) > 0, "at_time as number should issue a warning"
 
     def test_timezone_no_date(self):
         """

--- a/test/test_timezone.py
+++ b/test/test_timezone.py
@@ -1,0 +1,66 @@
+import pickle
+import unittest
+
+import pytz
+import pytz.tzinfo
+
+from geopy.compat import u
+from geopy.timezone import Timezone, from_timezone_name
+
+
+class TimezoneTestCase(unittest.TestCase):
+
+    timezone_name = u("Europe/Moscow")
+
+    def test_create_from_timezone_name(self):
+        raw = dict(foo="bar")
+        tz = from_timezone_name(self.timezone_name, raw)
+
+        self.assertEqual(tz.raw['foo'], 'bar')
+        self.assertIsInstance(tz.pytz_timezone, pytz.tzinfo.BaseTzInfo)
+
+    def test_create_from_pytz_timezone(self):
+        pytz_timezone = pytz.timezone(self.timezone_name)
+        tz = Timezone(pytz_timezone)
+        self.assertIs(tz.pytz_timezone, pytz_timezone)
+
+    def test_string(self):
+        raw = dict(foo="bar")
+        tz = from_timezone_name(self.timezone_name, raw)
+        self.assertEqual(str(tz), self.timezone_name)
+
+    def test_repr(self):
+        raw = dict(foo="bar")
+        pytz_timezone = pytz.timezone(self.timezone_name)
+        tz = Timezone(pytz_timezone, raw)
+        self.assertEqual(repr(tz), "Timezone(%s)" % repr(pytz_timezone))
+
+    def test_eq(self):
+        tz = pytz.timezone("Europe/Paris")
+        raw1 = dict(a=1)
+        raw2 = dict(a=1)
+        self.assertEqual(Timezone(tz, raw1), Timezone(tz, raw2))
+
+    def test_ne(self):
+        tz1 = pytz.timezone("Europe/Paris")
+        tz2 = pytz.timezone("Europe/Prague")
+        raw = {}
+        self.assertNotEqual(Timezone(tz1, raw), Timezone(tz2, raw))
+
+    def test_picklable(self):
+        raw = dict(foo="bar")
+        tz = from_timezone_name(self.timezone_name, raw)
+        # https://docs.python.org/2/library/pickle.html#data-stream-format
+        for protocol in (0, 1, 2, -1):
+            pickled = pickle.dumps(tz, protocol=protocol)
+            tz_unp = pickle.loads(pickled)
+            self.assertEqual(tz, tz_unp)
+
+    def test_with_unpicklable_raw(self):
+        some_class = type('some_class', (object,), {})
+        raw_unpicklable = dict(missing=some_class())
+        del some_class
+        tz_unpicklable = from_timezone_name(self.timezone_name, raw_unpicklable)
+        for protocol in (0, 1, 2, -1):
+            with self.assertRaises((AttributeError, pickle.PicklingError)):
+                pickle.dumps(tz_unpicklable, protocol=protocol)


### PR DESCRIPTION
Currently only GoogleV3 implements a query returning a timezone. It returns pytz.timezone directly, and the raw geocoder response is not accessible. This PR introduces a `geopy.Location`-like wrapper for pytz.timezone -- `geopy.Timezone`.

For a smooth transition I decided to introduce a new `GoogleV3.reverse_timezone` method, which is similar to `GoogleV3.timezone` except that it returns `geopy.Timezone` object. I don't really like the `reverse_timezone` method name, but I couldn't come up with a better idea of smooth transition from
pytz.timezone as return type to geopy.Timezone.

This feature came out from #327.