### PR TITLE
Update link to TomTom Search API documentation

### DIFF
--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -10,7 +10,7 @@ class TomTom(Geocoder):
     """TomTom geocoder.
 
     Documentation at:
-        https://developer.tomtom.com/online-search/online-search-documentation
+        https://developer.tomtom.com/search-api/search-api-documentation
 
     .. versionadded:: 1.15.0
     """


### PR DESCRIPTION
There was a naming change. Online Search is now Search API.