### PR TITLE
Fix collections.abc import for Python 3.9

### DIFF
--- a/geopy/point.py
+++ b/geopy/point.py
@@ -3,7 +3,6 @@
 :class:`.Point` data structure.
 """
 
-import collections
 import re
 import warnings
 from itertools import islice
@@ -12,6 +11,14 @@ from math import fmod
 from geopy import units, util
 from geopy.compat import isfinite, string_compare
 from geopy.format import DEGREE, DOUBLE_PRIME, PRIME, format_degrees, format_distance
+
+try:
+    # Python 3.3+
+    from collections.abc import Iterable
+except ImportError:
+    # Python 2.7
+    from collections import Iterable
+
 
 POINT_PATTERN = re.compile(r"""
     .*?
@@ -261,7 +268,7 @@ class Point(object):
         )
 
     def __eq__(self, other):
-        if not isinstance(other, collections.Iterable):
+        if not isinstance(other, Iterable):
             return NotImplemented
         return tuple(self) == tuple(other)
 


### PR DESCRIPTION
The Python 3.9 build is failing:

```
geopy/point.py:264: in __eq__
    if not isinstance(other, collections.Iterable):
E   AttributeError: module 'collections' has no attribute 'Iterable'
```

https://travis-ci.org/geopy/geopy/jobs/645182137#L297

Python 3.8 warns about the removal:

```
  /home/travis/build/geopy/geopy/geopy/point.py:264: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
```

https://travis-ci.org/geopy/geopy/jobs/645182134#L306

This change fixes the 3.9 build.