### PR TITLE
Add featuretype parameter for Nominatim

### DIFF
--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -220,6 +220,7 @@ class Nominatim(Geocoder):
             country_codes=None,
             viewbox=None,
             bounded=None,  # TODO: change default value to `False` in geopy 2.0
+            featuretype=None,
     ):
         """
         Return a location point by address.
@@ -295,6 +296,9 @@ class Nominatim(Geocoder):
             within the bounding view_box. Defaults to `False`.
 
             .. versionadded:: 1.19.0
+
+        :param str featuretype: If present, restrict results to certain type of features.
+            Allowed values: `country`, `state`, `city`, `settlement`.
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
@@ -379,6 +383,9 @@ class Nominatim(Geocoder):
                     "Invalid geometry format. Must be one of: "
                     "wkt, svg, kml, geojson."
                 )
+
+        if featuretype:
+            params['featuretype'] = featuretype
 
         url = self._construct_url(self.api, params)
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -302,6 +302,31 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
             {"latitude": 40.2317, "longitude": 32.6839},
         )
 
+    def test_featuretype_param(self):
+        self.geocode_run(
+            {"query": "mexico",
+             "featuretype": 'country'},
+            {"latitude": 22.5000485, "longitude": -100.0000375},
+        )
+
+        self.geocode_run(
+            {"query": "mexico",
+             "featuretype": 'state'},
+            {"latitude": 19.4839446, "longitude": -99.6899716},
+        )
+
+        self.geocode_run(
+            {"query": "mexico",
+             "featuretype": 'city'},
+            {"latitude": 19.4326009, "longitude": -99.1333416},
+        )
+
+        self.geocode_run(
+            {"query": "georgia",
+             "featuretype": 'settlement'},
+            {"latitude": 32.3293809, "longitude": -83.1137366},
+        )
+
 
 class NominatimTestCase(BaseNominatimTestCase, GeocoderTestBase):
 


### PR DESCRIPTION
Hi,

This commit adds 'featuretype' parameter for Nominatim geocoder, this limit results to certain type, like city, instead of trying to match all possible matches.

Note this feature is not documented in public API doc of Nominatim. More info: https://help.openstreetmap.org/questions/31629/restricting-nominatim-search-results-to-a-certain-adminstrative-level/31654