### PR TITLE
Travis: use xenial dist globally; sudo is not used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
-sudo: false
+dist: xenial
 
 python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
-  # 3.7 and 3.8 are defined separately in the jobs below.
-  # See: https://github.com/travis-ci/travis-ci/issues/9815
+  - "3.7"
+  - "3.8-dev"
   - "pypy"
   - "pypy3"
 
@@ -36,7 +36,7 @@ jobs:
   include:
     - stage: lint
       name: "Linting"
-      python: "3.6"
+      python: "3.7"
       before_script:
         - travis_retry pip install -e ".[dev-lint]"
       script:
@@ -44,7 +44,7 @@ jobs:
 
     - stage: rst
       name: "RST (README.rst + docs) syntax check"
-      python: "3.6"
+      python: "3.7"
       before_script:
         - travis_retry pip install -e ".[dev-docs]"
       script:
@@ -52,12 +52,3 @@ jobs:
 
     # The `test` stage using the `python` matrix above is included implicitly.
 
-    - stage: test
-      python: "3.7"
-      dist: xenial
-      sudo: required
-
-    - stage: test
-      python: "3.8-dev"
-      dist: xenial
-      sudo: required


### PR DESCRIPTION
This PR brings a few modern features of Travis CI:

* As of [April 2019](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment), `xenial` is the default build environment. But specify this at the top so that it is clear.
* The `sudo` keyword [is deprecated](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration#timeline---its-happening-fast) (and probably does nothing)
* Put the tests for 3.7 and 3.8-dev in the regular matrix
* Update lint and rst tests to use Python 3.7, which is current (for another month or two, at least)