### PR TITLE
Implement Nominatim reverse geocoder parameter "zoom"

### DIFF
--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -412,7 +412,8 @@ class Nominatim(Geocoder):
             exactly_one=True,
             timeout=DEFAULT_SENTINEL,
             language=False,
-            addressdetails=True
+            addressdetails=True,
+            zoom=None
     ):
         """
         Return an address by location point.
@@ -443,6 +444,8 @@ class Nominatim(Geocoder):
 
             .. versionadded:: 1.14.0
 
+        :param str zoom: Level of detail required for the address.
+
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
 
@@ -460,6 +463,9 @@ class Nominatim(Geocoder):
             params['accept-language'] = language
 
         params['addressdetails'] = 1 if addressdetails else 0
+
+        if zoom is not None:
+            params['zoom'] = zoom
 
         url = self._construct_url(self.reverse_api, params)
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -445,6 +445,7 @@ class Nominatim(Geocoder):
             .. versionadded:: 1.14.0
 
         :param str zoom: Level of detail required for the address.
+        :type zoom: str, int, or float.
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -347,10 +347,19 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
             {"query": query, "exactly_one": True, "zoom": "10"},
             {},
         )
-
         self.assertEqual(
             result_reverse.raw["display_name"],
             "Anaheim, Orange County, California, United States of America"
+        )
+
+        result_reverse = self.reverse_run(
+            {"query": query, "exactly_one": True},
+            {},
+        )
+        self.assertEqual(
+            result_reverse.raw["display_name"],
+            "Disneyland, 1313, South Harbor Boulevard, Anaheim Resort District, Anaheim, "
+            "Orange County, California, 92805, United States of America"
         )
 
 

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -341,6 +341,18 @@ class BaseNominatimTestCase(with_metaclass(ABCMeta, object)):
         )
         self.assertNotIn('namedetails', result.raw)
 
+    def test_reverse_zoom_parameter(self):
+        query = "33.8120962, -117.9211682"
+        result_reverse = self.reverse_run(
+            {"query": query, "exactly_one": True, "zoom": "10"},
+            {},
+        )
+
+        self.assertEqual(
+            result_reverse.raw["display_name"],
+            "Anaheim, Orange County, California, United States of America"
+        )
+
 
 class NominatimTestCase(BaseNominatimTestCase, GeocoderTestBase):
 


### PR DESCRIPTION
Implemented the "zoom" parameter for the Nominatim reverse geocoder. This allows the user to select the level of detail for the address.