### PR TITLE
Add language parameter to the Pelias geocoder

### DIFF
--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -203,7 +203,7 @@ class Pelias(Geocoder):
 
         if language:
             params["lang"] = language
-            
+
         url = "?".join((self.geocode_api, urlencode(params)))
         logger.debug("%s.geocode_api: %s", self.__class__.__name__, url)
         return self._parse_json(
@@ -253,7 +253,7 @@ class Pelias(Geocoder):
 
         if language:
             params['lang'] = language
-            
+
         if self.api_key:
             params.update({
                 'api_key': self.api_key

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -131,6 +131,7 @@ class Pelias(Geocoder):
             timeout=DEFAULT_SENTINEL,
             boundary_rect=None,
             country_bias=None,
+            language=False
     ):
         """
         Return a location point by address.
@@ -156,6 +157,12 @@ class Pelias(Geocoder):
         :param str country_bias: Bias results to this country (ISO alpha-3).
 
             .. versionadded:: 1.19.0
+
+        :param str language: Preferred language in which to return results.
+            Either uses standard
+            `RFC2616 <http://www.ietf.org/rfc/rfc2616.txt>`_
+            accept-language string or a simple comma-separated
+            list of language codes.
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
@@ -194,6 +201,9 @@ class Pelias(Geocoder):
         if country_bias:
             params['boundary.country'] = country_bias
 
+        if language:
+            params["lang"] = language
+            
         url = "?".join((self.geocode_api, urlencode(params)))
         logger.debug("%s.geocode_api: %s", self.__class__.__name__, url)
         return self._parse_json(
@@ -205,6 +215,7 @@ class Pelias(Geocoder):
             query,
             exactly_one=True,
             timeout=DEFAULT_SENTINEL,
+            language=False
     ):
         """
         Return an address by location point.
@@ -222,6 +233,12 @@ class Pelias(Geocoder):
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
 
+        :param str language: Preferred language in which to return results.
+            Either uses standard
+            `RFC2616 <http://www.ietf.org/rfc/rfc2616.txt>`_
+            accept-language string or a simple comma-separated
+            list of language codes.
+
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
@@ -234,6 +251,9 @@ class Pelias(Geocoder):
             'point.lon': lon,
         }
 
+        if language:
+            params['lang'] = language
+            
         if self.api_key:
             params.update({
                 'api_key': self.api_key

--- a/test/geocoders/pelias.py
+++ b/test/geocoders/pelias.py
@@ -4,12 +4,12 @@ from __future__ import unicode_literals
 import unittest
 import warnings
 from abc import ABCMeta, abstractmethod
+from test.geocoders.util import GeocoderTestBase, env
 
 from six import with_metaclass
 
 from geopy.geocoders import Pelias
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
 
 
 class BasePeliasTestCase(with_metaclass(ABCMeta, object)):
@@ -100,7 +100,7 @@ class BasePeliasTestCase(with_metaclass(ABCMeta, object)):
             "Austria"
         )
 
-        
+
 @unittest.skipUnless(
     bool(env.get('PELIAS_DOMAIN')),
     "No PELIAS_DOMAIN env variable set"

--- a/test/geocoders/pelias.py
+++ b/test/geocoders/pelias.py
@@ -4,12 +4,12 @@ from __future__ import unicode_literals
 import unittest
 import warnings
 from abc import ABCMeta, abstractmethod
-from test.geocoders.util import GeocoderTestBase, env
 
 from six import with_metaclass
 
 from geopy.geocoders import Pelias
 from geopy.point import Point
+from test.geocoders.util import GeocoderTestBase, env
 
 
 class BasePeliasTestCase(with_metaclass(ABCMeta, object)):

--- a/test/geocoders/pelias.py
+++ b/test/geocoders/pelias.py
@@ -63,13 +63,52 @@ class BasePeliasTestCase(with_metaclass(ABCMeta, object)):
             )
             self.assertEqual(1, len(w))
 
+    def test_geocode_language_parameter(self):
+        query = "Graben 7, Wien"
+        result_geocode = self.geocode_run(
+            {"query": query, "language": "de"}, {}
+        )
+        self.assertEqual(
+            result_geocode.raw['properties']['country'],
+            "Österreich"
+        )
+        result_geocode = self.geocode_run(
+            {"query": query, "language": "en"}, {}
+        )
+        self.assertEqual(
+            result_geocode.raw['properties']['country'],
+            "Austria"
+        )
 
+    def test_reverse_language_parameter(self):
+        query = "48.198674, 16.348388"
+        result_reverse_de = self.reverse_run(
+            {"query": query, "exactly_one": True, "language": "de"},
+            {},
+        )
+        self.assertEqual(
+            result_reverse_de.raw['properties']['country'],
+            "Österreich"
+        )
+
+        result_reverse_en = self.reverse_run(
+            {"query": query, "exactly_one": True, "language": "en"},
+            {},
+        )
+        self.assertTrue(
+            result_reverse_en.raw['properties']['country'],
+            "Austria"
+        )
+
+        
 @unittest.skipUnless(
     bool(env.get('PELIAS_DOMAIN')),
     "No PELIAS_DOMAIN env variable set"
 )
 class PeliasTestCase(BasePeliasTestCase, GeocoderTestBase):
 
+    @classmethod
     def make_geocoder(cls, **kwargs):
+        print(env)
         return Pelias(env.get('PELIAS_DOMAIN'), api_key=env.get('PELIAS_KEY'),
                       **kwargs)

--- a/test/geocoders/pelias.py
+++ b/test/geocoders/pelias.py
@@ -109,6 +109,5 @@ class PeliasTestCase(BasePeliasTestCase, GeocoderTestBase):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        print(env)
         return Pelias(env.get('PELIAS_DOMAIN'), api_key=env.get('PELIAS_KEY'),
                       **kwargs)


### PR DESCRIPTION
Both methods `geocode` and `reverse` accept the `language` parameter which will be passed to the pelias-api as GET parameter `lang`.

This applies to `GeocodeEarth` as well.