### PR TITLE
Fixed MapBox raw

### DIFF
--- a/docs/changelog_1xx.rst
+++ b/docs/changelog_1xx.rst
@@ -4,7 +4,7 @@ Changelog
 =========
 1.19.0
 ------
-2019-03-TBD
+2019-03-26
 
 *   ADDED: `GoogleV3`: `place_id` arg has been added to
     the `geocode` method. Contributed by Mesut Öncel. (#348)

--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -75,10 +75,9 @@ class MapBox(Geocoder):
 
         def parse_feature(feature):
             location = feature['place_name']
-            place = feature['text']
             longitude = feature['geometry']['coordinates'][0]
             latitude = feature['geometry']['coordinates'][1]
-            return Location(location, (latitude, longitude), place)
+            return Location(location, (latitude, longitude), feature)
         if exactly_one:
             return parse_feature(features[0])
         else:

--- a/geopy/util.py
+++ b/geopy/util.py
@@ -17,7 +17,7 @@ except ImportError:  # pragma: no cover
     pass
 
 
-__version__ = "1.18.1"
+__version__ = "1.19.0"
 
 logger = logging.getLogger('geopy')
 


### PR DESCRIPTION
Provide detailed Mapbox place API response to use as a Location `raw` attribute.

Closes #353 