### PR TITLE
Deprecate `geocode`-specific args in `__init__`

### DIFF
--- a/geopy/geocoders/geocodeearth.py
+++ b/geopy/geocoders/geocodeearth.py
@@ -41,7 +41,15 @@ class GeocodeEarth(Pelias):
                 This format is now deprecated in favor of a list/tuple
                 of a pair of geopy Points and will be removed in geopy 2.0.
 
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `boundary_rect` instead.
+
         :param str country_bias: Bias results to this country (ISO alpha-3).
+
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `country_bias` instead.
 
         :param str domain: Specify a custom domain for Pelias API.
 

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -48,7 +48,12 @@ class GeoNames(Geocoder):
             scheme='http',
     ):
         """
-        :param str country_bias:
+        :param str country_bias: Records from the country_bias are listed first.
+            Two letter country code ISO-3166.
+
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `country_bias` instead.
 
         :param str username: GeoNames username, required. Sign up here:
             http://www.geonames.org/login
@@ -100,6 +105,15 @@ class GeoNames(Geocoder):
                 'http://www.geonames.org/login'
             )
         self.username = username
+        if country_bias is not None:
+            warnings.warn(
+                '`country_bias` argument of the %(cls)s.__init__ '
+                'is deprecated and will be removed in geopy 2.0. Use '
+                '%(cls)s.geocode(country_bias=%(value)r) instead.'
+                % dict(cls=type(self).__name__, value=country_bias),
+                DeprecationWarning,
+                stacklevel=2
+            )
         self.country_bias = country_bias
         domain = 'api.geonames.org'
         self.api = (

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -23,7 +23,7 @@ class OpenMapQuest(Nominatim):
             api_key=None,
             format_string=None,
             view_box=None,
-            bounded=False,
+            bounded=None,
             country_bias=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -50,16 +50,28 @@ class OpenMapQuest(Nominatim):
 
             .. versionadded:: 1.17.0
 
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `viewbox` instead.
+
         :param bool bounded: Restrict the results to only items contained
             within the bounding view_box.
 
             .. versionadded:: 1.17.0
 
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `bounded` instead.
+
+        :type country_bias: str or list
         :param country_bias: Limit search results to a specific country.
             This param sets a default value for the `geocode`'s ``country_codes``.
-        :type country_bias: str or list
 
             .. versionadded:: 1.17.0
+
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `country_codes` instead.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -59,7 +59,15 @@ class Pelias(Geocoder):
                 This format is now deprecated in favor of a list/tuple
                 of a pair of geopy Points and will be removed in geopy 2.0.
 
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `boundary_rect` instead.
+
         :param str country_bias: Bias results to this country (ISO alpha-3).
+
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `country_bias` instead.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -86,7 +94,25 @@ class Pelias(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
         )
+        if country_bias is not None:
+            warnings.warn(
+                '`country_bias` argument of the %(cls)s.__init__ '
+                'is deprecated and will be removed in geopy 2.0. Use '
+                '%(cls)s.geocode(country_bias=%(value)r) instead.'
+                % dict(cls=type(self).__name__, value=country_bias),
+                DeprecationWarning,
+                stacklevel=2
+            )
         self.country_bias = country_bias
+        if boundary_rect is not None:
+            warnings.warn(
+                '`boundary_rect` argument of the %(cls)s.__init__ '
+                'is deprecated and will be removed in geopy 2.0. Use '
+                '%(cls)s.geocode(boundary_rect=%(value)r) instead.'
+                % dict(cls=type(self).__name__, value=boundary_rect),
+                DeprecationWarning,
+                stacklevel=2
+            )
         self.boundary_rect = boundary_rect
         self.api_key = api_key
         self.domain = domain.strip('/')
@@ -103,6 +129,8 @@ class Pelias(Geocoder):
             query,
             exactly_one=True,
             timeout=DEFAULT_SENTINEL,
+            boundary_rect=None,
+            country_bias=None,
     ):
         """
         Return a location point by address.
@@ -118,6 +146,17 @@ class Pelias(Geocoder):
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
 
