### PR TITLE
Make all `country`-params accept a Python list of them when supported

### DIFF
--- a/geopy/geocoders/geolake.py
+++ b/geopy/geocoders/geolake.py
@@ -1,4 +1,4 @@
-from geopy.compat import urlencode
+from geopy.compat import string_compare, urlencode
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
 from geopy.location import Location
 from geopy.util import logger
@@ -100,11 +100,14 @@ class Geolake(Geocoder):
             are one of: `country`, `state`, `city`, `zipcode`, `street`, `address`,
             `houseNumber` or `subNumber`.
 
-         :param str country_codes: Provides the geocoder with a list of country codes
-            that the query may reside in. This value will limit the geocoder to the
-            supplied countries. Te country code is a 2 character code as defined by
-            the ISO-3166-1 alpha-2 standard.
+        :param country_codes: Provides the geocoder with a list
+            of country codes that the query may reside in. This value will
+            limit the geocoder to the supplied countries. The country code
+            is a 2 character code as defined by the ISO-3166-1 alpha-2
+            standard (e.g. ``FR``). Multiple countries can be specified with
+            a Python list.
 
+        :type country_codes: str or list
 
         :param bool exactly_one: Return one result or a list of one result.
 
@@ -132,10 +135,11 @@ class Geolake(Geocoder):
                 'q': self.format_string % query,
             }
 
-        if country_codes is None:
+        if not country_codes:
             country_codes = []
-
-        if len(country_codes):
+        if isinstance(country_codes, string_compare):
+            country_codes = [country_codes]
+        if country_codes:
             params['countryCodes'] = ",".join(country_codes)
 
         url = "?".join((self.api, urlencode(params)))

--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -1,4 +1,4 @@
-from geopy.compat import quote, urlencode
+from geopy.compat import quote, string_compare, urlencode
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
 from geopy.location import Location
 from geopy.point import Point
@@ -111,8 +111,11 @@ class MapBox(Geocoder):
         :type proximity: :class:`geopy.point.Point`, list or tuple of ``(latitude,
             longitude)``, or string as ``"%(latitude)s, %(longitude)s"``.
 
-        :param string country: Country to filter result in form of
-            ISO 3166-1 alpha-2 country code.
+        :param country: Country to filter result in form of
+            ISO 3166-1 alpha-2 country code (e.g. ``FR``).
+            Might be a Python list of strings.
+
+        :type country: str or list
 
         :param bbox: The bounding box of the viewport within which
             to bias geocode results more prominently.
@@ -131,8 +134,12 @@ class MapBox(Geocoder):
             params['bbox'] = self._format_bounding_box(
                 bbox, "%(lon1)s,%(lat1)s,%(lon2)s,%(lat2)s")
 
+        if not country:
+            country = []
+        if isinstance(country, string_compare):
+            country = [country]
         if country:
-            params['country'] = country
+            params['country'] = ",".join(country)
 
         if proximity:
             p = Point(proximity)

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -113,9 +113,12 @@ class OpenCage(Geocoder):
                 This format is now deprecated in favor of a list/tuple
                 of a pair of geopy Points and will be removed in geopy 2.0.
 
-        :param str country: Restricts the results to the specified country or countries.
-            The country code is a 2 character code as defined by the ISO 3166-1 Alpha 2
-            standard.
+        :param country: Restricts the results to the specified
+            country or countries. The country code is a 2 character code as
+            defined by the ISO 3166-1 Alpha 2 standard (e.g. ``fr``).
+            Might be a Python list of strings.
+
+        :type country: str or list
 
         :param bool exactly_one: Return one result or a list of results, if
             available.
@@ -150,8 +153,13 @@ class OpenCage(Geocoder):
                 bounds, "%(lon1)s,%(lat1)s,%(lon2)s,%(lat2)s")
         if language:
             params['language'] = language
+
+        if not country:
+            country = []
+        if isinstance(country, string_compare):
+            country = [country]
         if country:
-            params['countrycode'] = country
+            params['countrycode'] = ",".join(country)
 
         url = "?".join((self.api, urlencode(params)))
 

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -55,7 +55,9 @@ class OpenMapQuest(Nominatim):
 
             .. versionadded:: 1.17.0
 
-        :param str country_bias: Bias results to this country.
+        :param country_bias: Limit search results to a specific country.
+            This param sets a default value for the `geocode`'s ``country_codes``.
+        :type country_bias: str or list
 
             .. versionadded:: 1.17.0
 

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -1,6 +1,6 @@
 import warnings
 
-from geopy.compat import urlencode
+from geopy.compat import string_compare, urlencode
 from geopy.exc import GeocoderQueryError
 from geopy.geocoders.base import _DEFAULT_USER_AGENT, DEFAULT_SENTINEL, Geocoder
 from geopy.location import Location
@@ -84,7 +84,9 @@ class Nominatim(Geocoder):
 
             .. versionadded:: 1.15.0
 
-        :param str country_bias: Bias results to this country.
+        :param country_bias: Limit search results to a specific country.
+            This param sets a default value for the `geocode`'s ``country_codes``.
+        :type country_bias: str or list
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -172,6 +174,7 @@ class Nominatim(Geocoder):
             language=False,
             geometry=None,
             extratags=False,
