### PR TITLE
add namedetails argument to Nominatim, simplify country_codes logic

### DIFF
--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -356,7 +356,9 @@ class Nominatim(Geocoder):
             params['bounded'] = 1
 
         if country_codes is None:
-            country_codes = self.country_bias or []
+            country_codes = self.country_bias
+        if not country_codes:
+            country_codes = []
         if isinstance(country_codes, string_compare):
             country_codes = [country_codes]
         if country_codes:

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -221,6 +221,7 @@ class Nominatim(Geocoder):
             viewbox=None,
             bounded=None,  # TODO: change default value to `False` in geopy 2.0
             featuretype=None,
+            namedetails=False,
     ):
         """
         Return a location point by address.
@@ -300,6 +301,10 @@ class Nominatim(Geocoder):
         :param str featuretype: If present, restrict results to certain type of features.
             Allowed values: `country`, `state`, `city`, `settlement`.
 
+        :param bool namedetails: If you want in *Location.raw* to include
+            namedetails, set it to True. This will be a list of alternative names,
+            including language variants, etc.
+
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
 
@@ -351,9 +356,7 @@ class Nominatim(Geocoder):
             params['bounded'] = 1
 
         if country_codes is None:
-            country_codes = self.country_bias
-        if not country_codes:
-            country_codes = []
+            country_codes = self.country_bias or []
         if isinstance(country_codes, string_compare):
             country_codes = [country_codes]
         if country_codes:
@@ -361,6 +364,9 @@ class Nominatim(Geocoder):
 
         if addressdetails:
             params['addressdetails'] = 1
+
+        if namedetails:
+            params['namedetails'] = 1
 
         if language:
             params['accept-language'] = language

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [flake8]
-max-complexity = 23
+max-complexity = 24
 max-line-length = 90
 exclude =
     .git,

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -342,7 +342,6 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         self.assertNotIn('namedetails', result.raw)
 
 
-
 class NominatimTestCase(BaseNominatimTestCase, GeocoderTestBase):
 
     @classmethod

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -327,6 +327,21 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
             {"latitude": 32.3293809, "longitude": -83.1137366},
         )
 
+    def test_namedetails(self):
+        query = "Kyoto, Japan"
+        result = self.geocode_run(
+            {"query": query, "namedetails": True},
+            {},
+        )
+        self.assertIn('namedetails', result.raw)
+
+        result = self.geocode_run(
+            {"query": query, "namedetails": False},
+            {},
+        )
+        self.assertNotIn('namedetails', result.raw)
+
+
 
 class NominatimTestCase(BaseNominatimTestCase, GeocoderTestBase):
 


### PR DESCRIPTION
Add namedetails argument to nominatim #367.

I needed to simplify the logic of the function because flake8 was giving error. 

```
$ flake8 geopy
geopy/geocoders/osm.py:210:5: C901 'Nominatim.geocode' is too complex (24) 
```

If you can think about another option to workaround this issue of complexity, please do let me know.