### PR TITLE
Tests: allow running tests without internet with a `--skip-tests-requiring-internet` switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ format:
 
 .PHONY: test
 test:
+	# Run tests without Internet first. These are fast and help to avoid
+	# spending geocoders quota for test runs which would fail anyway.
+	python -m pytest --skip-tests-requiring-internet
+	# Run tests with Internet:
 	coverage run -m py.test
 	coverage report
 


### PR DESCRIPTION
Geocoders tests currently rely on the Internet presence to make actual queries to the geocoding services.

This is inconvenient in the following ways:
- The network requests make the tests slow
- Network requests spend quotas, making it harder to use for TDD
- The test suite cannot be easily run in an environment without Internet access
- Networking issues make the test runs flaky, which is unwanted for downstream package maintainers.

One solution would be to record actual requests (see #203) and replay them in tests instead of making actual requests. There are two problems with this solution:
1. Some services disallow storing responses in their ToS 
2. The recorded responses would slowly decay, making maintenance more costly.

Another approach (which is implemented here) is to add an option (`--skip-tests-requiring-internet`) to the test suite which skips tests requiring network. The test coverage would definitely be lower than the usual runs, however, it is still useful to quickly run a subset of tests to verify that things are not completely broken.

`--skip-tests-requiring-internet` works by raising `pytest.skip` at the moment of the first network request in a test. So the code preparing the request is actually getting executed, although it is not validated.

Usage:

    python -m pytest --skip-tests-requiring-internet
    <...>
    ==== 302 passed, 295 skipped, 2 xfailed, 1 warning in 8.84s =====