+            country_codes=None,
     ):
         """
         Return a location point by address.
@@ -226,6 +229,13 @@ class Nominatim(Geocoder):
 
             .. versionadded:: 1.17.0
 
+        :param country_codes: Limit search results
+            to a specific country (or a list of countries).
+            A country_code should be the ISO 3166-1alpha2 code,
+            e.g. ``gb`` for the United Kingdom, ``de`` for Germany, etc.
+
+        :type country_codes: str or list
+
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
 
@@ -274,8 +284,14 @@ class Nominatim(Geocoder):
         if self.bounded:
             params['bounded'] = 1
 
-        if self.country_bias:
-            params['countrycodes'] = self.country_bias
+        if country_codes is None:
+            country_codes = self.country_bias
+        if not country_codes:
+            country_codes = []
+        if isinstance(country_codes, string_compare):
+            country_codes = [country_codes]
+        if country_codes:
+            params['countrycodes'] = ",".join(country_codes)
 
         if addressdetails:
             params['addressdetails'] = 1

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -50,7 +50,9 @@ class PickPoint(Nominatim):
                 This format is now deprecated in favor of a list/tuple
                 of a pair of geopy Points and will be removed in geopy 2.0.
 
-        :param string country_bias: Bias results to this country.
+        :param country_bias: Limit search results to a specific country.
+            This param sets a default value for the `geocode`'s ``country_codes``.
+        :type country_bias: str or list
 
         :param bool bounded: Restrict the results to only items contained
             within the bounding view_box.

--- a/test/geocoders/geolake.py
+++ b/test/geocoders/geolake.py
@@ -29,27 +29,24 @@ class GeolakeTestCase(GeocoderTestBase):
         cls.delta_exact = 0.2
 
     def test_geocode(self):
-        """
-        Geolake.geocode
-        """
         self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890344, "longitude": -87.623234, "address": "Chicago, US"},
         )
 
-    def test_geocode_country_codes(self):
-        """
-        Geolake.geocode
-        """
+    def test_geocode_country_codes_str(self):
         self.geocode_run(
-            {"query": "Toronto", "country_codes": ["US"]},
+            {"query": "Toronto", "country_codes": "US"},
+            {"latitude": 40.46, "longitude": -80.6, "address": "Toronto, US"},
+        )
+
+    def test_geocode_country_codes_list(self):
+        self.geocode_run(
+            {"query": "Toronto", "country_codes": ["CN", "US"]},
             {"latitude": 40.46, "longitude": -80.6, "address": "Toronto, US"},
         )
 
     def test_geocode_structured(self):
-        """
-        Geolake.geocode
-        """
         query = {
             "street": "north michigan ave",
             "houseNumber": "435",

--- a/test/geocoders/geonames.py
+++ b/test/geocoders/geonames.py
@@ -183,6 +183,24 @@ class GeoNamesTestCase(GeocoderTestBase):
             pytz.FixedOffset(5 * 60),
         )
 
+    def test_country_str(self):
+        self.geocode_run(
+            {"query": "kazan", "country": "TR"},
+            {"latitude": 40.2317, "longitude": 32.6839},
+        )
+
+    def test_country_list(self):
+        self.geocode_run(
+            {"query": "kazan", "country": ["CN", "TR", "JP"]},
+            {"latitude": 40.2317, "longitude": 32.6839},
+        )
+
+    def test_country_bias(self):
+        self.geocode_run(
+            {"query": "kazan", "country_bias": "TR"},
+            {"latitude": 40.2317, "longitude": 32.6839},
+        )
+
 
 class GeoNamesInvalidAccountTestCase(GeocoderTestBase):
 

--- a/test/geocoders/mapbox.py
+++ b/test/geocoders/mapbox.py
@@ -69,8 +69,14 @@ class MapBoxTestCase(GeocoderTestBase):
             {"latitude": 45.270208, "longitude": -66.050289, "delta": 0.1},
         )
 
-    def test_geocode_country(self):
+    def test_geocode_country_str(self):
         self.geocode_run(
             {"query": "kazan", "country": "TR"},
+            {"latitude": 40.2317, "longitude": 32.6839},
+        )
+
+    def test_geocode_country_list(self):
+        self.geocode_run(
+            {"query": "kazan", "country": ["CN", "TR"]},
             {"latitude": 40.2317, "longitude": 32.6839},
         )

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -291,6 +291,20 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         # in response a success.
         self.assertTrue(location.raw['extratags']['wikidata'])
 
+    def test_country_codes_str(self):
+        self.geocode_run(
+            {"query": "kazan",
+             "country_codes": 'tr'},
+            {"latitude": 40.2317, "longitude": 32.6839},
+        )
+
+    def test_country_codes_list(self):
+        self.geocode_run(
+            {"query": "kazan",
+             "country_codes": ['cn', 'tr']},
+            {"latitude": 40.2317, "longitude": 32.6839},
+        )
+
 
 class NominatimTestCase(BaseNominatimTestCase, GeocoderTestBase):
 

--- a/test/geocoders/opencage.py
+++ b/test/geocoders/opencage.py
@@ -72,9 +72,16 @@ class OpenCageTestCase(GeocoderTestBase):
             )
             self.assertEqual(1, len(w))
 
-    def test_country(self):
+    def test_country_str(self):
         self.geocode_run(
-            {"query": "moscow",  # Idaho USA
-             "country": 'us'},
-            {"latitude": 46.7323875, "longitude": -117.0001651}
+            {"query": "kazan",
+             "country": 'tr'},
+            {"latitude": 40.2317, "longitude": 32.6839},
+        )
+
+    def test_country_list(self):
+        self.geocode_run(
+            {"query": "kazan",
+             "country": ['cn', 'tr']},
+            {"latitude": 40.2317, "longitude": 32.6839},
         )


### PR DESCRIPTION
Closes #343

All params accepting multiple countries have been made to accept a Python list of them.