### PR TITLE
Fix GeoNames reverse_timezone error handling

### DIFF
--- a/geopy/timezone.py
+++ b/geopy/timezone.py
@@ -8,6 +8,11 @@ except ImportError:
     pytz_available = False
 
 
+__all__ = (
+    "Timezone",
+)
+
+
 def ensure_pytz_is_installed():
     if not pytz_available:
         raise ImportError(
@@ -30,6 +35,12 @@ def from_timezone_name(timezone_name, raw=None):
             "geopy could not find a timezone in this response: %s" %
             raw
         )
+    return Timezone(pytz_timezone, raw)
+
+
+def from_fixed_gmt_offset(gmt_offset_hours, raw=None):
+    ensure_pytz_is_installed()
+    pytz_timezone = pytz.FixedOffset(gmt_offset_hours * 60)
     return Timezone(pytz_timezone, raw)
 
 

--- a/test/geocoders/geonames.py
+++ b/test/geocoders/geonames.py
@@ -35,7 +35,10 @@ class GeoNamesTestCase(GeocoderTestBase):
 
     def reverse_timezone_run(self, payload, expected):
         timezone = self._make_request(self.geocoder.reverse_timezone, **payload)
-        self.assertEqual(timezone.pytz_timezone, expected)
+        if expected is None:
+            self.assertIsNone(timezone)
+        else:
+            self.assertEqual(timezone.pytz_timezone, expected)
         return timezone
 
     def test_unicode_name(self):
@@ -167,6 +170,19 @@ class GeoNamesTestCase(GeocoderTestBase):
         )
         self.assertEqual(timezone.raw['countryCode'], 'US')
 
+    def test_reverse_timezone_unknown(self):
+        self.reverse_timezone_run(
+            # Geonames doesn't return `timezoneId` for Antarctica,
+            # but it provides GMT offset which can be used
+            # to create a FixedOffset pytz timezone.
+            {"query": "89.0, 1.0"},
+            pytz.UTC,
+        )
+        self.reverse_timezone_run(
+            {"query": "89.0, 80.0"},
+            pytz.FixedOffset(5 * 60),
+        )
+
 
 class GeoNamesInvalidAccountTestCase(GeocoderTestBase):
 
@@ -176,7 +192,10 @@ class GeoNamesInvalidAccountTestCase(GeocoderTestBase):
 
     def reverse_timezone_run(self, payload, expected):
         timezone = self._make_request(self.geocoder.reverse_timezone, **payload)
-        self.assertEqual(timezone.pytz_timezone, expected)
+        if expected is None:
+            self.assertIsNone(timezone)
+        else:
+            self.assertEqual(timezone.pytz_timezone, expected)
         return timezone
 
     def test_geocode(self):


### PR DESCRIPTION
This PR improves error handling for reverse_timezone methods of GoogleV3 and GeoNames.

Specifically:
1. GoogleV3's reverse_timezone now returns `None` instead of raising KeyError for uncovered points (e.g. Antarctica);
2. GeoNames's reverse_timezone now uses `pytz.FixedOffset` timezone for uncovered points (mentioned in the updated docs);
3. GeoNames's reverse_timezone didn't perform error checking (this is the main cause of #338).

Closes #338 