+        :type boundary_rect: list or tuple of 2 items of :class:`geopy.point.Point`
+            or ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
+        :param boundary_rect: Coordinates to restrict search within.
+            Example: ``[Point(22, 180), Point(-22, -180)]``.
+
+            .. versionadded:: 1.19.0
+
+        :param str country_bias: Bias results to this country (ISO alpha-3).
+
+            .. versionadded:: 1.19.0
+
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
@@ -128,8 +167,9 @@ class Pelias(Geocoder):
                 'api_key': self.api_key
             })
 
-        if self.boundary_rect:
+        if boundary_rect is None:
             boundary_rect = self.boundary_rect
+        if boundary_rect:
             if len(boundary_rect) == 4:
                 warnings.warn(
                     '%s `boundary_rect` format of '
@@ -149,8 +189,10 @@ class Pelias(Geocoder):
             params['boundary.rect.max_lon'] = lon2
             params['boundary.rect.max_lat'] = lat2
 
-        if self.country_bias:
-            params['boundary.country'] = self.country_bias
+        if country_bias is None:
+            country_bias = self.country_bias
+        if country_bias:
+            params['boundary.country'] = country_bias
 
         url = "?".join((self.geocode_api, urlencode(params)))
         logger.debug("%s.geocode_api: %s", self.__class__.__name__, url)

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -22,7 +22,7 @@ class PickPoint(Nominatim):
             api_key,
             format_string=None,
             view_box=None,
-            bounded=False,
+            bounded=None,
             country_bias=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -50,12 +50,24 @@ class PickPoint(Nominatim):
                 This format is now deprecated in favor of a list/tuple
                 of a pair of geopy Points and will be removed in geopy 2.0.
 
-        :param country_bias: Limit search results to a specific country.
-            This param sets a default value for the `geocode`'s ``country_codes``.
-        :type country_bias: str or list
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `viewbox` instead.
 
         :param bool bounded: Restrict the results to only items contained
             within the bounding view_box.
+
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `bounded` instead.
+
+        :type country_bias: str or list
+        :param country_bias: Limit search results to a specific country.
+            This param sets a default value for the `geocode`'s ``country_codes``.
+
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `country_codes` instead.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -1,3 +1,5 @@
+import warnings
+
 from geopy.compat import urlencode
 from geopy.exc import ConfigurationError, GeocoderQuotaExceeded
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -20,7 +22,7 @@ class LiveAddress(Geocoder):
             self,
             auth_id,
             auth_token,
-            candidates=1,
+            candidates=None,
             scheme='https',
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -38,7 +40,11 @@ class LiveAddress(Geocoder):
 
         :param int candidates: An integer between 1 and 10 indicating the max
             number of candidate addresses to return if a valid address
-            could be found.
+            could be found. Defaults to `1`.
+
+            .. deprecated:: 1.19.0
+                This argument will be removed in geopy 2.0.
+                Use `geocode`'s `candidates` instead.
 
         :param str scheme: Must be ``https``.
 
@@ -87,14 +93,30 @@ class LiveAddress(Geocoder):
             raise ConfigurationError("LiveAddress now requires `https`.")
         self.auth_id = auth_id
         self.auth_token = auth_token
+
         if candidates:
             if not (1 <= candidates <= 10):
                 raise ValueError('candidates must be between 1 and 10')
+        if candidates is not None:
+            warnings.warn(
+                '`candidates` argument of the %(cls)s.__init__ '
+                'is deprecated and will be removed in geopy 2.0. Use '
+                '%(cls)s.geocode(candidates=%(value)r) instead.'
+                % dict(cls=type(self).__name__, value=candidates),
+                DeprecationWarning,
+                stacklevel=2
+            )
         self.candidates = candidates
         domain = 'api.smartystreets.com'
         self.api = '%s://%s%s' % (self.scheme, domain, self.geocode_path)
 
-    def geocode(self, query, exactly_one=True, timeout=DEFAULT_SENTINEL):
+    def geocode(
+            self,
+            query,
+            exactly_one=True,
+            timeout=DEFAULT_SENTINEL,
+            candidates=None,  # TODO: change default value to `1` in geopy 2.0
+    ):
         """
         Return a location point by address.
 
@@ -108,10 +130,34 @@ class LiveAddress(Geocoder):
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
 
+        :param int candidates: An integer between 1 and 10 indicating the max
+            number of candidate addresses to return if a valid address
+            could be found. Defaults to `1`.
+
+            .. versionadded:: 1.19.0
+
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
-        url = self._compose_url(self.format_string % query)
+
+        if candidates is None:
+            candidates = self.candidates
+
+        if candidates is None:
+            candidates = 1  # TODO: move to default args in geopy 2.0.
+
+        if candidates:
+            if not (1 <= candidates <= 10):
+                raise ValueError('candidates must be between 1 and 10')
+
+        query = {
+            'auth-id': self.auth_id,
+            'auth-token': self.auth_token,
+            'street': self.format_string % query,
+            'candidates': candidates,
+        }
+        url = '{url}?{query}'.format(url=self.api, query=urlencode(query))
+
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
         return self._parse_json(self._call_geocoder(url, timeout=timeout),
                                 exactly_one)
@@ -122,18 +168,6 @@ class LiveAddress(Geocoder):
         """
         if "no active subscriptions found" in message.lower():
             raise GeocoderQuotaExceeded(message)
-
-    def _compose_url(self, location):
-        """
-        Generate API URL.
-        """
-        query = {
-            'auth-id': self.auth_id,
-            'auth-token': self.auth_token,
-            'street': location,
-            'candidates': self.candidates
-        }
-        return '{url}?{query}'.format(url=self.api, query=urlencode(query))
 
     def _parse_json(self, response, exactly_one=True):
         """

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -79,28 +79,6 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         )
         self.assertIn("New York", location.address)
 
-    def test_country_bias(self):
-        self.geocoder = self.make_geocoder(country_bias='RU')
-        self.geocode_run(
-            {"query": "moscow"},
-            {"latitude": 55.7507178, "longitude": 37.6176606,
-             "delta": 0.3},
-        )
-
-        self.geocoder = self.make_geocoder(country_bias='US')
-        location = self.geocode_run(
-            {"query": "moscow"},
-            # There are two possible results:
-            # Moscow Idaho: 46.7323875,-117.0001651
-            # Moscow Penn: 41.3367497,-75.5185191
-            {},
-        )
-        # We don't care which Moscow is returned, unless it's
-        # the Russian one. We can sort this out by asserting
-        # the longitudes. The Russian Moscow has positive longitudes.
-        self.assertLess(-119, location.longitude)
-        self.assertLess(location.longitude, -70)
-
     def test_structured_query(self):
         self.geocode_run(
             {"query": {"country": "us", "city": "moscow",
@@ -109,10 +87,9 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         )
 
     def test_city_district_with_dict_query(self):
-        self.geocoder = self.make_geocoder(country_bias='DE')
         query = {'postalcode': 10117}
         result = self.geocode_run(
-            {"query": query, "addressdetails": True},
+            {"query": query, "addressdetails": True, "country_codes": "DE"},
             {},
         )
         try:
@@ -219,7 +196,7 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         )
         self.assertNotIn('address', res.raw)
 
-    def test_view_box(self):
+    def test_viewbox(self):
         res = self.geocode_run(
             {"query": "Maple Street"},
             {},
@@ -227,16 +204,17 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         self.assertFalse(50 <= res.latitude <= 52)
         self.assertFalse(-0.15 <= res.longitude <= -0.11)
 
-        for view_box in [((52, -0.11), (50, -0.15)),
-                         [Point(52, -0.11), Point(50, -0.15)],
-                         (("52", "-0.11"), ("50", "-0.15"))]:
-            self.geocoder = self.make_geocoder(view_box=view_box)
+        for viewbox in [
+            ((52, -0.11), (50, -0.15)),
+            [Point(52, -0.11), Point(50, -0.15)],
+            (("52", "-0.11"), ("50", "-0.15"))
+        ]:
             self.geocode_run(
-                {"query": "Maple Street"},
+                {"query": "Maple Street", "viewbox": viewbox},
                 {"latitude": 51.5223513, "longitude": -0.1382104}
             )
 
-    def test_deprecated_view_box(self):
+    def test_deprecated_viewbox(self):
         res = self.geocode_run(
             {"query": "Maple Street"},
             {},
@@ -244,13 +222,14 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         self.assertFalse(50 <= res.latitude <= 52)
         self.assertFalse(-0.15 <= res.longitude <= -0.11)
 
-        for view_box in [(-0.11, 52, -0.15, 50),
-                         ("-0.11", "52", "-0.15", "50")]:
+        for viewbox in [
+            (-0.11, 52, -0.15, 50),
+            ("-0.11", "52", "-0.15", "50")
+        ]:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
-                self.geocoder = self.make_geocoder(view_box=view_box)
                 self.geocode_run(
-                    {"query": "Maple Street"},
+                    {"query": "Maple Street", "viewbox": viewbox},
                     {"latitude": 51.5223513, "longitude": -0.1382104}
                 )
                 self.assertEqual(1, len(w))
@@ -260,15 +239,13 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         query = u('\u0441\u0442\u0440\u043e\u0438\u0442\u0435\u043b\u044c '
                   '\u0442\u043e\u043c\u0441\u043a')
 
-        self.geocoder = self.make_geocoder(view_box=bb)
         self.geocode_run(
-            {"query": query},
+            {"query": query, "viewbox": bb},
             {"latitude": 56.4129459, "longitude": 84.847831069814},
         )
 
-        self.geocoder = self.make_geocoder(view_box=bb, bounded=True)
         self.geocode_run(
-            {"query": query},
+            {"query": query, "viewbox": bb, "bounded": True},
             {"latitude": 56.4803224, "longitude": 85.0060457653324},
         )
 
@@ -290,6 +267,26 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         # So let's simply consider just having the `wikidata` key
         # in response a success.
         self.assertTrue(location.raw['extratags']['wikidata'])
+
+    def test_country_codes_moscow(self):
+        self.geocode_run(
+            {"query": "moscow", "country_codes": "RU"},
+            {"latitude": 55.7507178, "longitude": 37.6176606,
+             "delta": 0.3},
+        )
+
+        location = self.geocode_run(
+            {"query": "moscow", "country_codes": "US"},
+            # There are two possible results:
+            # Moscow Idaho: 46.7323875,-117.0001651
+            # Moscow Penn: 41.3367497,-75.5185191
+            {},
+        )
+        # We don't care which Moscow is returned, unless it's
+        # the Russian one. We can sort this out by asserting
+        # the longitudes. The Russian Moscow has positive longitudes.
+        self.assertLess(-119, location.longitude)
+        self.assertLess(location.longitude, -70)
 
     def test_country_codes_str(self):
         self.geocode_run(

--- a/test/geocoders/pelias.py
+++ b/test/geocoders/pelias.py
@@ -47,20 +47,18 @@ class BasePeliasTestCase(with_metaclass(ABCMeta, object)):
         )
 
     def test_boundary_rect(self):
-        self.geocoder = self.make_geocoder(
-            boundary_rect=[[50.1, -130.1], [44.1, -100.9]])
         self.geocode_run(
-            {"query": "moscow"},  # Idaho USA
+            {"query": "moscow",  # Idaho USA
+             "boundary_rect": [[50.1, -130.1], [44.1, -100.9]]},
             {"latitude": 46.7323875, "longitude": -117.0001651},
         )
 
     def test_boundary_rect_deprecated(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            self.geocoder = self.make_geocoder(
-                boundary_rect=[-130.1, 44.1, -100.9, 50.1])
             self.geocode_run(
-                {"query": "moscow"},  # Idaho USA
+                {"query": "moscow",  # Idaho USA
+                 "boundary_rect": [-130.1, 44.1, -100.9, 50.1]},
                 {"latitude": 46.7323875, "longitude": -117.0001651},
             )
             self.assertEqual(1, len(w))


### PR DESCRIPTION
`__init__` args which are specific to the `geocode` methods have been deprecated in this PR.

The motivation is:
1. They raise questions like "do they affect other methods like `reverse`?"
2. They tend to not have a corresponding param in the `geocode` method, which forces to create new instances of geocoder for queries which need different values for such args.
3. Most of the `geocode` args still cannot be specified in the `__init__` methods.
4. They clutter the `__init__` method args which naturally should specify only the credentials and connectivity settings (well, except for the `format_string`).

As an alternative I'd suggest to use `functools.partial`:

```python
# Change this:
#   geocoder = GeocodeEarth("my_api_key", country_bias="US")
#   location = geocoder.geocode("new york")
# to this:

from functools import partial

geocoder = GeocodeEarth("my_api_key")
geocode = partial(geocoder.geocode, country_bias="US")
location = geocode("new york")
```
