### PR TITLE
Update link to Nominatim documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ geopy includes geocoder classes for the `OpenStreetMap Nominatim`_,
 The full list is available on the `Geocoders doc section`_.
 Geocoder classes are located in `geopy.geocoders`_.
 
-.. _OpenStreetMap Nominatim: https://wiki.openstreetmap.org/wiki/Nominatim
+.. _OpenStreetMap Nominatim: https://nominatim.org
 .. _Google Geocoding API (V3): https://developers.google.com/maps/documentation/geocoding/
 .. _Geocoders doc section: https://geopy.readthedocs.io/en/latest/#geocoders
 .. _geopy.geocoders: https://github.com/geopy/geopy/tree/master/geopy/geocoders

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -15,7 +15,7 @@ class Nominatim(Geocoder):
     """Nominatim geocoder for OpenStreetMap data.
 
     Documentation at:
-        https://wiki.openstreetmap.org/wiki/Nominatim
+        https://nominatim.org/release-docs/develop/api/Overview/
 
     .. attention::
        Using Nominatim with the default `user_agent` is strongly discouraged,
@@ -235,7 +235,7 @@ class Nominatim(Geocoder):
                 `postalcode`. For more information, see Nominatim's
                 documentation for `structured requests`:
 
-                    https://wiki.openstreetmap.org/wiki/Nominatim
+                    https://nominatim.org/release-docs/develop/api/Search
 
         :type query: dict or str
 


### PR DESCRIPTION
The documentation for Nominatim is no longer maintained in the OSM wiki. Point to the latest documentation on nominatim.org instead. That is the one that is valid for nominatim.openstreetmap.org.