### PR TITLE
Don't warn in GoogleV3 when using premier

### DIFF
--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -103,7 +103,11 @@ class GoogleV3(Geocoder):
         if secret_key and not client_id:
             raise ConfigurationError('Must provide client_id with secret_key.')
 
-        if not api_key:
+        self.premier = bool(client_id and secret_key)
+        self.client_id = client_id
+        self.secret_key = secret_key
+
+        if not self.premier and not api_key:
             warnings.warn(
                 'Since July 2018 Google requires each request to have an API key. '
                 'Pass a valid `api_key` to GoogleV3 geocoder to hide this warning. '
@@ -115,9 +119,6 @@ class GoogleV3(Geocoder):
         self.api_key = api_key
         self.domain = domain.strip('/')
 
-        self.premier = bool(client_id and secret_key)
-        self.client_id = client_id
-        self.secret_key = secret_key
         self.channel = channel
 
         self.api = '%s://%s%s' % (self.scheme, self.domain, self.api_path)

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -57,6 +57,22 @@ class GoogleV3TestCase(GeocoderTestBase):
         with self.assertRaises(exc.ConfigurationError):
             GoogleV3(api_key='mock', secret_key='a')
 
+    def test_warning_with_no_api_key(self):
+        """
+        GoogleV3 warns if no API key is present
+        """
+        with warnings.catch_warnings(record=True) as w:
+            GoogleV3()
+        self.assertEqual(len(w), 1)
+
+    def test_no_warning_with_no_api_key_but_using_premier(self):
+        """
+        GoogleV3 does not warn about the API key if using premier
+        """
+        with warnings.catch_warnings(record=True) as w:
+            GoogleV3(client_id='client_id', secret_key='secret_key')
+        self.assertEqual(len(w), 0)
+
     def test_check_status(self):
         """
         GoogleV3 raises correctly on Google-specific API status flags


### PR DESCRIPTION
We're in the process of upgrading to the latest version of geopy and noticed we are getting warnings about the `api_key` when using the geocoder.  This PR removes the warning when the `client_id` and `secret_key` are passed in.