### PR TITLE
Fixing the 'exactly_one' parameter usage in the mapbox geocoder

### DIFF
--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -155,7 +155,7 @@ class MapBox(Geocoder):
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
 
         return self._parse_json(
-            self._call_geocoder(url, timeout=timeout)
+            self._call_geocoder(url, timeout=timeout), exactly_one
         )
 
     def reverse(

--- a/test/geocoders/mapbox.py
+++ b/test/geocoders/mapbox.py
@@ -80,3 +80,7 @@ class MapBoxTestCase(GeocoderTestBase):
             {"query": "kazan", "country": ["CN", "TR"]},
             {"latitude": 40.2317, "longitude": 32.6839},
         )
+
+    def test_geocode_exactly_one_true(self):
+        list_result = self.geocode_run({"query": "New York", "exactly_one": False}, {})
+        self.assertTrue(isinstance(list_result, list))


### PR DESCRIPTION
The mapbox geocoder returned exactly one argument even when setting `exactly_one=False` when geocoding. The problem was that the `_parse_json` method never recieved the said argument and used its default value `exactly_one=True`.