### PR TITLE
Allow multiple components of the same type in Googlev3.

### DIFF
--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -152,9 +152,19 @@ class GoogleV3(Geocoder):
         """
         Format the components dict to something Google understands.
         """
+        component_items = []
+
+        if isinstance(components, dict):
+            component_items = components.items()
+        elif isinstance(components, list):
+            component_items = components
+        else:
+            raise ValueError(
+                '`components` parameter must be of type `dict` or `list`')
+
         return "|".join(
-            (":".join(item) for item in components.items())
-        )
+                (":".join(item) for item in component_items)
+            )
 
     def geocode(
             self,
@@ -203,8 +213,14 @@ class GoogleV3(Geocoder):
         :param str region: The region code, specified as a ccTLD
             ("top-level domain") two-character value.
 
-        :param dict components: Restricts to an area. Can use any combination
+        :param Union[dict,list] components: Restricts to an area. Can use any combination
             of: route, locality, administrative_area, postal_code, country.
+            
+            Pass a list of tuples if you want to specify multiple components of the same type
+            e.g.:
+             
+                >>> [('administrative_area','VA'), ('administrative_area':'Arlington')]
+            
 
         :param str place_id: Retrieve a Location using a Place ID.
             Cannot be not used with ``query`` or ``bounds`` parameters.


### PR DESCRIPTION
PR to address #407 

This PR will allow GoogleV3 queries to accept a list of tuples as the component value. This should make it possible to add multiple constraints using the same component type. This change should not break the existing functionality of providing a dict with components.

Tests in `test/geocoders/googlev3.py` have also been updated.

The function will raise a `ValueError` if the input for the `components` parameter is not of type `list` or `dict`

E.g.:

```
[('administrative_area', 'CA'), ('administrative_area', 'Los Angeles')]
```