### PR TITLE
geopy 2.0: drop deprecation shims

### DIFF
--- a/docs/changelog_2xx.rst
+++ b/docs/changelog_2xx.rst
@@ -13,3 +13,35 @@ Packaging changes
 ~~~~~~~~~~~~~~~~~
 
 - Dropped support for Python 2.7 and 3.4.
+
+Chores
+~~~~~~
+
+- ``geopy.distance`` algorithms now raise ``ValueError`` for points with
+  different altitudes, because :ref:`altitude is ignored in calculations
+  <distance_altitudes>`.
+- Removed ``geopy.distance.vincenty``, use :class:`geopy.distance.geodesic` instead.
+- ``timeout=None`` now disables request timeout, previously
+  a default timeout has been used in this case.
+- Removed ``GoogleV3.timezone``, use :meth:`.GoogleV3.reverse_timezone` instead.
+- Removed ``format_string`` param from all geocoders.
+  See :ref:`Specifying Parameters Once <specifying_parameters_once>`
+  doc section for alternatives.
+- ``exactly_one``'s default is now ``True`` for all geocoders
+  and methods.
+- Removed service-specific request params from all ``__init__`` methods
+  of geocoders. Pass them to the corresponding ``geocode``/``reverse``
+  methods instead.
+- All bounding box arguments now must be passed as a list of two Points.
+  Previously some geocoders accepted unique formats like plain strings
+  and lists of 4 coordinates -- these values are not valid anymore.
+- :meth:`.GoogleV3.reverse_timezone` used to allow numeric ``at_time`` value.
+  Pass ``datetime`` instances instead.
+- ``reverse`` methods used to bypass the query if it couldn't be parsed
+  as a :class:`.Point`. Now a ``ValueError`` is raised in this case.
+- :class:`.Location` and :class:`.Timezone` classes no longer accept None
+  for ``point`` and ``raw`` args.
+- :class:`.Nominatim` now raises :class:`geopy.exc.ConfigurationError` when
+  used with a default or sample user-agent.
+- :class:`.Point` now raises a ``ValueError`` if constructed from a single number.
+  A zero longitude must be explicitly passed to avoid the error.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -327,9 +327,6 @@ Calculating Distance
 .. autoclass:: geopy.distance.geodesic
     :members: __init__
 
-.. autoclass:: geopy.distance.vincenty
-    :members: __init__
-
 .. autoclass:: geopy.distance.great_circle
     :members: __init__
 

--- a/geopy/distance.py
+++ b/geopy/distance.py
@@ -426,7 +426,7 @@ class geodesic(Distance):
         """
         Change the ellipsoid used in the calculation.
         """
-        if not isinstance(ellipsoid, (list, tuple)):
+        if isinstance(ellipsoid, str):
             try:
                 self.ELLIPSOID = ELLIPSOIDS[ellipsoid]
                 self.ellipsoid_key = ellipsoid
@@ -437,7 +437,6 @@ class geodesic(Distance):
         else:
             self.ELLIPSOID = ellipsoid
             self.ellipsoid_key = None
-        return
 
     # Call geographiclib routines for measure and destination
     def measure(self, a, b):

--- a/geopy/distance.py
+++ b/geopy/distance.py
@@ -187,12 +187,9 @@ def lonlat(x, y, z=0):
 
 def _ensure_same_altitude(a, b):
     if abs(a.altitude - b.altitude) > 1e-6:
-        warnings.warn(
+        raise ValueError(
             'Calculating distance between points with different altitudes '
-            'is not supported. The calculated distance would be '
-            'at the same elevation (as if the points had equal altitudes). '
-            'In geopy 2.0 this will become a ValueError exception.',
-            DeprecationWarning, stacklevel=3
+            'is not supported'
         )
     # Note: non-zero equal altitudes are fine: assuming that
     # the elevation is many times smaller than the Earth radius

--- a/geopy/distance.py
+++ b/geopy/distance.py
@@ -111,10 +111,8 @@ a suitable approximation::
     >>> print(euclidian_distance)
     1.359986705262199
 
-.. versionchanged:: 1.23.0
-    Calculating distances between points with different altitudes now
-    causes a deprecation warning. In geopy 2.0 this will become a
-    ``ValueError`` exception.
+An attempt to calculate distances between points with different altitudes
+would result in a ``ValueError`` exception.
 
 """
 from math import asin, atan2, cos, sin, sqrt
@@ -409,8 +407,6 @@ class geodesic(Distance):
         >>> print(geodesic(newport_ri, cleveland_oh).miles)
         538.390445368
 
-
-    .. versionadded:: 1.13.0
     """
 
     ellipsoid_key = None

--- a/geopy/distance.py
+++ b/geopy/distance.py
@@ -19,12 +19,7 @@ The geodesic distance is the shortest distance on the surface of an
 ellipsoidal model of the earth.  The default algorithm uses the method
 is given by `Karney (2013)
 <https://doi.org/10.1007%2Fs00190-012-0578-z>`_ (:class:`.geodesic`);
-this is accurate to round-off and always converges.  An older
-*deprecated* method due to `Vincenty (1975)
-<https://en.wikipedia.org/wiki/Vincenty's_formulae>`_
-(:class:`.vincenty`) is also available; this is only accurate to 0.2 mm
-and the distance calculation fails to converge for nearly antipodal
-points.
+this is accurate to round-off and always converges.
 
 ``geopy.distance.distance`` currently uses :class:`.geodesic`.
 
@@ -55,8 +50,6 @@ Here are examples of ``distance.distance`` usage::
     >>> salamanca = (40.96, -5.50)
     >>> print(distance.distance(wellington, salamanca).km)
     19959.6792674
-
-The second example above fails with :class:`.vincenty`.
 
 Using :class:`.great_circle` distance::
 
@@ -124,8 +117,7 @@ a suitable approximation::
     ``ValueError`` exception.
 
 """
-import warnings
-from math import asin, atan, atan2, cos, pi, sin, sqrt, tan
+from math import asin, atan2, cos, sin, sqrt
 
 from geographiclib.geodesic import Geodesic
 
@@ -197,10 +189,6 @@ def _ensure_same_altitude(a, b):
 
 
 class Distance:
-    """
-    Base for :class:`.great_circle`, :class:`.vincenty`, and
-    :class:`.geodesic`.
-    """
 
     def __init__(self, *args, **kwargs):
         kilometers = kwargs.pop('kilometers', 0)
@@ -431,10 +419,6 @@ class geodesic(Distance):
 
     def __init__(self, *args, **kwargs):
         self.set_ellipsoid(kwargs.pop('ellipsoid', 'WGS-84'))
-        if 'iterations' in kwargs:
-            warnings.warn('Ignoring unused `iterations` kwarg for geodesic '
-                          'distance.', DeprecationWarning, stacklevel=2)
-        kwargs.pop('iterations', 0)
         major, minor, f = self.ELLIPSOID
         super().__init__(*args, **kwargs)
 
@@ -498,261 +482,6 @@ class geodesic(Distance):
 
 
 GeodesicDistance = geodesic
-
-
-class vincenty(Distance):
-    """
-    .. deprecated:: 1.13
-       Use :class:`.geodesic` instead.
-       Vincenty will be removed in geopy 2.0.
-
-    Calculate the geodesic distance between two points using the Vincenty's
-    method.
-
-    Set which ellipsoidal model of the earth to use by specifying an
-    ``ellipsoid`` keyword argument. The default is 'WGS-84', which is the
-    most globally accurate model.  If ``ellipsoid`` is a string, it is
-    looked up in the `ELLIPSOIDS` dictionary to obtain the major and minor
-    semiaxes and the flattening. Otherwise, it should be a tuple with those
-    values.  See the comments above the `ELLIPSOIDS` dictionary for
-    more information.
-
-    Example::
-
-        >>> from geopy.distance import vincenty
-        >>> newport_ri = (41.49008, -71.312796)
-        >>> cleveland_oh = (41.499498, -81.695391)
-        >>> print(vincenty(newport_ri, cleveland_oh).miles)
-        538.390445362
-
-    Note: Vincenty's method for distance fails to converge for some
-    valid (nearly antipodal) points. In such cases, use
-    :class:`.geodesic` which always produces an accurate result.
-
-    """
-
-    ellipsoid_key = None
-    ELLIPSOID = None
-    _show_deprecation_warning = True
-
-    def __init__(self, *args, **kwargs):
-        if self._show_deprecation_warning:
-            warnings.warn('Vincenty is deprecated and is going to be removed '
-                          'in geopy 2.0. Use `geopy.distance.geodesic` '
-                          '(or the default `geopy.distance.distance`) '
-                          'instead, which is more accurate and always converges.',
-                          DeprecationWarning, stacklevel=2)
-        self.set_ellipsoid(kwargs.pop('ellipsoid', 'WGS-84'))
-        self.iterations = kwargs.pop('iterations', 20)
-        major, minor, f = self.ELLIPSOID
-        super().__init__(*args, **kwargs)
-
-    def set_ellipsoid(self, ellipsoid):
-        """
-        Change the ellipsoid used in the calculation.
-        """
-        if not isinstance(ellipsoid, (list, tuple)):
-            try:
-                self.ELLIPSOID = ELLIPSOIDS[ellipsoid]
-                self.ellipsoid_key = ellipsoid
-            except KeyError:
-                raise Exception(
-                    "Invalid ellipsoid. See geopy.distance.ELIPSOIDS"
-                )
-        else:
-            self.ELLIPSOID = ellipsoid
-            self.ellipsoid_key = None
-        return
-
-    def measure(self, a, b):
-        a, b = Point(a), Point(b)
-        lat1, lng1 = radians(degrees=a.latitude), radians(degrees=a.longitude)
-        lat2, lng2 = radians(degrees=b.latitude), radians(degrees=b.longitude)
-
-        if isinstance(self.ELLIPSOID, str):
-            major, minor, f = ELLIPSOIDS[self.ELLIPSOID]
-        else:
-            major, minor, f = self.ELLIPSOID
-
-        delta_lng = lng2 - lng1
-
-        reduced_lat1 = atan((1 - f) * tan(lat1))
-        reduced_lat2 = atan((1 - f) * tan(lat2))
-
-        sin_reduced1, cos_reduced1 = sin(reduced_lat1), cos(reduced_lat1)
-        sin_reduced2, cos_reduced2 = sin(reduced_lat2), cos(reduced_lat2)
-
-        lambda_lng = delta_lng
-        lambda_prime = 2 * pi
-
-        iter_limit = self.iterations
-
-        i = 0
-
-        while (i == 0 or
-               (abs(lambda_lng - lambda_prime) > 10e-12 and i <= iter_limit)):
-            i += 1
-
-            sin_lambda_lng, cos_lambda_lng = sin(lambda_lng), cos(lambda_lng)
-
-            sin_sigma = sqrt(
-                (cos_reduced2 * sin_lambda_lng) ** 2 +
-                (cos_reduced1 * sin_reduced2 -
-                 sin_reduced1 * cos_reduced2 * cos_lambda_lng) ** 2
-            )
-
-            if sin_sigma == 0:
-                return 0  # Coincident points
-
-            cos_sigma = (
-                sin_reduced1 * sin_reduced2 +
-                cos_reduced1 * cos_reduced2 * cos_lambda_lng
-            )
-
-            sigma = atan2(sin_sigma, cos_sigma)
-
-            sin_alpha = (
-                cos_reduced1 * cos_reduced2 * sin_lambda_lng / sin_sigma
-            )
-            cos_sq_alpha = 1 - sin_alpha ** 2
-
-            if cos_sq_alpha != 0:
-                cos2_sigma_m = cos_sigma - 2 * (
-                    sin_reduced1 * sin_reduced2 / cos_sq_alpha
-                )
-            else:
-                cos2_sigma_m = 0.0  # Equatorial line
-
-            C = f / 16. * cos_sq_alpha * (4 + f * (4 - 3 * cos_sq_alpha))
-
-            lambda_prime = lambda_lng
-            lambda_lng = (
-                delta_lng + (1 - C) * f * sin_alpha * (
-                    sigma + C * sin_sigma * (
-                        cos2_sigma_m + C * cos_sigma * (
-                            -1 + 2 * cos2_sigma_m ** 2
-                        )
-                    )
-                )
-            )
-
-        if i > iter_limit:
-            raise ValueError("Vincenty formula failed to converge!")
-
-        u_sq = cos_sq_alpha * (major ** 2 - minor ** 2) / minor ** 2
-
-        A = 1 + u_sq / 16384. * (
-            4096 + u_sq * (-768 + u_sq * (320 - 175 * u_sq))
-        )
-
-        B = u_sq / 1024. * (256 + u_sq * (-128 + u_sq * (74 - 47 * u_sq)))
-
-        delta_sigma = (
-            B * sin_sigma * (
-                cos2_sigma_m + B / 4. * (
-                    cos_sigma * (
-                        -1 + 2 * cos2_sigma_m ** 2
-                    ) - B / 6. * cos2_sigma_m * (
-                        -3 + 4 * sin_sigma ** 2
-                    ) * (
-                        -3 + 4 * cos2_sigma_m ** 2
-                    )
-                )
-            )
-        )
-
-        s = minor * A * (sigma - delta_sigma)
-        return s
-
-    def destination(self, point, bearing, distance=None):
-        """
-        TODO docs.
-        """
-        point = Point(point)
-        lat1 = units.radians(degrees=point.latitude)
-        lng1 = units.radians(degrees=point.longitude)
-        bearing = units.radians(degrees=bearing)
-
-        if distance is None:
-            distance = self
-        if isinstance(distance, Distance):
-            distance = distance.kilometers
-
-        ellipsoid = self.ELLIPSOID
-        if isinstance(ellipsoid, str):
-            ellipsoid = ELLIPSOIDS[ellipsoid]
-
-        major, minor, f = ellipsoid
-
-        tan_reduced1 = (1 - f) * tan(lat1)
-        cos_reduced1 = 1 / sqrt(1 + tan_reduced1 ** 2)
-        sin_reduced1 = tan_reduced1 * cos_reduced1
-        sin_bearing, cos_bearing = sin(bearing), cos(bearing)
-        sigma1 = atan2(tan_reduced1, cos_bearing)
-        sin_alpha = cos_reduced1 * sin_bearing
-        cos_sq_alpha = 1 - sin_alpha ** 2
-        u_sq = cos_sq_alpha * (major ** 2 - minor ** 2) / minor ** 2
-
-        A = 1 + u_sq / 16384. * (
-            4096 + u_sq * (-768 + u_sq * (320 - 175 * u_sq))
-        )
-        B = u_sq / 1024. * (256 + u_sq * (-128 + u_sq * (74 - 47 * u_sq)))
-
-        sigma = distance / (minor * A)
-        sigma_prime = 2 * pi
-
-        while abs(sigma - sigma_prime) > 10e-12:
-            cos2_sigma_m = cos(2 * sigma1 + sigma)
-            sin_sigma, cos_sigma = sin(sigma), cos(sigma)
-            delta_sigma = B * sin_sigma * (
-                cos2_sigma_m + B / 4. * (
-                    cos_sigma * (
-                        -1 + 2 * cos2_sigma_m ** 2
-                    ) - B / 6. * cos2_sigma_m * (
-                        -3 + 4 * sin_sigma ** 2
-                    ) * (
-                        -3 + 4 * cos2_sigma_m ** 2
-                    )
-                )
-            )
-            sigma_prime = sigma
-            sigma = distance / (minor * A) + delta_sigma
-
-        sin_sigma, cos_sigma = sin(sigma), cos(sigma)
-
-        lat2 = atan2(
-            sin_reduced1 * cos_sigma + cos_reduced1 * sin_sigma * cos_bearing,
-            (1 - f) * sqrt(
-                sin_alpha ** 2 + (
-                    sin_reduced1 * sin_sigma -
-                    cos_reduced1 * cos_sigma * cos_bearing
-                ) ** 2
-            )
-        )
-
-        lambda_lng = atan2(
-            sin_sigma * sin_bearing,
-            cos_reduced1 * cos_sigma - sin_reduced1 * sin_sigma * cos_bearing
-        )
-
-        C = f / 16. * cos_sq_alpha * (4 + f * (4 - 3 * cos_sq_alpha))
-
-        delta_lng = (
-            lambda_lng - (1 - C) * f * sin_alpha * (
-                sigma + C * sin_sigma * (
-                    cos2_sigma_m + C * cos_sigma * (
-                        -1 + 2 * cos2_sigma_m ** 2
-                    )
-                )
-            )
-        )
-
-        lng2 = lng1 + delta_lng
-
-        return Point(units.degrees(radians=lat2), units.degrees(radians=lng2))
-
-
-VincentyDistance = vincenty
 
 # Set the default distance formula
 distance = GeodesicDistance

--- a/geopy/extra/rate_limiter.py
+++ b/geopy/extra/rate_limiter.py
@@ -59,8 +59,6 @@ class RateLimiter:
     Before using this class, please consult with the Geocoding service
     ToS, which might explicitly consider bulk requests (even throttled)
     a violation.
-
-    .. versionadded:: 1.16.0
     """
 
     def __init__(self, func, min_delay_seconds=0.0, max_retries=2,

--- a/geopy/geocoders/algolia.py
+++ b/geopy/geocoders/algolia.py
@@ -27,7 +27,6 @@ class AlgoliaPlaces(Geocoder):
             app_id=None,
             api_key=None,
             domain='places-dsn.algolia.net',
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -43,11 +42,6 @@ class AlgoliaPlaces(Geocoder):
 
         :param str domain: Currently it is ``'places-dsn.algolia.net'``,
             can be changed for testing purposes.
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -67,7 +61,6 @@ class AlgoliaPlaces(Geocoder):
 
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -160,7 +153,7 @@ class AlgoliaPlaces(Geocoder):
         """
 
         params = {
-            'query': self.format_string % query,
+            'query': query,
         }
 
         if type is not None:

--- a/geopy/geocoders/algolia.py
+++ b/geopy/geocoders/algolia.py
@@ -15,8 +15,6 @@ class AlgoliaPlaces(Geocoder):
 
     Documentation at:
         https://community.algolia.com/places/documentation.html
-
-    .. versionadded:: 1.22.0
     """
 
     geocode_path = '/1/places/query'

--- a/geopy/geocoders/algolia.py
+++ b/geopy/geocoders/algolia.py
@@ -1,3 +1,4 @@
+import collections.abc
 from urllib.parse import urlencode
 from urllib.request import Request
 
@@ -276,7 +277,7 @@ class AlgoliaPlaces(Geocoder):
         latitude = feature.get('_geoloc', {}).get('lat')
         longitude = feature.get('_geoloc', {}).get('lng')
 
-        if isinstance(feature['locale_names'], dict):
+        if isinstance(feature['locale_names'], collections.abc.Mapping):
             if language in feature['locale_names']:
                 placename = feature['locale_names'][language][0]
             else:

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -42,7 +42,6 @@ class ArcGIS(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
             auth_domain='www.arcgis.com',
             domain='geocode.arcgis.com',
@@ -79,13 +78,6 @@ class ArcGIS(Geocoder):
 
             .. versionadded:: 1.12.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. versionadded:: 1.14.0
-
-            .. deprecated:: 1.22.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
@@ -104,7 +96,6 @@ class ArcGIS(Geocoder):
             .. versionadded:: 1.17.0
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -185,7 +176,7 @@ class ArcGIS(Geocoder):
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
-        params = {'singleLine': self.format_string % query, 'f': 'json'}
+        params = {'singleLine': query, 'f': 'json'}
         if exactly_one:
             params['maxLocations'] = 1
         if out_fields is not None:

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -1,5 +1,4 @@
 import json
-import warnings
 from time import time
 from urllib.parse import urlencode
 from urllib.request import Request
@@ -204,7 +203,7 @@ class ArcGIS(Geocoder):
         return geocoded
 
     def reverse(self, query, exactly_one=True, timeout=DEFAULT_SENTINEL,
-                distance=None, wkid=DEFAULT_WKID):
+                distance=None):
         """
         Return an address by location point.
 
@@ -225,32 +224,11 @@ class ArcGIS(Geocoder):
             within which to search. ArcGIS has a default of 100 meters, if not
             specified.
 
-        :param str wkid: WKID to use for both input and output coordinates.
-
-            .. deprecated:: 1.14.0
-               It wasn't working before because it was specified incorrectly
-               in the request parameters, and won't work even if we fix the
-               request, because :class:`geopy.point.Point` normalizes the
-               coordinates according to WKID 4326. Please open an issue in
-               the geopy issue tracker if you believe that custom wkid values
-               should be supported.
-               This parameter is scheduled for removal in geopy 2.0.
-
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
         location = self._coerce_point_to_string(query, "%(lon)s,%(lat)s")
-        if wkid != DEFAULT_WKID:
-            warnings.warn("%s.reverse: custom wkid value has been ignored.  "
-                          "It wasn't working before because it was specified "
-                          "incorrectly in the request parameters, and won't "
-                          "work even if we fix the request, because geopy.Point "
-                          "normalizes the coordinates according to WKID %s. "
-                          "Please open an issue in the geopy issue tracker "
-                          "if you believe that custom wkid values should be "
-                          "supported." % (type(self).__name__, DEFAULT_WKID),
-                          DeprecationWarning, stacklevel=2)
-            wkid = DEFAULT_WKID
+        wkid = DEFAULT_WKID
         params = {'location': location, 'f': 'json', 'outSR': wkid}
         if distance is not None:
             params['distance'] = distance

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -76,24 +76,16 @@ class ArcGIS(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
 
         :param str auth_domain: Domain where the target ArcGIS auth service
             is hosted. Used only in authenticated mode (i.e. username,
             password and referer are set).
 
-            .. versionadded:: 1.17.0
-
         :param str domain: Domain where the target ArcGIS service
             is hosted.
-
-            .. versionadded:: 1.17.0
         """
         super().__init__(
             scheme=scheme,
@@ -169,8 +161,6 @@ class ArcGIS(Geocoder):
             https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm
             for a list of supported output fields. If you want to return all
             supported output fields, set ``out_fields="*"``.
-
-            .. versionadded:: 1.14.0
         :type out_fields: str or iterable
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if

--- a/geopy/geocoders/azure.py
+++ b/geopy/geocoders/azure.py
@@ -9,8 +9,6 @@ class AzureMaps(TomTom):
 
     Documentation at:
         https://docs.microsoft.com/en-us/azure/azure-maps/index
-
-    .. versionadded:: 1.15.0
     """
 
     geocode_path = '/search/address/json'

--- a/geopy/geocoders/azure.py
+++ b/geopy/geocoders/azure.py
@@ -19,7 +19,6 @@ class AzureMaps(TomTom):
     def __init__(
             self,
             subscription_key,
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -29,11 +28,6 @@ class AzureMaps(TomTom):
     ):
         """
         :param str subscription_key: Azure Maps subscription key.
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -56,7 +50,6 @@ class AzureMaps(TomTom):
         """
         super().__init__(
             api_key=subscription_key,
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,

--- a/geopy/geocoders/baidu.py
+++ b/geopy/geocoders/baidu.py
@@ -37,7 +37,6 @@ class Baidu(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
             security_key=None,
     ):
@@ -64,13 +63,6 @@ class Baidu(Geocoder):
 
             .. versionadded:: 1.12.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. versionadded:: 1.14.0
-
-            .. deprecated:: 1.22.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
@@ -84,7 +76,6 @@ class Baidu(Geocoder):
             .. versionadded:: 1.15.0
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -131,7 +122,7 @@ class Baidu(Geocoder):
         params = {
             'ak': self.api_key,
             'output': 'json',
-            'address': self.format_string % query,
+            'address': query,
         }
 
         url = self._construct_url(self.api, self.api_path, params)

--- a/geopy/geocoders/baidu.py
+++ b/geopy/geocoders/baidu.py
@@ -23,8 +23,6 @@ class Baidu(Geocoder):
     .. attention::
         Newly registered API keys will not work with v2 API,
         use :class:`.BaiduV3` instead.
-
-    .. versionadded:: 1.0.0
     """
 
     api_path = '/geocoder/v2/'
@@ -49,9 +47,6 @@ class Baidu(Geocoder):
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
 
-            .. versionchanged:: 1.14.0
-               Default scheme has been changed from ``http`` to ``https``.
-
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
 
@@ -61,19 +56,13 @@ class Baidu(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
-            .. versionadded:: 1.14.0
-
         :param str security_key: The security key (SK) to calculate
             the SN parameter in request if authentication setting requires
             (http://lbsyun.baidu.com/index.php?title=lbscloud/api/appendix).
-
-            .. versionadded:: 1.15.0
         """
         super().__init__(
             scheme=scheme,
@@ -143,8 +132,6 @@ class Baidu(Geocoder):
 
         :param bool exactly_one: Return one result or a list of results, if
             available. Baidu's API will always return at most one result.
-
-            .. versionadded:: 1.14.0
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
@@ -284,8 +271,6 @@ class BaiduV3(Baidu):
 
     Documentation at:
         http://lbsyun.baidu.com/index.php?title=webapi/guide/webservice-geocoding
-
-    .. versionadded:: 1.22.0
     """
 
     api_path = '/geocoding/v3/'

--- a/geopy/geocoders/banfrance.py
+++ b/geopy/geocoders/banfrance.py
@@ -12,8 +12,6 @@ class BANFrance(Geocoder):
 
     Documentation at:
         https://adresse.data.gouv.fr/api
-
-    .. versionadded:: 1.18.0
     """
 
     geocode_path = '/search'

--- a/geopy/geocoders/banfrance.py
+++ b/geopy/geocoders/banfrance.py
@@ -22,7 +22,6 @@ class BANFrance(Geocoder):
     def __init__(
             self,
             domain='api-adresse.data.gouv.fr',
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -33,11 +32,6 @@ class BANFrance(Geocoder):
 
         :param str domain: Currently it is ``'api-adresse.data.gouv.fr'``, can
             be changed for testing purposes.
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -57,7 +51,6 @@ class BANFrance(Geocoder):
 
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -104,7 +97,7 @@ class BANFrance(Geocoder):
         """
 
         params = {
-            'q': self.format_string % query,
+            'q': query,
         }
 
         if limit is not None:

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -1,6 +1,5 @@
 import functools
 import json
-import warnings
 from socket import timeout as SocketTimeout
 from ssl import SSLError
 from urllib.error import HTTPError
@@ -218,28 +217,18 @@ class Geocoder:
         Do the right thing on "point" input. For geocoders with reverse
         methods.
         """
-        try:
-            if not isinstance(point, Point):
-                point = Point(point)
-        except ValueError as e:
-            if isinstance(point, str):
-                warnings.warn(
-                    'Unable to parse the string as Point: "%s". Using the value '
-                    'as-is for the query. In geopy 2.0 this will become an '
-                    'exception.' % str(e), DeprecationWarning, stacklevel=3
-                )
-                return point
-            raise
-        else:
-            # Altitude is silently dropped.
-            #
-            # Geocoding services (almost?) always consider only lat and lon
-            # in queries, so altitude doesn't affect the request.
-            # A non-zero altitude should not raise an exception
-            # though, because PoIs are assumed to span the whole
-            # altitude axis (i.e. not just the 0km plane).
-            return output_format % dict(lat=point.latitude,
-                                        lon=point.longitude)
+        if not isinstance(point, Point):
+            point = Point(point)
+
+        # Altitude is silently dropped.
+        #
+        # Geocoding services (almost?) always consider only lat and lon
+        # in queries, so altitude doesn't affect the request.
+        # A non-zero altitude should not raise an exception
+        # though, because PoIs are assumed to span the whole
+        # altitude axis (i.e. not just the 0km plane).
+        return output_format % dict(lat=point.latitude,
+                                    lon=point.longitude)
 
     @staticmethod
     def _format_bounding_box(bbox, output_format="%(lat1)s,%(lon1)s,%(lat2)s,%(lon2)s"):

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -52,16 +52,6 @@ class options:
         7
 
     Attributes:
-        default_format_string
-            String containing ``'%s'`` where the string to geocode should
-            be interpolated before querying the geocoder. Used by `geocode`
-            calls only. For example: ``'%s, Mountain View, CA'``.
-
-            .. deprecated:: 1.22.0
-                ``format_string`` is deprecated in favor of more advanced
-                alternatives (see :ref:`Specifying Parameters Once
-                <specifying_parameters_once>`) and will be removed in
-                geopy 2.0.
 
         default_proxies
             Tunnel requests through HTTP proxy.
@@ -155,7 +145,6 @@ class options:
     #
     # [1]: http://www.sphinx-doc.org/en/master/ext/autodoc.html#directive-autoattribute
     # [2]: https://github.com/rtfd/readthedocs.org/issues/855#issuecomment-261337038
-    default_format_string = '%s'
     default_proxies = None
     default_scheme = 'https'
     default_ssl_context = None
@@ -191,22 +180,12 @@ class Geocoder:
 
     def __init__(
             self,
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
     ):
-        if format_string is not None or options.default_format_string != "%s":
-            warnings.warn(
-                '`format_string` is deprecated. Please pass the already '
-                'formatted queries to `geocode` instead. See '
-                '`Specifying Parameters Once` section in docs for more '
-                'details. In geopy 2.0 `format_string` will be removed.',
-                DeprecationWarning, stacklevel=3
-            )
-        self.format_string = format_string or options.default_format_string
         self.scheme = scheme or options.default_scheme
         if self.scheme not in ('http', 'https'):
             raise ConfigurationError(

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -95,9 +95,6 @@ class options:
             For more information, see
             documentation on :class:`urllib.request.ProxyHandler`.
 
-            .. versionchanged:: 1.15.0
-               Added support for the string value.
-
         default_scheme
             Use ``'https'`` or ``'http'`` as the API URL's scheme.
 

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -140,17 +140,6 @@ class options:
             before raising a :class:`geopy.exc.GeocoderTimedOut` exception.
             Pass `None` to disable timeout.
 
-            .. note::
-               Currently ``None`` as a value is processed correctly only
-               for the ``geopy.geocoders.options.default_timeout`` option
-               value. ``timeout=None`` as a method argument (i.e.
-               ``geocoder.geocode(..., timeout=None)``) would be treated
-               as "use timeout, as set in
-               ``geopy.geocoders.options.default_timeout``", and
-               a deprecation warning would be raised.
-               In geopy 2.0 this will change, so that ``timeout=None``
-               would actually disable timeout.
-
         default_user_agent
             User-Agent header to send with the requests to geocoder API.
     """
@@ -342,16 +331,6 @@ class Geocoder:
                 req = Request(url=url, headers=self.headers)
 
         requester = requester or self.urlopen
-
-        if timeout is None:
-            warnings.warn(
-                ('`timeout=None` has been passed to a geocoder call. Using '
-                 'default geocoder timeout. In geopy 2.0 the '
-                 'behavior will be different: None will mean "no timeout" '
-                 'instead of "default geocoder timeout". Pass '
-                 'geopy.geocoders.base.DEFAULT_SENTINEL instead of None '
-                 'to get rid of this warning.'), DeprecationWarning, stacklevel=3)
-            timeout = DEFAULT_SENTINEL
 
         timeout = (timeout if timeout is not DEFAULT_SENTINEL
                    else self.timeout)

--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -1,3 +1,4 @@
+import collections.abc
 from urllib.parse import quote, urlencode
 
 from geopy.exc import (
@@ -135,7 +136,7 @@ class Bing(Geocoder):
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
-        if isinstance(query, dict):
+        if isinstance(query, collections.abc.Mapping):
             params = {
                 key: val
                 for key, val

--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -59,13 +59,9 @@ class Bing(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
         """
         super().__init__(
             scheme=scheme,
@@ -113,18 +109,12 @@ class Bing(Geocoder):
         :param str culture: Affects the language of the response,
             must be a two-letter country code.
 
-            .. versionadded:: 1.4.0
-
         :param bool include_neighborhood: Sets whether to include the
             neighborhood field in the response.
-
-            .. versionadded:: 1.4.0
 
         :param bool include_country_code: Sets whether to include the
             two-letter ISO code of the country in the response (field name
             'countryRegionIso2').
-
-            .. versionadded:: 1.4.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.

--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -36,7 +36,6 @@ class Bing(Geocoder):
     def __init__(
             self,
             api_key,
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -47,11 +46,6 @@ class Bing(Geocoder):
 
         :param str api_key: Should be a valid Bing Maps API key
             (https://www.microsoft.com/en-us/maps/create-a-bing-maps-key).
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -74,7 +68,6 @@ class Bing(Geocoder):
             .. versionadded:: 1.14.0
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -146,7 +139,7 @@ class Bing(Geocoder):
             params['key'] = self.api_key
         else:
             params = {
-                'query': self.format_string % query,
+                'query': query,
                 'key': self.api_key
             }
         if user_location:

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -39,13 +39,9 @@ class DataBC(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
         """
         super().__init__(
             scheme=scheme,

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -23,7 +23,6 @@ class DataBC(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
     ):
         """
@@ -42,13 +41,6 @@ class DataBC(Geocoder):
 
             .. versionadded:: 1.12.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. versionadded:: 1.14.0
-
-            .. deprecated:: 1.22.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
@@ -56,7 +48,6 @@ class DataBC(Geocoder):
             .. versionadded:: 1.14.0
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -102,7 +93,7 @@ class DataBC(Geocoder):
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
-        params = {'addressString': self.format_string % query}
+        params = {'addressString': query}
         if set_back != 0:
             params['setBack'] = set_back
         if location_descriptor not in ['any',

--- a/geopy/geocoders/geocodeearth.py
+++ b/geopy/geocoders/geocodeearth.py
@@ -12,8 +12,6 @@ class GeocodeEarth(Pelias):
     def __init__(
             self,
             api_key,
-            boundary_rect=None,
-            country_bias=None,
             domain='api.geocode.earth',
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -23,21 +21,6 @@ class GeocodeEarth(Pelias):
     ):
         """
         :param str api_key: Geocode.earth API key, required.
-
-        :type boundary_rect: list or tuple of 2 items of :class:`geopy.point.Point`
-            or ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
-        :param boundary_rect: Coordinates to restrict search within.
-            Example: ``[Point(22, 180), Point(-22, -180)]``.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `boundary_rect` instead.
-
-        :param str country_bias: Bias results to this country (ISO alpha-3).
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `country_bias` instead.
 
         :param str domain: Specify a custom domain for Pelias API.
 
@@ -60,8 +43,6 @@ class GeocodeEarth(Pelias):
         """
         super().__init__(
             api_key=api_key,
-            boundary_rect=boundary_rect,
-            country_bias=country_bias,
             domain=domain,
             timeout=timeout,
             proxies=proxies,

--- a/geopy/geocoders/geocodeearth.py
+++ b/geopy/geocoders/geocodeearth.py
@@ -7,8 +7,6 @@ __all__ = ("GeocodeEarth", )
 class GeocodeEarth(Pelias):
     """geocode.earth, a Pelias-based service provided by the developers
     of Pelias itself.
-
-    .. versionadded:: 1.15.0
     """
 
     def __init__(
@@ -30,12 +28,6 @@ class GeocodeEarth(Pelias):
             or ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
         :param boundary_rect: Coordinates to restrict search within.
             Example: ``[Point(22, 180), Point(-22, -180)]``.
-
-            .. versionchanged:: 1.17.0
-                Previously boundary_rect could be a list of 4 strings or numbers
-                in the format of ``[longitude, latitude, longitude, latitude]``.
-                This format is now deprecated in favor of a list/tuple
-                of a pair of geopy Points and will be removed in geopy 2.0.
 
             .. deprecated:: 1.19.0
                 This argument will be removed in geopy 2.0.

--- a/geopy/geocoders/geocodeearth.py
+++ b/geopy/geocoders/geocodeearth.py
@@ -14,7 +14,6 @@ class GeocodeEarth(Pelias):
     def __init__(
             self,
             api_key,
-            format_string=None,
             boundary_rect=None,
             country_bias=None,
             domain='api.geocode.earth',
@@ -26,11 +25,6 @@ class GeocodeEarth(Pelias):
     ):
         """
         :param str api_key: Geocode.earth API key, required.
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :type boundary_rect: list or tuple of 2 items of :class:`geopy.point.Point`
             or ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
@@ -74,7 +68,6 @@ class GeocodeEarth(Pelias):
         """
         super().__init__(
             api_key=api_key,
-            format_string=format_string,
             boundary_rect=boundary_rect,
             country_bias=country_bias,
             domain=domain,

--- a/geopy/geocoders/geocodefarm.py
+++ b/geopy/geocoders/geocodefarm.py
@@ -25,7 +25,6 @@ class GeocodeFarm(Geocoder):
     def __init__(
             self,
             api_key=None,
-            format_string=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
@@ -36,11 +35,6 @@ class GeocodeFarm(Geocoder):
 
         :param str api_key: (optional) The API key required by GeocodeFarm
             to perform geocoding requests.
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -65,7 +59,6 @@ class GeocodeFarm(Geocoder):
             .. versionadded:: 1.14.0
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -99,7 +92,7 @@ class GeocodeFarm(Geocoder):
             ``exactly_one=False``.
         """
         params = {
-            'addr': self.format_string % query,
+            'addr': query,
         }
         if self.api_key:
             params['key'] = self.api_key

--- a/geopy/geocoders/geocodefarm.py
+++ b/geopy/geocoders/geocodefarm.py
@@ -45,18 +45,12 @@ class GeocodeFarm(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
-            .. versionadded:: 1.14.0
-
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
-
-            .. versionadded:: 1.14.0
         """
         super().__init__(
             scheme=scheme,

--- a/geopy/geocoders/geolake.py
+++ b/geopy/geocoders/geolake.py
@@ -41,15 +41,9 @@ class Geolake(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
     ):
         """
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str api_key: The API key required by Geolake
             to perform geocoding requests. You can get your key here:
@@ -76,7 +70,6 @@ class Geolake(Geocoder):
 
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -140,7 +133,7 @@ class Geolake(Geocoder):
         else:
             params = {
                 'api_key': self.api_key,
-                'q': self.format_string % query,
+                'q': query,
             }
 
         if not country_codes:

--- a/geopy/geocoders/geolake.py
+++ b/geopy/geocoders/geolake.py
@@ -1,3 +1,4 @@
+import collections.abc
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -128,7 +129,7 @@ class Geolake(Geocoder):
 
         """
 
-        if isinstance(query, dict):
+        if isinstance(query, collections.abc.Mapping):
             params = {
                 key: val
                 for key, val

--- a/geopy/geocoders/geolake.py
+++ b/geopy/geocoders/geolake.py
@@ -16,8 +16,6 @@ class Geolake(Geocoder):
 
     Terms of Service at:
         https://geolake.com/terms-of-use
-
-    .. versionadded:: 1.18.0
     """
 
     structured_query_params = {
@@ -103,10 +101,6 @@ class Geolake(Geocoder):
             is a 2 character code as defined by the ISO-3166-1 alpha-2
             standard (e.g. ``FR``). Multiple countries can be specified with
             a Python list.
-
-            .. versionchanged:: 1.19.0
-                Previously only a Python list of countries could be specified.
-                Now a single country as a string can be specified as well.
 
         :type country_codes: str or list
 

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -66,13 +66,9 @@ class GeoNames(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`. Note that
@@ -81,8 +77,6 @@ class GeoNames(Geocoder):
             :attr:`geopy.geocoders.options.default_scheme` is not respected.
             This parameter is present to make it possible to switch to
             `https` once GeoNames adds support for it.
-
-            .. versionadded:: 1.18.0
         """
         super().__init__(
             scheme=scheme,
@@ -146,15 +140,10 @@ class GeoNames(Geocoder):
         :param country: Limit records to the specified countries.
             Two letter country code ISO-3166 (e.g. ``FR``). Might be
             a single string or a list of strings.
-
-            .. versionadded:: 1.19.0
-
         :type country: str or list
 
         :param str country_bias: Records from the country_bias are listed first.
             Two letter country code ISO-3166.
-
-            .. versionadded:: 1.19.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
@@ -197,8 +186,6 @@ class GeoNames(Geocoder):
         """
         Return an address by location point.
 
-            .. versionadded:: 1.2.0
-
         :param query: The coordinates for which you wish to obtain the
             closest human-readable addresses.
         :type query: :class:`geopy.point.Point`, list or tuple of ``(latitude,
@@ -207,12 +194,6 @@ class GeoNames(Geocoder):
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
-            .. versionchanged:: 1.14.0
-               Default value for ``exactly_one`` was ``False``, which differs
-               from the conventional default across geopy. Please always pass
-               this argument explicitly, otherwise you would get a warning.
-               In geopy 2.0 the default value will become ``True``.
-
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
             exception. Set this only if you wish to override, on this call
@@ -220,22 +201,16 @@ class GeoNames(Geocoder):
 
         :param str feature_code: A GeoNames feature code
 
-            .. versionadded:: 1.18.0
-
         :param str lang: language of the returned ``name`` element (the pseudo
             language code 'local' will return it in local language)
             Full list of supported languages can be found here:
             https://www.geonames.org/countries/
-
-            .. versionadded:: 1.18.0
 
         :param str find_nearby_type: A flag to switch between different
             GeoNames API endpoints. The default value is ``findNearbyPlaceName``
             which returns the closest populated place. Another currently
             implemented option is ``findNearby`` which returns
             the closest toponym for the lat/lng query.
-
-            .. versionadded:: 1.18.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
@@ -315,8 +290,6 @@ class GeoNames(Geocoder):
         GeoNames always returns a timezone: if the point being queried
         doesn't have an assigned Olson timezone id, a ``pytz.FixedOffset``
         timezone is used to produce the :class:`geopy.timezone.Timezone`.
-
-        .. versionadded:: 1.18.0
 
         :param query: The coordinates for which you want a timezone.
         :type query: :class:`geopy.point.Point`, list or tuple of (latitude,

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -37,7 +37,6 @@ class GeoNames(Geocoder):
 
     def __init__(
             self,
-            country_bias=None,
             username=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -46,12 +45,6 @@ class GeoNames(Geocoder):
             scheme='http',
     ):
         """
-        :param str country_bias: Records from the country_bias are listed first.
-            Two letter country code ISO-3166.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `country_bias` instead.
 
         :param str username: GeoNames username, required. Sign up here:
             http://www.geonames.org/login
@@ -91,16 +84,7 @@ class GeoNames(Geocoder):
                 'http://www.geonames.org/login'
             )
         self.username = username
-        if country_bias is not None:
-            warnings.warn(
-                '`country_bias` argument of the %(cls)s.__init__ '
-                'is deprecated and will be removed in geopy 2.0. Use '
-                '%(cls)s.geocode(country_bias=%(value)r) instead.'
-                % dict(cls=type(self).__name__, value=country_bias),
-                DeprecationWarning,
-                stacklevel=2
-            )
-        self.country_bias = country_bias
+
         domain = 'api.geonames.org'
         self.api = (
             "%s://%s%s" % (self.scheme, domain, self.geocode_path)
@@ -152,8 +136,6 @@ class GeoNames(Geocoder):
             ('username', self.username),
         ]
 
-        if country_bias is None:
-            country_bias = self.country_bias
         if country_bias:
             params.append(('countryBias', country_bias))
 

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -1,4 +1,3 @@
-import warnings
 from urllib.parse import urlencode
 
 from geopy.exc import (
@@ -177,7 +176,7 @@ class GeoNames(Geocoder):
     def reverse(
             self,
             query,
-            exactly_one=DEFAULT_SENTINEL,
+            exactly_one=True,
             timeout=DEFAULT_SENTINEL,
             feature_code=None,
             lang=None,
@@ -216,13 +215,6 @@ class GeoNames(Geocoder):
             ``exactly_one=False``.
 
         """
-        if exactly_one is DEFAULT_SENTINEL:
-            warnings.warn('%s.reverse: default value for `exactly_one` '
-                          'argument will become True in geopy 2.0. '
-                          'Specify `exactly_one=False` as the argument '
-                          'explicitly to get rid of this warning.' % type(self).__name__,
-                          DeprecationWarning, stacklevel=2)
-            exactly_one = False
 
         try:
             lat, lng = self._coerce_point_to_string(query).split(',')

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -43,7 +43,6 @@ class GeoNames(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
             scheme='http',
     ):
@@ -69,13 +68,6 @@ class GeoNames(Geocoder):
 
             .. versionadded:: 1.12.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. versionadded:: 1.14.0
-
-            .. deprecated:: 1.22.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
@@ -93,7 +85,6 @@ class GeoNames(Geocoder):
             .. versionadded:: 1.18.0
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -169,7 +160,7 @@ class GeoNames(Geocoder):
             ``exactly_one=False``.
         """
         params = [
-            ('q', self.format_string % query),
+            ('q', query),
             ('username', self.username),
         ]
 

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -41,7 +41,6 @@ class GoogleV3(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
             channel='',
     ):
@@ -76,13 +75,6 @@ class GoogleV3(Geocoder):
 
             .. versionadded:: 1.12.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. versionadded:: 1.14.0
-
-            .. deprecated:: 1.22.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
@@ -94,7 +86,6 @@ class GoogleV3(Geocoder):
             .. versionadded:: 1.12.0
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -259,7 +250,7 @@ class GoogleV3(Geocoder):
             params['place_id'] = place_id
 
         if query is not None:
-            params['address'] = self.format_string % query
+            params['address'] = query
 
         if query is None and place_id is None and not components:
             raise ValueError('Either `query` or `components` or `place_id` '

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -239,18 +239,6 @@ class GoogleV3(Geocoder):
         if self.api_key:
             params['key'] = self.api_key
         if bounds:
-            if len(bounds) == 4:
-                warnings.warn(
-                    'GoogleV3 `bounds` format of '
-                    '`[latitude, longitude, latitude, longitude]` is now '
-                    'deprecated and will not be supported in geopy 2.0. '
-                    'Use `[Point(latitude, longitude), Point(latitude, longitude)]` '
-                    'instead.',
-                    DeprecationWarning,
-                    stacklevel=2
-                )
-                lat1, lon1, lat2, lon2 = bounds
-                bounds = [[lat1, lon1], [lat2, lon2]]
             params['bounds'] = self._format_bounding_box(
                 bounds, "%(lat1)s,%(lon1)s|%(lat2)s,%(lon2)s")
         if region:

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -73,17 +73,11 @@ class GoogleV3(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
-            .. versionadded:: 1.14.0
-
         :param str channel: If using premier, the channel identifier.
-
-            .. versionadded:: 1.12.0
         """
         super().__init__(
             scheme=scheme,
@@ -184,9 +178,6 @@ class GoogleV3(Geocoder):
                 >>> g.geocode(components={"city": "Paris", "country": "FR"})
                 Location(France, (46.227638, 2.213749, 0.0))
 
-            .. versionchanged:: 1.14.0
-               Now ``query`` is optional if ``components`` param is set.
-
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
@@ -201,12 +192,6 @@ class GoogleV3(Geocoder):
             to bias geocode results more prominently.
             Example: ``[Point(22, 180), Point(-22, -180)]``.
 
-            .. versionchanged:: 1.17.0
-                Previously the only supported format for bounds was a
-                list like ``[latitude, longitude, latitude, longitude]``.
-                This format is now deprecated in favor of a list/tuple
-                of a pair of geopy Points and will be removed in geopy 2.0.
-
         :param str region: The region code, specified as a ccTLD
             ("top-level domain") two-character value.
 
@@ -220,15 +205,10 @@ class GoogleV3(Geocoder):
 
                 >>> [('administrative_area', 'VA'), ('administrative_area', 'Arlington')]
 
-            .. versionchanged:: 1.22.0
-                Added support for a list of tuples.
-
         :param str place_id: Retrieve a Location using a Place ID.
             Cannot be not used with ``query`` or ``bounds`` parameters.
 
                 >>> g.geocode(place_id='ChIJOcfP0Iq2j4ARDrXUa7ZWs34')
-
-            .. versionadded:: 1.19.0
 
         :param str language: The language in which to return results.
 
@@ -309,12 +289,6 @@ class GoogleV3(Geocoder):
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
-            .. versionchanged:: 1.14.0
-               Default value for ``exactly_one`` was ``False``, which differs
-               from the conventional default across geopy. Please always pass
-               this argument explicitly, otherwise you would get a warning.
-               In geopy 2.0 the default value will become ``True``.
-
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
             exception. Set this only if you wish to override, on this call
@@ -359,12 +333,8 @@ class GoogleV3(Geocoder):
         """
         Find the timezone a point in `query` was in for a specified `at_time`.
 
-        .. versionadded:: 1.18.0
-
-        .. versionchanged:: 1.18.1
-           Previously a :class:`KeyError` was raised for a point without
-           an assigned Olson timezone id (e.g. for Antarctica).
-           Now this method returns None for such requests.
+        `None` will be returned for points without an assigned
+        Olson timezone id (e.g. for Antarctica).
 
         :param query: The coordinates for which you want a timezone.
         :type query: :class:`geopy.point.Point`, list or tuple of (latitude,

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -273,7 +273,7 @@ class GoogleV3(Geocoder):
     def reverse(
             self,
             query,
-            exactly_one=DEFAULT_SENTINEL,
+            exactly_one=True,
             timeout=DEFAULT_SENTINEL,
             language=None,
             sensor=False,
@@ -302,13 +302,6 @@ class GoogleV3(Geocoder):
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
-        if exactly_one is DEFAULT_SENTINEL:
-            warnings.warn('%s.reverse: default value for `exactly_one` '
-                          'argument will become True in geopy 2.0. '
-                          'Specify `exactly_one=False` as the argument '
-                          'explicitly to get rid of this warning.' % type(self).__name__,
-                          DeprecationWarning, stacklevel=2)
-            exactly_one = False
 
         params = {
             'latlng': self._coerce_point_to_string(query),

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -5,7 +5,6 @@ import hmac
 import warnings
 from calendar import timegm
 from datetime import datetime
-from numbers import Number
 from urllib.parse import urlencode
 
 from geopy.exc import ConfigurationError, GeocoderQueryError, GeocoderQuotaExceeded
@@ -370,15 +369,6 @@ class GoogleV3(Geocoder):
     def _normalize_timezone_at_time(self, at_time):
         if at_time is None:
             timestamp = timegm(datetime.utcnow().utctimetuple())
-        elif isinstance(at_time, Number):
-            warnings.warn(
-                'Support for `at_time` as int/float is deprecated '
-                'and will be removed in geopy 2.0. '
-                'Pass a `datetime.datetime` instance instead.',
-                DeprecationWarning,
-                stacklevel=3
-            )
-            timestamp = at_time
         elif isinstance(at_time, datetime):
             # Naive datetimes are silently treated as UTC.
             # Timezone-aware datetimes are handled correctly.

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -364,57 +364,6 @@ class GoogleV3(Geocoder):
             self._call_geocoder(url, timeout=timeout), exactly_one
         )
 
-    def timezone(self, location, at_time=None, timeout=DEFAULT_SENTINEL):
-        """
-        Find the timezone a `location` was in for a specified `at_time`,
-        and return a pytz timezone object.
-
-        .. versionadded:: 1.2.0
-
-        .. deprecated:: 1.18.0
-           Use :meth:`GoogleV3.reverse_timezone` instead. This method
-           will be removed in geopy 2.0.
-
-        .. versionchanged:: 1.18.1
-           Previously a :class:`KeyError` was raised for a point without
-           an assigned Olson timezone id (e.g. for Antarctica).
-           Now this method returns None for such requests.
-
-        :param location: The coordinates for which you want a timezone.
-        :type location: :class:`geopy.point.Point`, list or tuple of (latitude,
-            longitude), or string as "%(latitude)s, %(longitude)s"
-
-        :param at_time: The time at which you want the timezone of this
-            location. This is optional, and defaults to the time that the
-            function is called in UTC. Timezone-aware datetimes are correctly
-            handled and naive datetimes are silently treated as UTC.
-
-            .. versionchanged:: 1.18.0
-               Previously this parameter accepted raw unix timestamp as
-               int or float. This is now deprecated in favor of datetimes
-               and support for numbers will be removed in geopy 2.0.
-
-        :type at_time: :class:`datetime.datetime` or None
-
-        :param int timeout: Time, in seconds, to wait for the geocoding service
-            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
-            exception. Set this only if you wish to override, on this call
-            only, the value set during the geocoder's initialization.
-
-        :rtype: ``None`` or pytz timezone. See :func:`pytz.timezone`.
-        """
-
-        warnings.warn('%(cls)s.timezone method is deprecated in favor of '
-                      '%(cls)s.reverse_timezone, which returns geopy.Timezone '
-                      'object containing pytz timezone and a raw response '
-                      'instead of just pytz timezone. This method will '
-                      'be removed in geopy 2.0.' % dict(cls=type(self).__name__),
-                      DeprecationWarning, stacklevel=2)
-        timezone = self.reverse_timezone(location, at_time, timeout)
-        if timezone is None:
-            return None
-        return timezone.pytz_timezone
-
     def reverse_timezone(self, query, at_time=None, timeout=DEFAULT_SENTINEL):
         """
         Find the timezone a point in `query` was in for a specified `at_time`.

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -1,4 +1,5 @@
 import base64
+import collections.abc
 import hashlib
 import hmac
 import warnings
@@ -156,9 +157,12 @@ class GoogleV3(Geocoder):
         """
         component_items = []
 
-        if isinstance(components, dict):
+        if isinstance(components, collections.abc.Mapping):
             component_items = components.items()
-        elif isinstance(components, list):
+        elif (
+            isinstance(components, collections.abc.Sequence)
+            and not isinstance(components, (str, bytes))
+        ):
             component_items = components
         else:
             raise ValueError(

--- a/geopy/geocoders/here.py
+++ b/geopy/geocoders/here.py
@@ -45,7 +45,6 @@ class Here(Geocoder):
             app_id=None,
             app_code=None,
             apikey=None,
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -79,11 +78,6 @@ class Here(Geocoder):
 
             .. versionadded:: 1.21.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
-
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
 
@@ -101,7 +95,6 @@ class Here(Geocoder):
             See :attr:`geopy.geocoders.options.default_ssl_context`.
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -212,7 +205,7 @@ class Here(Geocoder):
                 if key in self.structured_query_params
             }
         else:
-            params = {'searchtext': self.format_string % query}
+            params = {'searchtext': query}
         if bbox:
             params['bbox'] = self._format_bounding_box(
                 bbox, "%(lat2)s,%(lon1)s;%(lat1)s,%(lon2)s")

--- a/geopy/geocoders/here.py
+++ b/geopy/geocoders/here.py
@@ -22,8 +22,6 @@ class Here(Geocoder):
 
     Documentation at:
         https://developer.here.com/documentation/geocoder/
-
-    .. versionadded:: 1.15.0
     """
 
     structured_query_params = {
@@ -75,8 +73,6 @@ class Here(Geocoder):
             More authentication details are available at
             https://developer.here.com/blog/announcing-two-new-authentication-types.
             See https://developer.here.com/authenticationpage.
-
-            .. versionadded:: 1.21.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.

--- a/geopy/geocoders/here.py
+++ b/geopy/geocoders/here.py
@@ -55,7 +55,7 @@ class Here(Geocoder):
             be replaced with APIKEY.
             See https://developer.here.com/authenticationpage.
 
-            .. deprecated:: 1.21.0
+            .. attention::
                 App ID and App Code are being replaced by API Keys and OAuth 2.0
                 by HERE. Consider getting an ``apikey`` instead of using
                 ``app_id`` and ``app_code``.
@@ -64,7 +64,10 @@ class Here(Geocoder):
             eventually be replaced with APIKEY.
             See https://developer.here.com/authenticationpage.
 
-            .. deprecated:: 1.21.0
+            .. attention::
+                App ID and App Code are being replaced by API Keys and OAuth 2.0
+                by HERE. Consider getting an ``apikey`` instead of using
+                ``app_id`` and ``app_code``.
 
         :param str apikey: Should be a valid HERE Maps APIKEY. These keys were
             introduced in December 2019 and will eventually replace the legacy

--- a/geopy/geocoders/here.py
+++ b/geopy/geocoders/here.py
@@ -1,3 +1,4 @@
+import collections.abc
 import warnings
 from urllib.parse import urlencode
 
@@ -203,7 +204,7 @@ class Here(Geocoder):
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
-        if isinstance(query, dict):
+        if isinstance(query, collections.abc.Mapping):
             params = {
                 key: val
                 for key, val

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -1,5 +1,5 @@
 import base64
-import warnings
+
 import xml.etree.ElementTree as ET
 from urllib.parse import urlencode
 from urllib.request import Request
@@ -230,7 +230,7 @@ class IGNFrance(Geocoder):
             reverse_geocode_preference=('StreetAddress', ),
             maximum_responses=25,
             filtering='',
-            exactly_one=DEFAULT_SENTINEL,
+            exactly_one=True,
             timeout=DEFAULT_SENTINEL,
     ):
         """
@@ -264,13 +264,6 @@ class IGNFrance(Geocoder):
             ``exactly_one=False``.
 
         """
-        if exactly_one is DEFAULT_SENTINEL:
-            warnings.warn('%s.reverse: default value for `exactly_one` '
-                          'argument will become True in geopy 2.0. '
-                          'Specify `exactly_one=False` as the argument '
-                          'explicitly to get rid of this warning.' % type(self).__name__,
-                          DeprecationWarning, stacklevel=2)
-            exactly_one = False
 
         sub_request = """
             <ReverseGeocodeRequest>

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -83,14 +83,9 @@ class IGNFrance(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
-
         """
         super().__init__(
             scheme=scheme,
@@ -259,12 +254,6 @@ class IGNFrance(Geocoder):
 
         :param bool exactly_one: Return one result or a list of results, if
             available.
-
-            .. versionchanged:: 1.14.0
-               Default value for ``exactly_one`` was ``False``, which differs
-               from the conventional default across geopy. Please always pass
-               this argument explicitly, otherwise you would get a warning.
-               In geopy 2.0 the default value will become ``True``.
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -1,5 +1,4 @@
 import base64
-
 import xml.etree.ElementTree as ET
 from urllib.parse import urlencode
 from urllib.request import Request

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -48,7 +48,6 @@ class IGNFrance(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
     ):
         """
@@ -86,13 +85,6 @@ class IGNFrance(Geocoder):
 
             .. versionadded:: 1.12.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. versionadded:: 1.14.0
-
-            .. deprecated:: 1.22.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
@@ -101,7 +93,6 @@ class IGNFrance(Geocoder):
 
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -175,8 +166,6 @@ class IGNFrance(Geocoder):
             ``exactly_one=False``.
 
         """
-
-        query = self.format_string % query
 
         # Check if acceptable query type
         if query_type not in ['PositionOfInterest',

--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -22,7 +22,6 @@ class MapBox(Geocoder):
     def __init__(
             self,
             api_key,
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -34,11 +33,6 @@ class MapBox(Geocoder):
         :param str api_key: The API key required by Mapbox to perform
             geocoding requests. API keys are managed through Mapox's account
             page (https://www.mapbox.com/account/access-tokens).
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -59,7 +53,6 @@ class MapBox(Geocoder):
         :param str domain: base api domain for mapbox
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -143,7 +136,6 @@ class MapBox(Geocoder):
         params = {}
 
         params['access_token'] = self.api_key
-        query = self.format_string % query
         if bbox:
             params['bbox'] = self._format_bounding_box(
                 bbox, "%(lon1)s,%(lat1)s,%(lon2)s,%(lat2)s")

--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -13,8 +13,6 @@ class MapBox(Geocoder):
 
     Documentation at:
         https://www.mapbox.com/api-documentation/
-
-    .. versionadded:: 1.17.0
     """
 
     api_path = '/geocoding/v5/mapbox.places/%(query)s.json/'
@@ -91,18 +89,10 @@ class MapBox(Geocoder):
         """
         Return a location point by address.
 
-        .. versionchanged:: 1.20.0
-            Previously due to a bug the resulting :class:`geopy.location.Location`'s
-            ``raw`` attribute contained a single string instead of a full
-            service response.
-
         :param str query: The address or query you wish to geocode.
 
         :param bool exactly_one: Return one result or a list of results, if
             available.
-
-            .. versionchanged:: 1.20.0
-                Previously due to a bug this parameter wasn't respected.
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
@@ -117,10 +107,6 @@ class MapBox(Geocoder):
         :param country: Country to filter result in form of
             ISO 3166-1 alpha-2 country code (e.g. ``FR``).
             Might be a Python list of strings.
-
-            .. versionchanged:: 1.19.0
-                Previously only a single string could be specified.
-                Now a Python list of individual countries is supported.
 
         :type country: str or list
 
@@ -168,11 +154,6 @@ class MapBox(Geocoder):
     ):
         """
         Return an address by location point.
-
-        .. versionchanged:: 1.20.0
-            Previously due to a bug the resulting :class:`geopy.location.Location`'s
-            ``raw`` attribute contained a single string instead of a full
-            service response.
 
         :param query: The coordinates for which you wish to obtain the
             closest human-readable addresses.

--- a/geopy/geocoders/mapquest.py
+++ b/geopy/geocoders/mapquest.py
@@ -19,8 +19,6 @@ class MapQuest(Geocoder):
       which is based on Open data from OpenStreetMap.
     - :class:`geopy.geocoders.MapQuest` (this class) MapQuest's own API
       which is based on Licensed data.
-
-    .. versionadded:: 1.22.0
     """
 
     geocode_path = '/geocoding/v1/address'

--- a/geopy/geocoders/mapquest.py
+++ b/geopy/geocoders/mapquest.py
@@ -29,7 +29,6 @@ class MapQuest(Geocoder):
     def __init__(
             self,
             api_key,
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -41,11 +40,6 @@ class MapQuest(Geocoder):
         :param str api_key: The API key required by Mapquest to perform
             geocoding requests. API keys are managed through MapQuest's "Manage Keys"
             page (https://developer.mapquest.com/user/me/apps).
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -66,7 +60,6 @@ class MapQuest(Geocoder):
         :param str domain: base api domain for mapquest
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -152,7 +145,7 @@ class MapQuest(Geocoder):
         """
         params = {}
         params['key'] = self.api_key
-        params['location'] = self.format_string % query
+        params['location'] = query
 
         if limit is not None:
             params['maxResults'] = limit

--- a/geopy/geocoders/maptiler.py
+++ b/geopy/geocoders/maptiler.py
@@ -13,8 +13,6 @@ class MapTiler(Geocoder):
 
     Documentation at:
         https://cloud.maptiler.com/geocoding/ (requires sign-up)
-
-    .. versionadded:: 1.22.0
     """
 
     api_path = '/geocoding/%(query)s.json'

--- a/geopy/geocoders/maptiler.py
+++ b/geopy/geocoders/maptiler.py
@@ -22,7 +22,6 @@ class MapTiler(Geocoder):
     def __init__(
             self,
             api_key,
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -34,11 +33,6 @@ class MapTiler(Geocoder):
         :param str api_key: The API key required by Maptiler to perform
             geocoding requests. API keys are managed through Maptiler's account
             page (https://cloud.maptiler.com/account/keys).
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -59,7 +53,6 @@ class MapTiler(Geocoder):
         :param str domain: base api domain for Maptiler
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -129,7 +122,7 @@ class MapTiler(Geocoder):
         """
         params = {'key': self.api_key}
 
-        query = self.format_string % query
+        query = query
         if bbox:
             params['bbox'] = self._format_bounding_box(
                 bbox, "%(lon1)s,%(lat1)s,%(lon2)s,%(lat2)s")

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -151,7 +151,7 @@ class OpenCage(Geocoder):
             self,
             query,
             language=None,
-            exactly_one=DEFAULT_SENTINEL,
+            exactly_one=True,
             timeout=DEFAULT_SENTINEL,
     ):
         """
@@ -176,13 +176,6 @@ class OpenCage(Geocoder):
             ``exactly_one=False``.
 
         """
-        if exactly_one is DEFAULT_SENTINEL:
-            warnings.warn('%s.reverse: default value for `exactly_one` '
-                          'argument will become True in geopy 2.0. '
-                          'Specify `exactly_one=False` as the argument '
-                          'explicitly to get rid of this warning.' % type(self).__name__,
-                          DeprecationWarning, stacklevel=2)
-            exactly_one = False
 
         params = {
             'key': self.api_key,

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -28,7 +28,6 @@ class OpenCage(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
     ):
         """
@@ -54,13 +53,6 @@ class OpenCage(Geocoder):
 
             .. versionadded:: 1.12.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. versionadded:: 1.14.0
-
-            .. deprecated:: 1.22.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
@@ -69,7 +61,6 @@ class OpenCage(Geocoder):
 
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -141,7 +132,7 @@ class OpenCage(Geocoder):
         """
         params = {
             'key': self.api_key,
-            'q': self.format_string % query,
+            'q': query,
         }
         if bounds:
             if isinstance(bounds, str):

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -14,8 +14,6 @@ class OpenCage(Geocoder):
 
     Documentation at:
         https://opencagedata.com/api
-
-    .. versionadded:: 1.1.0
     """
 
     api_path = '/geocode/v1/json'
@@ -51,14 +49,9 @@ class OpenCage(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
-
         """
         super().__init__(
             scheme=scheme,
@@ -100,22 +93,10 @@ class OpenCage(Geocoder):
             coordinate points -- corners of a bounding box.
             Example: ``[Point(22, 180), Point(-22, -180)]``.
 
-            .. versionchanged:: 1.17.0
-                Previously the only supported format for bounds was a
-                string of ``"longitude,latitude,longitude,latitude"``.
-                This format is now deprecated in favor of a list/tuple
-                of a pair of geopy Points and will be removed in geopy 2.0.
-
         :param country: Restricts the results to the specified
             country or countries. The country code is a 2 character code as
             defined by the ISO 3166-1 Alpha 2 standard (e.g. ``fr``).
             Might be a Python list of strings.
-
-            .. versionchanged:: 1.19.0
-                This parameter didn't seem to be respected previously.
-                Also, previously only a single string could be specified.
-                Now a Python list of individual countries is supported.
-
         :type country: str or list
 
         :param bool exactly_one: Return one result or a list of results, if
@@ -185,12 +166,6 @@ class OpenCage(Geocoder):
 
         :param bool exactly_one: Return one result or a list of results, if
             available.
-
-            .. versionchanged:: 1.14.0
-               Default value for ``exactly_one`` was ``False``, which differs
-               from the conventional default across geopy. Please always pass
-               this argument explicitly, otherwise you would get a warning.
-               In geopy 2.0 the default value will become ``True``.
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -1,4 +1,3 @@
-import warnings
 from urllib.parse import urlencode
 
 from geopy.exc import GeocoderQueryError, GeocoderQuotaExceeded
@@ -116,18 +115,6 @@ class OpenCage(Geocoder):
             'q': query,
         }
         if bounds:
-            if isinstance(bounds, str):
-                warnings.warn(
-                    'OpenCage `bounds` format of '
-                    '`"longitude,latitude,longitude,latitude"` is now '
-                    'deprecated and will not be supported in geopy 2.0. '
-                    'Use `[Point(latitude, longitude), Point(latitude, longitude)]` '
-                    'instead.',
-                    DeprecationWarning,
-                    stacklevel=2
-                )
-                lon1, lat1, lon2, lat2 = bounds.split(',')
-                bounds = [[lat1, lon1], [lat2, lon2]]
             params['bounds'] = self._format_bounding_box(
                 bounds, "%(lon1)s,%(lat1)s,%(lon2)s,%(lat2)s")
         if language:

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -17,9 +17,6 @@ class OpenMapQuest(Nominatim):
       which is based on Open data from OpenStreetMap.
     - :class:`geopy.geocoders.MapQuest` MapQuest's own API which is based on
       Licensed data.
-
-    .. versionchanged:: 1.17.0
-       OpenMapQuest now extends the Nominatim class.
     """
 
     geocode_path = '/nominatim/v1/search'
@@ -42,16 +39,10 @@ class OpenMapQuest(Nominatim):
 
         :param str api_key: API key provided by MapQuest, required.
 
-            .. versionchanged:: 1.12.0
-               OpenMapQuest now requires an API key. Using an empty key will
-               result in a :class:`geopy.exc.ConfigurationError`.
-
         :type view_box: list or tuple of 2 items of :class:`geopy.point.Point` or
             ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
         :param view_box: Coordinates to restrict search within.
             Example: ``[Point(22, 180), Point(-22, -180)]``.
-
-            .. versionadded:: 1.17.0
 
             .. deprecated:: 1.19.0
                 This argument will be removed in geopy 2.0.
@@ -60,8 +51,6 @@ class OpenMapQuest(Nominatim):
         :param bool bounded: Restrict the results to only items contained
             within the bounding view_box.
 
-            .. versionadded:: 1.17.0
-
             .. deprecated:: 1.19.0
                 This argument will be removed in geopy 2.0.
                 Use `geocode`'s `bounded` instead.
@@ -69,8 +58,6 @@ class OpenMapQuest(Nominatim):
         :type country_bias: str or list
         :param country_bias: Limit search results to a specific country.
             This param sets a default value for the `geocode`'s ``country_codes``.
-
-            .. versionadded:: 1.17.0
 
             .. deprecated:: 1.19.0
                 This argument will be removed in geopy 2.0.
@@ -85,21 +72,15 @@ class OpenMapQuest(Nominatim):
         :param str domain: Domain where the target Nominatim service
             is hosted.
 
-            .. versionadded:: 1.17.0
-
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
 
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
         """
         super().__init__(
             view_box=view_box,

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -28,7 +28,6 @@ class OpenMapQuest(Nominatim):
     def __init__(
             self,
             api_key=None,
-            format_string=None,
             view_box=None,
             bounded=None,
             country_bias=None,
@@ -46,11 +45,6 @@ class OpenMapQuest(Nominatim):
             .. versionchanged:: 1.12.0
                OpenMapQuest now requires an API key. Using an empty key will
                result in a :class:`geopy.exc.ConfigurationError`.
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :type view_box: list or tuple of 2 items of :class:`geopy.point.Point` or
             ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
@@ -108,7 +102,6 @@ class OpenMapQuest(Nominatim):
             .. versionadded:: 1.14.0
         """
         super().__init__(
-            format_string=format_string,
             view_box=view_box,
             bounded=bounded,
             country_bias=country_bias,

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -25,9 +25,6 @@ class OpenMapQuest(Nominatim):
     def __init__(
             self,
             api_key=None,
-            view_box=None,
-            bounded=None,
-            country_bias=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             domain='open.mapquestapi.com',
@@ -38,30 +35,6 @@ class OpenMapQuest(Nominatim):
         """
 
         :param str api_key: API key provided by MapQuest, required.
-
-        :type view_box: list or tuple of 2 items of :class:`geopy.point.Point` or
-            ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
-        :param view_box: Coordinates to restrict search within.
-            Example: ``[Point(22, 180), Point(-22, -180)]``.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `viewbox` instead.
-
-        :param bool bounded: Restrict the results to only items contained
-            within the bounding view_box.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `bounded` instead.
-
-        :type country_bias: str or list
-        :param country_bias: Limit search results to a specific country.
-            This param sets a default value for the `geocode`'s ``country_codes``.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `country_codes` instead.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -83,9 +56,6 @@ class OpenMapQuest(Nominatim):
             See :attr:`geopy.geocoders.options.default_ssl_context`.
         """
         super().__init__(
-            view_box=view_box,
-            bounded=bounded,
-            country_bias=country_bias,
             timeout=timeout,
             proxies=proxies,
             domain=domain,

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -57,7 +57,6 @@ class Nominatim(Geocoder):
 
     def __init__(
             self,
-            format_string=None,
             view_box=None,
             bounded=None,
             country_bias=None,
@@ -71,10 +70,6 @@ class Nominatim(Geocoder):
             # inheriting classes (e.g. PickPoint).
     ):
         """
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :type view_box: list or tuple of 2 items of :class:`geopy.point.Point` or
             ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
@@ -140,7 +135,6 @@ class Nominatim(Geocoder):
 
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -333,7 +327,7 @@ class Nominatim(Geocoder):
                 if key in self.structured_query_params
             }
         else:
-            params = {'q': self.format_string % query}
+            params = {'q': query}
 
         params.update({
             'format': 'json'

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -53,9 +53,6 @@ class Nominatim(Geocoder):
 
     def __init__(
             self,
-            view_box=None,
-            bounded=None,
-            country_bias=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             domain=_DEFAULT_NOMINATIM_DOMAIN,
@@ -66,30 +63,6 @@ class Nominatim(Geocoder):
             # inheriting classes (e.g. PickPoint).
     ):
         """
-
-        :type view_box: list or tuple of 2 items of :class:`geopy.point.Point` or
-            ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
-        :param view_box: Coordinates to restrict search within.
-            Example: ``[Point(22, 180), Point(-22, -180)]``.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `viewbox` instead.
-
-        :param bool bounded: Restrict the results to only items contained
-            within the bounding view_box.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `bounded` instead.
-
-        :type country_bias: str or list
-        :param country_bias: Limit search results to a specific country.
-            This param sets a default value for the `geocode`'s ``country_codes``.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `country_codes` instead.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -117,39 +90,6 @@ class Nominatim(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
         )
-
-        if country_bias is not None:
-            warnings.warn(
-                '`country_bias` argument of the %(cls)s.__init__ '
-                'is deprecated and will be removed in geopy 2.0. Use '
-                '%(cls)s.geocode(country_codes=%(value)r) instead.'
-                % dict(cls=type(self).__name__, value=country_bias),
-                DeprecationWarning,
-                stacklevel=2
-            )
-        self.country_bias = country_bias
-
-        if view_box is not None:
-            warnings.warn(
-                '`view_box` argument of the %(cls)s.__init__ '
-                'is deprecated and will be removed in geopy 2.0. Use '
-                '%(cls)s.geocode(viewbox=%(value)r) instead.'
-                % dict(cls=type(self).__name__, value=view_box),
-                DeprecationWarning,
-                stacklevel=2
-            )
-        self.view_box = view_box
-
-        if bounded is not None:
-            warnings.warn(
-                '`bounded` argument of the %(cls)s.__init__ '
-                'is deprecated and will be removed in geopy 2.0. Use '
-                '%(cls)s.geocode(bounded=%(value)r) instead.'
-                % dict(cls=type(self).__name__, value=bounded),
-                DeprecationWarning,
-                stacklevel=2
-            )
-        self.bounded = bounded
 
         self.domain = domain.strip('/')
 
@@ -200,7 +140,7 @@ class Nominatim(Geocoder):
             extratags=False,
             country_codes=None,
             viewbox=None,
-            bounded=None,  # TODO: change default value to `False` in geopy 2.0
+            bounded=False,
             featuretype=None,
             namedetails=False,
     ):
@@ -262,7 +202,7 @@ class Nominatim(Geocoder):
             Example: ``[Point(22, 180), Point(-22, -180)]``.
 
         :param bool bounded: Restrict the results to only items contained
-            within the bounding view_box. Defaults to `False`.
+            within the bounding view_box.
 
         :param str featuretype: If present, restrict results to certain type of features.
             Allowed values: `country`, `state`, `city`, `settlement`.
@@ -298,8 +238,6 @@ class Nominatim(Geocoder):
                 raise ValueError("Limit cannot be less than 1")
             params['limit'] = limit
 
-        if viewbox is None:
-            viewbox = self.view_box
         if viewbox:
             if len(viewbox) == 4:
                 warnings.warn(
@@ -316,13 +254,9 @@ class Nominatim(Geocoder):
             params['viewbox'] = self._format_bounding_box(
                 viewbox, "%(lon1)s,%(lat1)s,%(lon2)s,%(lat2)s")
 
-        if bounded is None:
-            bounded = self.bounded
         if bounded:
             params['bounded'] = 1
 
-        if country_codes is None:
-            country_codes = self.country_bias
         if not country_codes:
             country_codes = []
         if isinstance(country_codes, str):

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -1,3 +1,4 @@
+import collections.abc
 import warnings
 from urllib.parse import urlencode
 
@@ -324,7 +325,7 @@ class Nominatim(Geocoder):
 
         """
 
-        if isinstance(query, dict):
+        if isinstance(query, collections.abc.Mapping):
             params = {
                 key: val
                 for key, val
@@ -503,7 +504,7 @@ class Nominatim(Geocoder):
     def _parse_json(self, places, exactly_one):
         if not places:
             return None
-        if not isinstance(places, list):
+        if not isinstance(places, collections.abc.Sequence):
             places = [places]
         if exactly_one:
             return self.parse_code(places[0])

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -1,8 +1,7 @@
 import collections.abc
-import warnings
 from urllib.parse import urlencode
 
-from geopy.exc import GeocoderQueryError
+from geopy.exc import ConfigurationError, GeocoderQueryError
 from geopy.geocoders.base import _DEFAULT_USER_AGENT, DEFAULT_SENTINEL, Geocoder
 from geopy.location import Location
 from geopy.util import logger
@@ -35,8 +34,7 @@ class Nominatim(Geocoder):
        ``Nominatim(user_agent="my-application")`` or by
        overriding the default `user_agent`:
        ``geopy.geocoders.options.default_user_agent = "my-application"``.
-       In geopy 2.0 an exception will be thrown when a custom
-       `user_agent` is not specified.
+       An exception will be thrown if a custom `user_agent` is not specified.
     """
 
     structured_query_params = {
@@ -95,7 +93,7 @@ class Nominatim(Geocoder):
 
         if (self.domain == _DEFAULT_NOMINATIM_DOMAIN
                 and self.headers['User-Agent'] in _REJECTED_USER_AGENTS):
-            warnings.warn(
+            raise ConfigurationError(
                 'Using Nominatim with default or sample `user_agent` "%s" is '
                 'strongly discouraged, as it violates Nominatim\'s ToS '
                 'https://operations.osmfoundation.org/policies/nominatim/ '
@@ -103,11 +101,8 @@ class Nominatim(Geocoder):
                 'Please specify a custom `user_agent` with '
                 '`Nominatim(user_agent="my-application")` or by '
                 'overriding the default `user_agent`: '
-                '`geopy.geocoders.options.default_user_agent = "my-application"`. '
-                'In geopy 2.0 this will become an exception.'
-                % self.headers['User-Agent'],
-                DeprecationWarning,
-                stacklevel=2
+                '`geopy.geocoders.options.default_user_agent = "my-application"`.'
+                % self.headers['User-Agent']
             )
 
         self.api = "%s://%s%s" % (self.scheme, self.domain, self.geocode_path)

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -239,18 +239,6 @@ class Nominatim(Geocoder):
             params['limit'] = limit
 
         if viewbox:
-            if len(viewbox) == 4:
-                warnings.warn(
-                    '%s `viewbox` format of '
-                    '`[longitude, latitude, longitude, latitude]` is now '
-                    'deprecated and will not be supported in geopy 2.0. '
-                    'Use `[Point(latitude, longitude), Point(latitude, longitude)]` '
-                    'instead.' % type(self).__name__,
-                    DeprecationWarning,
-                    stacklevel=2
-                )
-                lon1, lat1, lon2, lat2 = viewbox
-                viewbox = [[lat1, lon1], [lat2, lon2]]
             params['viewbox'] = self._format_bounding_box(
                 viewbox, "%(lon1)s,%(lat1)s,%(lon2)s,%(lat2)s")
 

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -37,10 +37,6 @@ class Nominatim(Geocoder):
        ``geopy.geocoders.options.default_user_agent = "my-application"``.
        In geopy 2.0 an exception will be thrown when a custom
        `user_agent` is not specified.
-
-    .. versionchanged:: 1.16.0
-       A warning is now issued when a default `user_agent` is used
-       which restates the `Attention` block above.
     """
 
     structured_query_params = {
@@ -76,23 +72,12 @@ class Nominatim(Geocoder):
         :param view_box: Coordinates to restrict search within.
             Example: ``[Point(22, 180), Point(-22, -180)]``.
 
-            .. versionchanged:: 1.15.0
-                Previously only a list of stringified coordinates was supported.
-
-            .. versionchanged:: 1.17.0
-                Previously view_box could be a list of 4 strings or numbers
-                in the format of ``[longitude, latitude, longitude, latitude]``.
-                This format is now deprecated in favor of a list/tuple
-                of a pair of geopy Points and will be removed in geopy 2.0.
-
             .. deprecated:: 1.19.0
                 This argument will be removed in geopy 2.0.
                 Use `geocode`'s `viewbox` instead.
 
         :param bool bounded: Restrict the results to only items contained
             within the bounding view_box.
-
-            .. versionadded:: 1.15.0
 
             .. deprecated:: 1.19.0
                 This argument will be removed in geopy 2.0.
@@ -115,24 +100,15 @@ class Nominatim(Geocoder):
         :param str domain: Domain where the target Nominatim service
             is hosted.
 
-            .. versionadded:: 1.8.2
-
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
-
-            .. versionadded:: 1.8.2
 
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
-
         """
         super().__init__(
             scheme=scheme,
@@ -234,13 +210,12 @@ class Nominatim(Geocoder):
         :param query: The address, query or a structured query
             you wish to geocode.
 
-            .. versionchanged:: 1.0.0
-                For a structured query, provide a dictionary whose keys
-                are one of: `street`, `city`, `county`, `state`, `country`, or
-                `postalcode`. For more information, see Nominatim's
-                documentation for `structured requests`:
+            For a structured query, provide a dictionary whose keys
+            are one of: `street`, `city`, `county`, `state`, `country`, or
+            `postalcode`. For more information, see Nominatim's
+            documentation for `structured requests`:
 
-                    https://nominatim.org/release-docs/develop/api/Search
+                https://nominatim.org/release-docs/develop/api/Search
 
         :type query: dict or str
 
@@ -255,8 +230,6 @@ class Nominatim(Geocoder):
         :param int limit: Maximum amount of results to return from Nominatim.
             Unless exactly_one is set to False, limit will always be 1.
 
-            .. versionadded:: 1.13.0
-
         :param bool addressdetails: If you want in *Location.raw* to include
             addressdetails such as city_district, etc set it to True
 
@@ -266,27 +239,19 @@ class Nominatim(Geocoder):
             accept-language string or a simple comma-separated
             list of language codes.
 
-            .. versionadded:: 1.0.0
-
         :param str geometry: If present, specifies whether the geocoding
             service should return the result's geometry in `wkt`, `svg`,
             `kml`, or `geojson` formats. This is available via the
             `raw` attribute on the returned :class:`geopy.location.Location`
             object.
 
-            .. versionadded:: 1.3.0
-
         :param bool extratags: Include additional information in the result if available,
             e.g. wikipedia link, opening hours.
-
-            .. versionadded:: 1.17.0
 
         :param country_codes: Limit search results
             to a specific country (or a list of countries).
             A country_code should be the ISO 3166-1alpha2 code,
             e.g. ``gb`` for the United Kingdom, ``de`` for Germany, etc.
-
-            .. versionadded:: 1.19.0
 
         :type country_codes: str or list
 
@@ -296,23 +261,15 @@ class Nominatim(Geocoder):
         :param viewbox: Coordinates to restrict search within.
             Example: ``[Point(22, 180), Point(-22, -180)]``.
 
-            .. versionadded:: 1.19.0
-
         :param bool bounded: Restrict the results to only items contained
             within the bounding view_box. Defaults to `False`.
-
-            .. versionadded:: 1.19.0
 
         :param str featuretype: If present, restrict results to certain type of features.
             Allowed values: `country`, `state`, `city`, `settlement`.
 
-            .. versionadded:: 1.21.0
-
         :param bool namedetails: If you want in *Location.raw* to include
             namedetails, set it to True. This will be a list of alternative names,
             including language variants, etc.
-
-            .. versionadded:: 1.21.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
@@ -442,18 +399,12 @@ class Nominatim(Geocoder):
             accept-language string or a simple comma-separated
             list of language codes.
 
-            .. versionadded:: 1.0.0
-
         :param bool addressdetails: Whether or not to include address details,
             such as city, county, state, etc. in *Location.raw*
-
-            .. versionadded:: 1.14.0
 
         :param int zoom: Level of detail required for the address,
             an integer in range from 0 (country level) to 18 (building level),
             default is 18.
-
-            .. versionadded:: 1.22.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -29,7 +29,6 @@ class Pelias(Geocoder):
             self,
             domain,
             api_key=None,
-            format_string=None,
             boundary_rect=None,
             country_bias=None,
             timeout=DEFAULT_SENTINEL,
@@ -44,11 +43,6 @@ class Pelias(Geocoder):
         :param str domain: Specify a domain for Pelias API.
 
         :param str api_key: Pelias API key, optional.
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :type boundary_rect: list or tuple of 2 items of :class:`geopy.point.Point`
             or ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
@@ -89,7 +83,6 @@ class Pelias(Geocoder):
 
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -171,7 +164,7 @@ class Pelias(Geocoder):
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
-        params = {'text': self.format_string % query}
+        params = {'text': query}
 
         if self.api_key:
             params.update({

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -1,4 +1,3 @@
-import warnings
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -120,18 +119,6 @@ class Pelias(Geocoder):
             })
 
         if boundary_rect:
-            if len(boundary_rect) == 4:
-                warnings.warn(
-                    '%s `boundary_rect` format of '
-                    '`[longitude, latitude, longitude, latitude]` is now '
-                    'deprecated and will not be supported in geopy 2.0. '
-                    'Use `[Point(latitude, longitude), Point(latitude, longitude)]` '
-                    'instead.' % type(self).__name__,
-                    DeprecationWarning,
-                    stacklevel=2
-                )
-                lon1, lat1, lon2, lat2 = boundary_rect
-                boundary_rect = [[lat1, lon1], [lat2, lon2]]
             lon1, lat1, lon2, lat2 = self._format_bounding_box(
                 boundary_rect, "%(lon1)s,%(lat1)s,%(lon2)s,%(lat2)s").split(',')
             params['boundary.rect.min_lon'] = lon1

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -25,8 +25,6 @@ class Pelias(Geocoder):
             self,
             domain,
             api_key=None,
-            boundary_rect=None,
-            country_bias=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
@@ -39,21 +37,6 @@ class Pelias(Geocoder):
         :param str domain: Specify a domain for Pelias API.
 
         :param str api_key: Pelias API key, optional.
-
-        :type boundary_rect: list or tuple of 2 items of :class:`geopy.point.Point`
-            or ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
-        :param boundary_rect: Coordinates to restrict search within.
-            Example: ``[Point(22, 180), Point(-22, -180)]``.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `boundary_rect` instead.
-
-        :param str country_bias: Bias results to this country (ISO alpha-3).
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `country_bias` instead.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -79,26 +62,7 @@ class Pelias(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
         )
-        if country_bias is not None:
-            warnings.warn(
-                '`country_bias` argument of the %(cls)s.__init__ '
-                'is deprecated and will be removed in geopy 2.0. Use '
-                '%(cls)s.geocode(country_bias=%(value)r) instead.'
-                % dict(cls=type(self).__name__, value=country_bias),
-                DeprecationWarning,
-                stacklevel=2
-            )
-        self.country_bias = country_bias
-        if boundary_rect is not None:
-            warnings.warn(
-                '`boundary_rect` argument of the %(cls)s.__init__ '
-                'is deprecated and will be removed in geopy 2.0. Use '
-                '%(cls)s.geocode(boundary_rect=%(value)r) instead.'
-                % dict(cls=type(self).__name__, value=boundary_rect),
-                DeprecationWarning,
-                stacklevel=2
-            )
-        self.boundary_rect = boundary_rect
+
         self.api_key = api_key
         self.domain = domain.strip('/')
 
@@ -155,8 +119,6 @@ class Pelias(Geocoder):
                 'api_key': self.api_key
             })
 
-        if boundary_rect is None:
-            boundary_rect = self.boundary_rect
         if boundary_rect:
             if len(boundary_rect) == 4:
                 warnings.warn(
@@ -177,8 +139,6 @@ class Pelias(Geocoder):
             params['boundary.rect.max_lon'] = lon2
             params['boundary.rect.max_lat'] = lat2
 
-        if country_bias is None:
-            country_bias = self.country_bias
         if country_bias:
             params['boundary.country'] = country_bias
 

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -16,10 +16,6 @@ class Pelias(Geocoder):
 
     See also :class:`geopy.geocoders.GeocodeEarth` which is a Pelias-based
     service provided by the developers of Pelias itself.
-
-    .. versionchanged:: 1.15.0
-       ``Mapzen`` geocoder has been renamed to ``Pelias``.
-
     """
 
     geocode_path = '/v1/search'
@@ -48,12 +44,6 @@ class Pelias(Geocoder):
             or ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
         :param boundary_rect: Coordinates to restrict search within.
             Example: ``[Point(22, 180), Point(-22, -180)]``.
-
-            .. versionchanged:: 1.17.0
-                Previously boundary_rect could be a list of 4 strings or numbers
-                in the format of ``[longitude, latitude, longitude, latitude]``.
-                This format is now deprecated in favor of a list/tuple
-                of a pair of geopy Points and will be removed in geopy 2.0.
 
             .. deprecated:: 1.19.0
                 This argument will be removed in geopy 2.0.
@@ -147,19 +137,13 @@ class Pelias(Geocoder):
         :param boundary_rect: Coordinates to restrict search within.
             Example: ``[Point(22, 180), Point(-22, -180)]``.
 
-            .. versionadded:: 1.19.0
-
         :param str country_bias: Bias results to this country (ISO alpha-3).
-
-            .. versionadded:: 1.19.0
 
         :param str language: Preferred language in which to return results.
             Either uses standard
             `RFC2616 <http://www.ietf.org/rfc/rfc2616.txt>`_
             accept-language string or a simple comma-separated
             list of language codes.
-
-            .. versionadded:: 1.21.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
@@ -235,8 +219,6 @@ class Pelias(Geocoder):
             `RFC2616 <http://www.ietf.org/rfc/rfc2616.txt>`_
             accept-language string or a simple comma-separated
             list of language codes.
-
-            .. versionadded:: 1.21.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -1,3 +1,4 @@
+import collections.abc
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -136,12 +137,12 @@ class Photon(Geocoder):
             if isinstance(osm_tag, str):
                 params['osm_tag'] = [osm_tag]
             else:
-                if not isinstance(osm_tag, (list, set)):
+                if not isinstance(osm_tag, collections.abc.Iterable):
                     raise ValueError(
-                        "osm_tag must be a string expression or "
-                        "a set/list of string expressions"
+                        "osm_tag must be a string or "
+                        "an iterable of strings"
                     )
-                params['osm_tag'] = osm_tag
+                params['osm_tag'] = list(osm_tag)
         url = "?".join((self.api, urlencode(params, doseq=True)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
         return self._parse_json(

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -49,13 +49,9 @@ class Photon(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
         """
         super().__init__(
             scheme=scheme,
@@ -97,8 +93,6 @@ class Photon(Geocoder):
 
         :param int limit: Limit the number of returned results, defaults to no
             limit.
-
-            .. versionadded:: 1.12.0
 
         :param osm_tag: The expression to filter (include/exclude) by key and/
             or value, str as ``'key:value'`` or list/set of str if multiple
@@ -172,11 +166,8 @@ class Photon(Geocoder):
         :param int limit: Limit the number of returned results, defaults to no
             limit.
 
-            .. versionadded:: 1.12.0
-
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
-
         """
         try:
             lat, lon = self._coerce_point_to_string(query).split(',')

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -24,7 +24,6 @@ class Photon(Geocoder):
 
     def __init__(
             self,
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -33,11 +32,6 @@ class Photon(Geocoder):
             ssl_context=DEFAULT_SENTINEL,
     ):
         """
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -64,7 +58,6 @@ class Photon(Geocoder):
             .. versionadded:: 1.14.0
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -117,7 +110,7 @@ class Photon(Geocoder):
 
         """
         params = {
-            'q': self.format_string % query
+            'q': query
         }
         if limit:
             params['limit'] = int(limit)

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -17,9 +17,6 @@ class PickPoint(Nominatim):
     def __init__(
             self,
             api_key,
-            view_box=None,
-            bounded=None,
-            country_bias=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             domain='api.pickpoint.io',
@@ -31,30 +28,6 @@ class PickPoint(Nominatim):
 
         :param str api_key: PickPoint API key obtained at
             https://pickpoint.io.
-
-        :type view_box: list or tuple of 2 items of :class:`geopy.point.Point` or
-            ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
-        :param view_box: Coordinates to restrict search within.
-            Example: ``[Point(22, 180), Point(-22, -180)]``.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `viewbox` instead.
-
-        :param bool bounded: Restrict the results to only items contained
-            within the bounding view_box.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `bounded` instead.
-
-        :type country_bias: str or list
-        :param country_bias: Limit search results to a specific country.
-            This param sets a default value for the `geocode`'s ``country_codes``.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `country_codes` instead.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -77,9 +50,6 @@ class PickPoint(Nominatim):
         """
 
         super().__init__(
-            view_box=view_box,
-            bounded=bounded,
-            country_bias=country_bias,
             timeout=timeout,
             proxies=proxies,
             domain=domain,

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -20,7 +20,6 @@ class PickPoint(Nominatim):
     def __init__(
             self,
             api_key,
-            format_string=None,
             view_box=None,
             bounded=None,
             country_bias=None,
@@ -35,11 +34,6 @@ class PickPoint(Nominatim):
 
         :param str api_key: PickPoint API key obtained at
             https://pickpoint.io.
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :type view_box: list or tuple of 2 items of :class:`geopy.point.Point` or
             ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
@@ -94,7 +88,6 @@ class PickPoint(Nominatim):
         """
 
         super().__init__(
-            format_string=format_string,
             view_box=view_box,
             bounded=bounded,
             country_bias=country_bias,

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -9,9 +9,6 @@ class PickPoint(Nominatim):
 
     Documentation at:
        https://pickpoint.io/api-reference
-
-    .. versionadded:: 1.13.0
-
     """
 
     geocode_path = '/v1/forward'
@@ -39,12 +36,6 @@ class PickPoint(Nominatim):
             ``(latitude, longitude)`` or ``"%(latitude)s, %(longitude)s"``.
         :param view_box: Coordinates to restrict search within.
             Example: ``[Point(22, 180), Point(-22, -180)]``.
-
-            .. versionchanged:: 1.17.0
-                Previously view_box could be a list of 4 strings or numbers
-                in the format of ``[longitude, latitude, longitude, latitude]``.
-                This format is now deprecated in favor of a list/tuple
-                of a pair of geopy Points and will be removed in geopy 2.0.
 
             .. deprecated:: 1.19.0
                 This argument will be removed in geopy 2.0.
@@ -83,8 +74,6 @@ class PickPoint(Nominatim):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
         """
 
         super().__init__(

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -27,7 +27,6 @@ class LiveAddress(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
     ):
         """
@@ -67,13 +66,6 @@ class LiveAddress(Geocoder):
 
             .. versionadded:: 1.12.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. versionadded:: 1.14.0
-
-            .. deprecated:: 1.22.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
@@ -81,7 +73,6 @@ class LiveAddress(Geocoder):
             .. versionadded:: 1.14.0
         """
         super().__init__(
-            format_string=format_string,
             # The `scheme` argument is present for the legacy reasons only.
             # If a custom value has been passed, it should be validated.
             # Otherwise use `https` instead of the `options.default_scheme`.
@@ -155,7 +146,7 @@ class LiveAddress(Geocoder):
         query = {
             'auth-id': self.auth_id,
             'auth-token': self.auth_token,
-            'street': self.format_string % query,
+            'street': query,
             'candidates': candidates,
         }
         url = '{url}?{query}'.format(url=self.api, query=urlencode(query))

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -1,7 +1,6 @@
-import warnings
 from urllib.parse import urlencode
 
-from geopy.exc import ConfigurationError, GeocoderQuotaExceeded
+from geopy.exc import GeocoderQuotaExceeded
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
 from geopy.location import Location
 from geopy.util import logger
@@ -22,8 +21,6 @@ class LiveAddress(Geocoder):
             self,
             auth_id,
             auth_token,
-            candidates=None,
-            scheme='https',
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
@@ -34,20 +31,6 @@ class LiveAddress(Geocoder):
         :param str auth_id: Valid `Auth ID` from SmartyStreets.
 
         :param str auth_token: Valid `Auth Token` from SmartyStreets.
-
-        :param int candidates: An integer between 1 and 10 indicating the max
-            number of candidate addresses to return if a valid address
-            could be found. Defaults to `1`.
-
-            .. deprecated:: 1.19.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s `candidates` instead.
-
-        :param str scheme: Must be ``https``.
-
-            .. deprecated:: 1.14.0
-               Don't use this parameter, it's going to be removed in
-               geopy 2.0.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -63,33 +46,15 @@ class LiveAddress(Geocoder):
             See :attr:`geopy.geocoders.options.default_ssl_context`.
         """
         super().__init__(
-            # The `scheme` argument is present for the legacy reasons only.
-            # If a custom value has been passed, it should be validated.
-            # Otherwise use `https` instead of the `options.default_scheme`.
-            scheme=(scheme or 'https'),
+            scheme='https',
             timeout=timeout,
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
         )
-        if self.scheme != "https":
-            raise ConfigurationError("LiveAddress now requires `https`.")
         self.auth_id = auth_id
         self.auth_token = auth_token
 
-        if candidates:
-            if not (1 <= candidates <= 10):
-                raise ValueError('candidates must be between 1 and 10')
-        if candidates is not None:
-            warnings.warn(
-                '`candidates` argument of the %(cls)s.__init__ '
-                'is deprecated and will be removed in geopy 2.0. Use '
-                '%(cls)s.geocode(candidates=%(value)r) instead.'
-                % dict(cls=type(self).__name__, value=candidates),
-                DeprecationWarning,
-                stacklevel=2
-            )
-        self.candidates = candidates
         domain = 'api.smartystreets.com'
         self.api = '%s://%s%s' % (self.scheme, domain, self.geocode_path)
 
@@ -98,7 +63,7 @@ class LiveAddress(Geocoder):
             query,
             exactly_one=True,
             timeout=DEFAULT_SENTINEL,
-            candidates=None,  # TODO: change default value to `1` in geopy 2.0
+            candidates=1,
     ):
         """
         Return a location point by address.
@@ -115,21 +80,14 @@ class LiveAddress(Geocoder):
 
         :param int candidates: An integer between 1 and 10 indicating the max
             number of candidate addresses to return if a valid address
-            could be found. Defaults to `1`.
+            could be found.
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
 
-        if candidates is None:
-            candidates = self.candidates
-
-        if candidates is None:
-            candidates = 1  # TODO: move to default args in geopy 2.0.
-
-        if candidates:
-            if not (1 <= candidates <= 10):
-                raise ValueError('candidates must be between 1 and 10')
+        if not (1 <= candidates <= 10):
+            raise ValueError('candidates must be between 1 and 10')
 
         query = {
             'auth-id': self.auth_id,

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -33,8 +33,6 @@ class LiveAddress(Geocoder):
 
         :param str auth_id: Valid `Auth ID` from SmartyStreets.
 
-            .. versionadded:: 1.5.0
-
         :param str auth_token: Valid `Auth Token` from SmartyStreets.
 
         :param int candidates: An integer between 1 and 10 indicating the max
@@ -51,10 +49,6 @@ class LiveAddress(Geocoder):
                Don't use this parameter, it's going to be removed in
                geopy 2.0.
 
-            .. versionchanged:: 1.8.0
-               LiveAddress now requires `https`. Specifying `scheme=http` will
-               result in a :class:`geopy.exc.ConfigurationError`.
-
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
 
@@ -64,13 +58,9 @@ class LiveAddress(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
         """
         super().__init__(
             # The `scheme` argument is present for the legacy reasons only.
@@ -126,8 +116,6 @@ class LiveAddress(Geocoder):
         :param int candidates: An integer between 1 and 10 indicating the max
             number of candidate addresses to return if a valid address
             could be found. Defaults to `1`.
-
-            .. versionadded:: 1.19.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.

--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -23,7 +23,6 @@ class TomTom(Geocoder):
     def __init__(
             self,
             api_key,
-            format_string=None,
             scheme=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -33,11 +32,6 @@ class TomTom(Geocoder):
     ):
         """
         :param str api_key: TomTom API key.
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
@@ -59,7 +53,6 @@ class TomTom(Geocoder):
             is hosted.
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -108,7 +101,6 @@ class TomTom(Geocoder):
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
-        query = self.format_string % query
         params = self._geocode_params(query)
         params['typeahead'] = self._boolean_value(typeahead)
 

--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -13,8 +13,6 @@ class TomTom(Geocoder):
 
     Documentation at:
         https://developer.tomtom.com/search-api/search-api-documentation
-
-    .. versionadded:: 1.15.0
     """
 
     geocode_path = '/search/2/geocode/%(query)s.json'
@@ -149,8 +147,6 @@ class TomTom(Geocoder):
             available for a specific field, default language is used.
             List of supported languages (case-insensitive):
             https://developer.tomtom.com/online-search/online-search-documentation/supported-languages
-
-            .. versionadded:: 1.18.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.

--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -26,7 +26,6 @@ class What3Words(Geocoder):
     def __init__(
             self,
             api_key,
-            scheme='https',
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
@@ -36,14 +35,6 @@ class What3Words(Geocoder):
 
         :param str api_key: Key provided by What3Words
             (https://accounts.what3words.com/register).
-
-        :param str scheme: Must be ``https``.
-
-            .. deprecated:: 1.15.0
-               API v2 requires https. Don't use this parameter,
-               it's going to be removed in geopy 2.0.
-               Scheme other than ``https`` would result in a
-               :class:`geopy.exc.ConfigurationError` being thrown.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -59,17 +50,12 @@ class What3Words(Geocoder):
             See :attr:`geopy.geocoders.options.default_ssl_context`.
         """
         super().__init__(
-            # The `scheme` argument is present for the legacy reasons only.
-            # If a custom value has been passed, it should be validated.
-            # Otherwise use `https` instead of the `options.default_scheme`.
-            scheme=(scheme or 'https'),
+            scheme='https',
             timeout=timeout,
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
         )
-        if self.scheme != "https":
-            raise exc.ConfigurationError("What3Words now requires `https`.")
 
         self.api_key = api_key
         domain = 'api.what3words.com'

--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -14,11 +14,6 @@ class What3Words(Geocoder):
 
     Documentation at:
         https://docs.what3words.com/api/v2/
-
-    .. versionadded:: 1.5.0
-
-    .. versionchanged:: 1.15.0
-       API has been updated to v2.
     """
 
     multiple_word_re = re.compile(
@@ -59,13 +54,9 @@ class What3Words(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
         """
         super().__init__(
             # The `scheme` argument is present for the legacy reasons only.
@@ -114,10 +105,6 @@ class What3Words(Geocoder):
             available. Due to the address scheme there is always exactly one
             result for each `3 words` address, so this parameter is rather
             useless for this geocoder.
-
-            .. versionchanged:: 1.14.0
-               ``exactly_one=False`` now returns a list of a single location.
-               This option wasn't respected before.
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
@@ -203,10 +190,6 @@ class What3Words(Geocoder):
             available. Due to the address scheme there is always exactly one
             result for each `3 words` address, so this parameter is rather
             useless for this geocoder.
-
-            .. versionchanged:: 1.14.0
-               ``exactly_one=False`` now returns a list of a single location.
-               This option wasn't respected before.
 
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`

--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -31,7 +31,6 @@ class What3Words(Geocoder):
     def __init__(
             self,
             api_key,
-            format_string=None,
             scheme='https',
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
@@ -42,11 +41,6 @@ class What3Words(Geocoder):
 
         :param str api_key: Key provided by What3Words
             (https://accounts.what3words.com/register).
-
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. deprecated:: 1.22.0
 
         :param str scheme: Must be ``https``.
 
@@ -74,7 +68,6 @@ class What3Words(Geocoder):
             .. versionadded:: 1.14.0
         """
         super().__init__(
-            format_string=format_string,
             # The `scheme` argument is present for the legacy reasons only.
             # If a custom value has been passed, it should be validated.
             # Otherwise use `https` instead of the `options.default_scheme`.
@@ -141,7 +134,7 @@ class What3Words(Geocoder):
             )
 
         params = {
-            'addr': self.format_string % query,
+            'addr': query,
             'lang': lang.lower(),
             'key': self.api_key,
         }

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -15,8 +15,6 @@ class Yandex(Geocoder):
     Documentation at:
         https://tech.yandex.com/maps/doc/geocoder/desc/concepts/input_params-docpage/
 
-    .. versionadded:: 1.5.0
-
     .. attention::
         Since September 2019 Yandex requires each request to have an API key.
         API keys can be created at https://developer.tech.yandex.ru/
@@ -36,14 +34,8 @@ class Yandex(Geocoder):
     ):
         """
 
-        .. versionchanged:: 1.14.0
-           Default scheme has been changed from ``http`` to ``https``.
-
         :param str api_key: Yandex API key, mandatory.
             The key can be created at https://developer.tech.yandex.ru/
-
-            .. versionchanged:: 1.21.0
-                API key is mandatory since September 2019.
 
         :param str lang: Language of the response and regional settings
             of the map. List of supported values:
@@ -68,18 +60,12 @@ class Yandex(Geocoder):
         :param str user_agent:
             See :attr:`geopy.geocoders.options.default_user_agent`.
 
-            .. versionadded:: 1.12.0
-
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
-
-            .. versionadded:: 1.14.0
 
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
-
-            .. versionadded:: 1.14.0
         """
         super().__init__(
             scheme=scheme,
@@ -141,8 +127,6 @@ class Yandex(Geocoder):
             - ``uk_UA`` -- Ukrainian;
             - ``be_BY`` -- Belarusian.
 
-            .. versionadded:: 1.22.0
-
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
@@ -184,12 +168,6 @@ class Yandex(Geocoder):
         :param bool exactly_one: Return one result or a list of results, if
             available.
 
-            .. versionchanged:: 1.14.0
-               Default value for ``exactly_one`` was ``False``, which differs
-               from the conventional default across geopy. Please always pass
-               this argument explicitly, otherwise you would get a warning.
-               In geopy 2.0 the default value will become ``True``.
-
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
             exception. Set this only if you wish to override, on this call
@@ -197,8 +175,6 @@ class Yandex(Geocoder):
 
         :param str kind: Type of toponym. Allowed values: `house`, `street`, `metro`,
             `district`, `locality`.
-
-            .. versionadded:: 1.14.0
 
         :param str lang: Language of the response and regional settings
             of the map. List of supported values:
@@ -209,8 +185,6 @@ class Yandex(Geocoder):
             - ``ru_RU`` -- Russian (default);
             - ``uk_UA`` -- Ukrainian;
             - ``be_BY`` -- Belarusian.
-
-            .. versionadded:: 1.22.0
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -32,7 +32,6 @@ class Yandex(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             scheme=None,
-            format_string=None,
             ssl_context=DEFAULT_SENTINEL,
     ):
         """
@@ -76,13 +75,6 @@ class Yandex(Geocoder):
 
             .. versionadded:: 1.14.0
 
-        :param str format_string:
-            See :attr:`geopy.geocoders.options.default_format_string`.
-
-            .. versionadded:: 1.14.0
-
-            .. deprecated:: 1.22.0
-
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
@@ -90,7 +82,6 @@ class Yandex(Geocoder):
             .. versionadded:: 1.14.0
         """
         super().__init__(
-            format_string=format_string,
             scheme=scheme,
             timeout=timeout,
             proxies=proxies,
@@ -156,7 +147,7 @@ class Yandex(Geocoder):
             ``exactly_one=False``.
         """
         params = {
-            'geocode': self.format_string % query,
+            'geocode': query,
             'format': 'json'
         }
         if self.api_key:

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -1,4 +1,3 @@
-import warnings
 from urllib.parse import urlencode
 
 from geopy.exc import GeocoderParseError, GeocoderServiceError
@@ -152,7 +151,7 @@ class Yandex(Geocoder):
     def reverse(
             self,
             query,
-            exactly_one=DEFAULT_SENTINEL,
+            exactly_one=True,
             timeout=DEFAULT_SENTINEL,
             kind=None,
             lang=None,
@@ -189,13 +188,6 @@ class Yandex(Geocoder):
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
-        if exactly_one is DEFAULT_SENTINEL:
-            warnings.warn('%s.reverse: default value for `exactly_one` '
-                          'argument will become True in geopy 2.0. '
-                          'Specify `exactly_one=False` as the argument '
-                          'explicitly to get rid of this warning.' % type(self).__name__,
-                          DeprecationWarning, stacklevel=2)
-            exactly_one = False
 
         try:
             point = self._coerce_point_to_string(query, "%(lon)s,%(lat)s")

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -1,3 +1,4 @@
+import warnings
 from urllib.parse import urlencode
 
 from geopy.exc import GeocoderParseError, GeocoderServiceError
@@ -24,7 +25,6 @@ class Yandex(Geocoder):
     def __init__(
             self,
             api_key=None,
-            lang=None,
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
@@ -35,20 +35,6 @@ class Yandex(Geocoder):
 
         :param str api_key: Yandex API key, mandatory.
             The key can be created at https://developer.tech.yandex.ru/
-
-        :param str lang: Language of the response and regional settings
-            of the map. List of supported values:
-
-            - ``tr_TR`` -- Turkish (only for maps of Turkey);
-            - ``en_RU`` -- response in English, Russian map features;
-            - ``en_US`` -- response in English, American map features;
-            - ``ru_RU`` -- Russian (default);
-            - ``uk_UA`` -- Ukrainian;
-            - ``be_BY`` -- Belarusian.
-
-            .. deprecated:: 1.22.0
-                This argument will be removed in geopy 2.0.
-                Use `geocode`'s and `reverse`'s `lang` instead.
 
         :param int timeout:
             See :attr:`geopy.geocoders.options.default_timeout`.
@@ -82,17 +68,6 @@ class Yandex(Geocoder):
                 stacklevel=2
             )
         self.api_key = api_key
-        if lang is not None:
-            warnings.warn(
-                '`lang` argument of the %(cls)s.__init__ '
-                'is deprecated and will be removed in geopy 2.0. Use '
-                '%(cls)s.geocode(lang=%(value)r) and '
-                '%(cls)s.reverse(lang=%(value)r) instead.'
-                % dict(cls=type(self).__name__, value=lang),
-                DeprecationWarning,
-                stacklevel=2
-            )
-        self.lang = lang
         domain = 'geocode-maps.yandex.ru'
         self.api = '%s://%s%s' % (self.scheme, domain, self.api_path)
 
@@ -135,8 +110,6 @@ class Yandex(Geocoder):
         }
         if self.api_key:
             params['apikey'] = self.api_key
-        if lang is None:
-            lang = self.lang
         if lang:
             params['lang'] = lang
         if exactly_one:
@@ -199,8 +172,6 @@ class Yandex(Geocoder):
         }
         if self.api_key:
             params['apikey'] = self.api_key
-        if lang is None:
-            lang = self.lang
         if lang:
             params['lang'] = lang
         if kind:

--- a/geopy/location.py
+++ b/geopy/location.py
@@ -1,6 +1,7 @@
 """
 :class:`.Location` returns geocoder results.
 """
+import collections.abc
 
 from geopy.point import Point
 
@@ -28,7 +29,7 @@ class Location:
             self._point = point
         elif isinstance(point, str):
             self._point = Point(point)
-        elif isinstance(point, (tuple, list)):
+        elif isinstance(point, collections.abc.Sequence):
             self._point = Point(point)
         else:
             raise TypeError(

--- a/geopy/location.py
+++ b/geopy/location.py
@@ -1,6 +1,3 @@
-"""
-:class:`.Location` returns geocoder results.
-"""
 import collections.abc
 
 from geopy.point import Point
@@ -21,11 +18,12 @@ class Location:
 
     __slots__ = ("_address", "_point", "_tuple", "_raw")
 
-    def __init__(self, address="", point=None, raw=None):
+    def __init__(self, address, point, raw):
+        if address is None:
+            raise TypeError("`address` must not be None")
         self._address = address
-        if point is None:
-            self._point = (None, None, None)
-        elif isinstance(point, Point):
+
+        if isinstance(point, Point):
             self._point = point
         elif isinstance(point, str):
             self._point = Point(point)
@@ -33,10 +31,12 @@ class Location:
             self._point = Point(point)
         else:
             raise TypeError(
-                "point an unsupported type: %r; use %r or Point",
-                type(point), type(str)
+                "`point` is of unsupported type: %r" % type(point)
             )
         self._tuple = _location_tuple(self)
+
+        if raw is None:
+            raise TypeError("`raw` must not be None")
         self._raw = raw
 
     @property
@@ -45,7 +45,7 @@ class Location:
         Location as a formatted string returned by the geocoder or constructed
         by geopy, depending on the service.
 
-        :rtype: unicode
+        :rtype: str
         """
         return self._address
 
@@ -54,7 +54,7 @@ class Location:
         """
         Location's latitude.
 
-        :rtype: float or None
+        :rtype: float
         """
         return self._point[0]
 
@@ -63,7 +63,7 @@ class Location:
         """
         Location's longitude.
 
-        :rtype: float or None
+        :rtype: float
         """
         return self._point[1]
 
@@ -77,7 +77,7 @@ class Location:
             requests nor in responses, so almost always the value of this
             property would be zero.
 
-        :rtype: float or None
+        :rtype: float
         """
         return self._point[2]
 
@@ -87,9 +87,9 @@ class Location:
         :class:`geopy.point.Point` instance representing the location's
         latitude, longitude, and altitude.
 
-        :rtype: :class:`geopy.point.Point` or None
+        :rtype: :class:`geopy.point.Point`
         """
-        return self._point if self._point != (None, None, None) else None
+        return self._point
 
     @property
     def raw(self):
@@ -97,7 +97,7 @@ class Location:
         Location's raw, unparsed geocoder response. For details on this,
         consult the service's documentation.
 
-        :rtype: dict or None
+        :rtype: dict
         """
         return self._raw
 

--- a/geopy/point.py
+++ b/geopy/point.py
@@ -174,14 +174,14 @@ class Point:
                     return cls.from_sequence(seq)
 
         if single_arg:
-            warnings.warn('A single number has been passed to the Point '
-                          'constructor. This is probably a mistake, because '
-                          'constructing a Point with just a latitude '
-                          'seems senseless. If this is exactly what was '
-                          'meant, then pass the zero longitude explicitly '
-                          'to get rid of this warning. '
-                          'In geopy 2.0 this will become an exception.',
-                          DeprecationWarning, stacklevel=2)
+            raise ValueError(
+                'A single number has been passed to the Point '
+                'constructor. This is probably a mistake, because '
+                'constructing a Point with just a latitude '
+                'seems senseless. If this is exactly what was '
+                'meant, then pass the zero longitude explicitly '
+                'to get rid of this error.'
+            )
 
         latitude, longitude, altitude = \
             _normalize_coordinates(latitude, longitude, altitude)

--- a/geopy/point.py
+++ b/geopy/point.py
@@ -2,7 +2,7 @@
 :class:`.Point` data structure.
 """
 
-import collections
+import collections.abc
 import re
 import warnings
 from itertools import islice
@@ -315,7 +315,7 @@ class Point:
         return self.format()
 
     def __eq__(self, other):
-        if not isinstance(other, collections.Iterable):
+        if not isinstance(other, collections.abc.Iterable):
             return NotImplemented
         return tuple(self) == tuple(other)
 

--- a/geopy/point.py
+++ b/geopy/point.py
@@ -261,8 +261,6 @@ class Point:
             >>> p.format_unicode()
             '41° 30′ 0″ N, 81° 0′ 0″ W, 12.3km'
 
-        .. versionadded:: 1.23.0
-
         :param bool altitude: Whether to include ``altitude`` value.
             By default it is automatically included if it is non-zero.
         """

--- a/geopy/timezone.py
+++ b/geopy/timezone.py
@@ -21,7 +21,7 @@ def ensure_pytz_is_installed():
         )
 
 
-def from_timezone_name(timezone_name, raw=None):
+def from_timezone_name(timezone_name, raw):
     ensure_pytz_is_installed()
     try:
         pytz_timezone = pytz.timezone(timezone_name)
@@ -38,7 +38,7 @@ def from_timezone_name(timezone_name, raw=None):
     return Timezone(pytz_timezone, raw)
 
 
-def from_fixed_gmt_offset(gmt_offset_hours, raw=None):
+def from_fixed_gmt_offset(gmt_offset_hours, raw):
     ensure_pytz_is_installed()
     pytz_timezone = pytz.FixedOffset(gmt_offset_hours * 60)
     return Timezone(pytz_timezone, raw)
@@ -52,7 +52,7 @@ class Timezone:
 
     __slots__ = ("_pytz_timezone", "_raw")
 
-    def __init__(self, pytz_timezone, raw=None):
+    def __init__(self, pytz_timezone, raw):
         self._pytz_timezone = pytz_timezone
         self._raw = raw
 
@@ -71,7 +71,7 @@ class Timezone:
         Timezone's raw, unparsed geocoder response. For details on this,
         consult the service's documentation.
 
-        :rtype: dict or None
+        :rtype: dict
         """
         return self._raw
 

--- a/geopy/timezone.py
+++ b/geopy/timezone.py
@@ -48,8 +48,6 @@ class Timezone:
     """
     Contains a parsed response for a timezone request, which is
     implemented in few geocoders which provide such lookups.
-
-    .. versionadded:: 1.18.0
     """
 
     __slots__ = ("_pytz_timezone", "_raw")

--- a/test/geocoders/arcgis.py
+++ b/test/geocoders/arcgis.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 import pytest
 
@@ -94,18 +93,6 @@ class ArcGISTestCase(GeocoderTestBase):
             {},
             expect_failure=True
         )
-
-    def test_custom_wkid(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            # Custom wkid should be ignored and a warning should be issued.
-            location = self.reverse_run(
-                {"query": Point(40.753898, -73.985071), "wkid": 2000},
-                {"latitude": 40.75376406311989,
-                 "longitude": -73.98489005863667},
-            )
-            assert 'New York' in location.address
-            assert 1 == len(w)
 
 
 @unittest.skipUnless(

--- a/test/geocoders/banfrance.py
+++ b/test/geocoders/banfrance.py
@@ -23,7 +23,7 @@ class BANFranceTestCase(GeocoderTestBase):
 
     def test_reverse(self):
         location = self.reverse_run(
-            {"query": "48.154587,3.221237", "exactly_one": True},
+            {"query": "48.154587,3.221237"},
             {"latitude": 48.154587, "longitude": 3.221237},
         )
         assert "Rue des Fontaines" in location.address

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -1,6 +1,5 @@
 import unittest
 import urllib.request
-import warnings
 from contextlib import ExitStack
 from unittest.mock import patch, sentinel
 
@@ -165,12 +164,8 @@ class GeocoderPointCoercionTestCase(unittest.TestCase):
         assert lonlat == expected
 
     def test_address(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            latlon = self.method(self.coordinates_address)
-            assert 1 == len(w)
-
-        assert latlon == self.coordinates_address
+        with pytest.raises(ValueError):
+            self.method(self.coordinates_address)
 
 
 class GeocoderFormatBoundingBoxTestCase(unittest.TestCase):

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -118,12 +118,9 @@ class GeocoderTestCase(unittest.TestCase):
             args, kwargs = mock_urlopen.call_args
             assert kwargs['timeout'] == 7
 
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
-                g._call_geocoder(url, timeout=None, raw=True)
-                args, kwargs = mock_urlopen.call_args
-                assert kwargs['timeout'] == 12
-                assert 1 == len(w)
+            g._call_geocoder(url, timeout=None, raw=True)
+            args, kwargs = mock_urlopen.call_args
+            assert kwargs['timeout'] is None
 
     def test_ssl_context(self):
 

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -49,20 +49,8 @@ class GeocoderTestCase(unittest.TestCase):
             assert locals()[attr] == getattr(geocoder, attr)
         assert user_agent == geocoder.headers['User-Agent']
 
-    def test_deprecated_format_string(self):
-        format_string = '%s Los Angeles, CA USA'
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            geocoder = Geocoder(
-                format_string=format_string,
-            )
-            assert format_string == geocoder.format_string
-            assert 1 == len(w)
-
     def test_init_with_defaults(self):
         attr_to_option = {
-            'format_string': 'default_format_string',
             'scheme': 'default_scheme',
             'timeout': 'default_timeout',
             'proxies': 'default_proxies',

--- a/test/geocoders/geonames.py
+++ b/test/geocoders/geonames.py
@@ -59,7 +59,6 @@ class GeoNamesTestCase(GeocoderTestBase):
         location = self.reverse_run(
             {
                 "query": "40.75376406311989, -73.98489005863667",
-                "exactly_one": True,
             },
             {
                 "latitude": 40.75376406311989,
@@ -80,7 +79,6 @@ class GeoNamesTestCase(GeocoderTestBase):
             self.reverse_run(
                 {
                     "query": "40.75376406311989, -73.98489005863667",
-                    "exactly_one": True,
                     "feature_code": "ADM1",
                 },
                 {},
@@ -90,7 +88,6 @@ class GeoNamesTestCase(GeocoderTestBase):
             self.reverse_run(
                 {
                     "query": "40.75376406311989, -73.98489005863667",
-                    "exactly_one": True,
                     "feature_code": "ADM1",
                     "find_nearby_type": "findNearbyPlaceName",
                 },
@@ -101,7 +98,6 @@ class GeoNamesTestCase(GeocoderTestBase):
         location = self.reverse_run(
             {
                 "query": "52.50, 13.41",
-                "exactly_one": True,
                 "lang": 'ru',
             },
             {},
@@ -113,7 +109,6 @@ class GeoNamesTestCase(GeocoderTestBase):
             self.reverse_run(
                 {
                     "query": "40.75376406311989, -73.98489005863667",
-                    "exactly_one": True,
                     "find_nearby_type": 'findNearby',
                     "lang": 'en',
                 },
@@ -124,7 +119,6 @@ class GeoNamesTestCase(GeocoderTestBase):
         location = self.reverse_run(
             {
                 "query": "40.75376406311989, -73.98489005863667",
-                "exactly_one": True,
                 "find_nearby_type": 'findNearby',
             },
             {
@@ -138,7 +132,6 @@ class GeoNamesTestCase(GeocoderTestBase):
         self.reverse_run(
             {
                 "query": "40.75376406311989, -73.98489005863667",
-                "exactly_one": True,
                 "find_nearby_type": 'findNearby',
                 "feature_code": "ADM1",
             },
@@ -153,7 +146,6 @@ class GeoNamesTestCase(GeocoderTestBase):
             self.reverse_run(
                 {
                     "query": "40.75376406311989, -73.98489005863667",
-                    "exactly_one": True,
                     "find_nearby_type": "findSomethingNonExisting",
                 },
                 {},

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -278,15 +278,6 @@ class GoogleV3TestCase(GeocoderTestBase):
             {"latitude": 51.52, "longitude": -0.15},
         )
 
-    def test_geocode_bounds_deprecated(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.geocode_run(
-                {"query": "221b Baker St", "bounds": [50, -2, 55, 2]},
-                {"latitude": 51.52, "longitude": -0.15},
-            )
-            assert 1 == len(w)
-
     def test_geocode_bounds_invalid(self):
         with pytest.raises(exc.GeocoderQueryError):
             self.geocode_run(

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -209,7 +209,7 @@ class GoogleV3TestCase(GeocoderTestBase):
 
     def test_reverse(self):
         self.reverse_run(
-            {"query": self.new_york_point, "exactly_one": True},
+            {"query": self.new_york_point},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667},
         )
 

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -32,19 +32,6 @@ class GoogleV3TestCase(GeocoderTestBase):
         else:
             assert timezone.pytz_timezone == expected
 
-        # `timezone` method is deprecated, but we still support it.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            if 'query' in payload:
-                payload['location'] = payload['query']
-                del payload['query']
-            pytz_timezone = self._make_request(self.geocoder.timezone, **payload)
-            if expected is None:
-                assert pytz_timezone is None
-            else:
-                assert pytz_timezone == expected
-            assert 0 < len(w)
-
         return timezone
 
     def test_user_agent_custom(self):

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -245,15 +245,14 @@ class GoogleV3TestCase(GeocoderTestBase):
             utc_timestamp == self.geocoder._normalize_timezone_at_time(local_aware_dt)
         )
 
-    def test_timezone_integer(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+    def test_timezone_integer_raises(self):
+        # In geopy 1.x `at_time` could be an integer -- a unix timestamp.
+        # This is an error since geopy 2.0.
+        with pytest.raises(exc.GeocoderQueryError):
             self.reverse_timezone_run(
                 {"query": self.new_york_point, "at_time": 0},
                 self.america_new_york,
             )
-            # at_time as number should issue a warning
-            assert 0 < len(w)
 
     def test_timezone_no_date(self):
         self.reverse_timezone_run(

--- a/test/geocoders/ignfrance.py
+++ b/test/geocoders/ignfrance.py
@@ -58,8 +58,7 @@ class BaseIGNFranceTestCase(ABC):
     def test_geocode(self):
         self.geocode_run(
             {"query": "44109000EX0114",
-             "query_type": "CadastralParcel",
-             "exactly_one": True},
+             "query_type": "CadastralParcel"},
             {"latitude": 47.222482, "longitude": -1.556303},
         )
 
@@ -73,7 +72,7 @@ class BaseIGNFranceTestCase(ABC):
     def test_reverse_no_result(self):
         self.reverse_run(
             # North Atlantic Ocean
-            {"query": (35.173809, -37.485351), "exactly_one": True},
+            {"query": (35.173809, -37.485351)},
             {},
             expect_failure=True
         )
@@ -81,8 +80,7 @@ class BaseIGNFranceTestCase(ABC):
     def test_geocode_with_address(self):
         self.geocode_run(
             {"query": "Camp des Landes, 41200 VILLEFRANCHE-SUR-CHER",
-             "query_type": "StreetAddress",
-             "exactly_one": True},
+             "query_type": "StreetAddress"},
             {"latitude": 47.293048,
              "longitude": 1.718985,
              "address": "le camp des landes, 41200 Villefranche-sur-Cher"},
@@ -92,8 +90,7 @@ class BaseIGNFranceTestCase(ABC):
         self.geocode_run(
             {"query": "8 rue Général Buat, Nantes",
              "query_type": "StreetAddress",
-             "is_freeform": True,
-             "exactly_one": True},
+             "is_freeform": True},
             {"address": "8 r general buat , 44000 Nantes"},
         )
 
@@ -172,8 +169,7 @@ class BaseIGNFranceTestCase(ABC):
 
     def test_reverse(self):
         res = self.reverse_run(
-            {"query": '47.229554,-1.541519',
-             "exactly_one": True},
+            {"query": '47.229554,-1.541519'},
             {},
         )
         assert res.address == '7 av camille guerin, 44000 Nantes'
@@ -182,7 +178,6 @@ class BaseIGNFranceTestCase(ABC):
         with pytest.raises(GeocoderQueryError):
             self.geocoder.reverse(
                 query='47.229554,-1.541519',
-                exactly_one=True,
                 reverse_geocode_preference=['a']  # invalid
             )
 
@@ -299,8 +294,7 @@ class IGNFranceUsernameAuthProxyTestCase(GeocoderTestBase):
         assert 0 == len(self.proxy_server.requests)
         self.geocode_run(
             {"query": "Camp des Landes, 41200 VILLEFRANCHE-SUR-CHER",
-             "query_type": "StreetAddress",
-             "exactly_one": True},
+             "query_type": "StreetAddress"},
             {"latitude": 47.293048,
              "longitude": 1.718985,
              "address": "le camp des landes, 41200 Villefranche-sur-Cher"},

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -189,26 +189,6 @@ class BaseNominatimTestCase(ABC):
                 {"latitude": 51.5223513, "longitude": -0.1382104}
             )
 
-    def test_deprecated_viewbox(self):
-        res = self.geocode_run(
-            {"query": "Maple Street"},
-            {},
-        )
-        assert not (50 <= res.latitude <= 52)
-        assert not (-0.15 <= res.longitude <= -0.11)
-
-        for viewbox in [
-            (-0.11, 52, -0.15, 50),
-            ("-0.11", "52", "-0.15", "50")
-        ]:
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
-                self.geocode_run(
-                    {"query": "Maple Street", "viewbox": viewbox},
-                    {"latitude": 51.5223513, "longitude": -0.1382104}
-                )
-                assert 1 == len(w)
-
     def test_bounded(self):
         bb = (Point('56.588456', '84.719353'), Point('56.437293', '85.296822'))
         query = (

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -117,13 +117,13 @@ class BaseNominatimTestCase(ABC):
     def test_reverse_language_parameter(self):
         query = "52.51693903613385, 13.3859332733135"
         result_reverse_de = self.reverse_run(
-            {"query": query, "exactly_one": True, "language": "de"},
+            {"query": query, "language": "de"},
             {},
         )
         assert result_reverse_de.raw['address']['country'] == "Deutschland"
 
         result_reverse_en = self.reverse_run(
-            {"query": query, "exactly_one": True, "language": "en"},
+            {"query": query, "language": "en"},
             {},
         )
         # have had a change in the exact authority name
@@ -321,14 +321,14 @@ class BaseNominatimTestCase(ABC):
     def test_reverse_zoom_parameter(self):
         query = "40.689253199999996, -74.04454817144321"
         result_reverse = self.reverse_run(
-            {"query": query, "exactly_one": True, "zoom": 10},
+            {"query": query, "zoom": 10},
             {},
         )
         assert "New York" in result_reverse.address
         assert "Statue of Liberty" not in result_reverse.address
 
         result_reverse = self.reverse_run(
-            {"query": query, "exactly_one": True},
+            {"query": query},
             {},
         )
         assert "New York" in result_reverse.address

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -1,10 +1,10 @@
-import warnings
 from abc import ABC, abstractmethod
 from unittest.mock import patch
 
 import pytest
 
 import geopy.geocoders
+from geopy.exc import ConfigurationError
 from geopy.geocoders import Nominatim
 from geopy.point import Point
 from test.geocoders.util import GeocoderTestBase
@@ -322,27 +322,17 @@ class NominatimTestCase(BaseNominatimTestCase, GeocoderTestBase):
         kwargs.setdefault('user_agent', 'geopy-test')
         return Nominatim(**kwargs)
 
-    def test_default_user_agent_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+    def test_default_user_agent_error(self):
+        with pytest.raises(ConfigurationError):
             Nominatim()
-            assert 1 == len(w)
 
-    def test_example_user_agent_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+    def test_example_user_agent_error(self):
+        with pytest.raises(ConfigurationError):
             Nominatim(user_agent="specify_your_app_name_here")
-            assert 1 == len(w)
 
     def test_custom_user_agent_works(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            Nominatim(user_agent='my_application')
-            assert 0 == len(w)
+        Nominatim(user_agent='my_application')
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            with patch.object(geopy.geocoders.options, 'default_user_agent',
-                              'my_application'):
-                Nominatim()
-            assert 0 == len(w)
+        with patch.object(geopy.geocoders.options, 'default_user_agent',
+                          'my_application'):
+            Nominatim()

--- a/test/geocoders/opencage.py
+++ b/test/geocoders/opencage.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 from geopy.geocoders import OpenCage
 from test.geocoders.util import GeocoderTestBase, env
@@ -53,16 +52,6 @@ class OpenCageTestCase(GeocoderTestBase):
              "bounds": [[50.1, -130.1], [44.1, -100.9]]},
             {"latitude": 46.7323875, "longitude": -117.0001651},
         )
-
-    def test_bounds_deprecated(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.geocode_run(
-                {"query": "moscow",  # Idaho USA
-                 "bounds": "-130.1,50.1,-100.9,44.1"},
-                {"latitude": 46.7323875, "longitude": -117.0001651},
-            )
-            assert 1 == len(w)
 
     def test_country_str(self):
         self.geocode_run(

--- a/test/geocoders/pelias.py
+++ b/test/geocoders/pelias.py
@@ -73,13 +73,13 @@ class BasePeliasTestCase(ABC):
     def test_reverse_language_parameter(self):
         query = "48.198674, 16.348388"
         result_reverse_de = self.reverse_run(
-            {"query": query, "exactly_one": True, "language": "de"},
+            {"query": query, "language": "de"},
             {},
         )
         assert result_reverse_de.raw['properties']['country'] == "Österreich"
 
         result_reverse_en = self.reverse_run(
-            {"query": query, "exactly_one": True, "language": "en"},
+            {"query": query, "language": "en"},
             {},
         )
         assert result_reverse_en.raw['properties']['country'] == "Austria"

--- a/test/geocoders/pelias.py
+++ b/test/geocoders/pelias.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 from abc import ABC, abstractmethod
 
 from geopy.geocoders import Pelias
@@ -47,16 +46,6 @@ class BasePeliasTestCase(ABC):
              "boundary_rect": [[50.1, -130.1], [44.1, -100.9]]},
             {"latitude": 46.7323875, "longitude": -117.0001651},
         )
-
-    def test_boundary_rect_deprecated(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.geocode_run(
-                {"query": "moscow",  # Idaho USA
-                 "boundary_rect": [-130.1, 44.1, -100.9, 50.1]},
-                {"latitude": 46.7323875, "longitude": -117.0001651},
-            )
-            assert 1 == len(w)
 
     def test_geocode_language_parameter(self):
         query = "Graben 7, Wien"

--- a/test/geocoders/photon.py
+++ b/test/geocoders/photon.py
@@ -62,7 +62,6 @@ class PhotonTestCase(GeocoderTestBase):
 
         result_reverse_it = self.reverse_run(
             {"query": "45.7733105, 4.8869339",
-             "exactly_one": True,
              "language": "de"},
             {},
         )
@@ -73,7 +72,6 @@ class PhotonTestCase(GeocoderTestBase):
 
         result_reverse_fr = self.reverse_run(
             {"query": "45.7733105, 4.8869339",
-             "exactly_one": True,
              "language": "fr"},
             {},
         )

--- a/test/geocoders/smartystreets.py
+++ b/test/geocoders/smartystreets.py
@@ -1,10 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-import pytest
-
 import geopy.geocoders
-from geopy.exc import ConfigurationError
 from geopy.geocoders import LiveAddress
 from test.geocoders.util import GeocoderTestBase, env
 
@@ -21,20 +18,9 @@ class LiveAddressTestCaseUnitTest(GeocoderTestBase):
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_http_scheme_is_disallowed(self):
-        with pytest.raises(ConfigurationError):
-            LiveAddress(
-                auth_id=self.dummy_id,
-                auth_token=self.dummy_token,
-                scheme='http',
-            )
-
     @patch.object(geopy.geocoders.options, 'default_scheme', 'http')
     def test_default_scheme_is_ignored(self):
         geocoder = LiveAddress(auth_id=self.dummy_id, auth_token=self.dummy_token)
-        assert geocoder.scheme == 'https'
-        geocoder = LiveAddress(auth_id=self.dummy_id, auth_token=self.dummy_token,
-                               scheme=None)
         assert geocoder.scheme == 'https'
 
 

--- a/test/geocoders/what3words.py
+++ b/test/geocoders/what3words.py
@@ -19,18 +19,9 @@ class What3WordsTestCaseUnitTest(GeocoderTestBase):
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_http_scheme_is_disallowed(self):
-        with pytest.raises(geopy.exc.ConfigurationError):
-            What3Words(
-                api_key=self.dummy_api_key,
-                scheme='http',
-            )
-
     @patch.object(geopy.geocoders.options, 'default_scheme', 'http')
     def test_default_scheme_is_ignored(self):
         geocoder = What3Words(api_key=self.dummy_api_key)
-        assert geocoder.scheme == 'https'
-        geocoder = What3Words(api_key=self.dummy_api_key, scheme=None)
         assert geocoder.scheme == 'https'
 
 
@@ -43,9 +34,7 @@ class What3WordsTestCase(GeocoderTestBase):
     def setUpClass(cls):
         cls.geocoder = What3Words(
             env['WHAT3WORDS_KEY'],
-            scheme='https',
             timeout=3
-
         )
         cls.delta = 0.7
 

--- a/test/geocoders/yandex.py
+++ b/test/geocoders/yandex.py
@@ -49,7 +49,7 @@ class YandexTestCase(GeocoderTestBase):
 
     def test_reverse(self):
         self.reverse_run(
-            {"query": "40.75376406311989, -73.98489005863667", "exactly_one": True},
+            {"query": "40.75376406311989, -73.98489005863667"},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667},
         )
 
@@ -62,13 +62,13 @@ class YandexTestCase(GeocoderTestBase):
 
     def test_reverse_kind(self):
         self.reverse_run(
-            {"query": (55.743659, 37.408055), "kind": "locality", "exactly_one": True},
+            {"query": (55.743659, 37.408055), "kind": "locality"},
             {"address": "Москва, Россия"}
         )
 
     def test_reverse_lang(self):
         self.reverse_run(
             {"query": (55.743659, 37.408055), "kind": "locality",
-             "lang": "uk_UA", "exactly_one": True},
+             "lang": "uk_UA"},
             {"address": "Москва, Росія"}
         )

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -310,16 +310,13 @@ class TestWhenComputingGreatCircleDistance(CommonDistanceCases,
         self.assertAlmostEqual(destination.latitude, 0)
         self.assertAlmostEqual(destination.longitude, 180)
 
-    def test_different_altitudes_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            # Different altitudes emit a warning:
+    def test_different_altitudes_error(self):
+        with self.assertRaises(ValueError):
+            # Different altitudes raise an exception:
             self.cls((10, 10, 10), (20, 20, 15))
-            self.assertEqual(1, len(w))
 
-            # Equal non-zero altitudes don't warn:
-            self.cls((10, 10, 10), (20, 20, 10))
-            self.assertEqual(1, len(w))
+        # Equal non-zero altitudes don't raise:
+        self.cls((10, 10, 10), (20, 20, 10))
 
 
 @patch.object(VincentyDistance, '_show_deprecation_warning', False)
@@ -374,16 +371,13 @@ class TestWhenComputingGeodesicDistance(CommonDistanceCases,
     def tearDown(self):
         self.cls.ELLIPSOID = self.original_ellipsoid
 
-    def test_different_altitudes_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            # Different altitudes emit a warning:
+    def test_different_altitudes_error(self):
+        with self.assertRaises(ValueError):
+            # Different altitudes raise an exception:
             self.cls((10, 10, 10), (20, 20, 15))
-            self.assertEqual(1, len(w))
 
-            # Equal non-zero altitudes don't warn:
-            self.cls((10, 10, 10), (20, 20, 10))
-            self.assertEqual(1, len(w))
+        # Equal non-zero altitudes don't raise:
+        self.cls((10, 10, 10), (20, 20, 10))
 
     def test_miscellaneous_high_accuracy_cases(self):
 

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -91,18 +91,15 @@ class CommonDistanceComputationCases:
         self.assertAlmostEqual(dist_total.kilometers,
                                dist1.km + dist2.km + dist3.km)
 
-    def test_should_warn_when_using_single_numbers_as_points(self):
+    def test_should_raise_when_using_single_numbers_as_points(self):
         # Each argument is expected to be a Point. If it's not a point,
         # it will be wrapped in Point.
         # Point(10) equals to Point(10, 0).
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            dist1 = self.cls(10, 20)
-            self.assertEqual(2, len(w))  # 1 per each point
-            dist2 = self.cls((10, 0), (20, 0))
-            # no warnings: explicit tuples are not that suspicious
-            self.assertEqual(2, len(w))
-        self.assertAlmostEqual(dist1.kilometers, dist2.kilometers)
+        with self.assertRaises(ValueError):
+            self.cls(10, 20)
+
+        # no error: explicit tuples are not that suspicious
+        self.cls((10, 0), (20, 0))
 
     def test_should_tolerate_tuples_with_textual_numbers(self):
         dist1 = self.cls(("1", "30"), ("20", "60"))

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -44,37 +44,36 @@ class LocationTestCase(unittest.TestCase):
             self.assertEqual(loc.raw, raw)
 
     def test_location_str(self):
-        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_COORDS_STR)
+        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_COORDS_STR, {})
         self._location_iter_test(loc)
         self.assertEqual(loc.point, GRAND_CENTRAL_POINT)
 
     def test_location_point(self):
-        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT)
+        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT, {})
         self._location_iter_test(loc)
         self.assertEqual(loc.point, GRAND_CENTRAL_POINT)
 
     def test_location_none(self):
-        loc = Location(GRAND_CENTRAL_STR, None)
-        self._location_iter_test(loc, GRAND_CENTRAL_STR, None, None)
-        self.assertEqual(loc.point, None)
+        with self.assertRaises(TypeError):
+            Location(GRAND_CENTRAL_STR, None, {})
 
     def test_location_iter(self):
-        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_COORDS_TUPLE)
+        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_COORDS_TUPLE, {})
         self._location_iter_test(loc)
         self.assertEqual(loc.point, GRAND_CENTRAL_POINT)
 
-    def test_location_typeerror(self):
+    def test_location_point_typeerror(self):
         with self.assertRaises(TypeError):
-            Location(GRAND_CENTRAL_STR, 1)
+            Location(GRAND_CENTRAL_STR, 1, {})
 
     def test_location_array_access(self):
-        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_COORDS_TUPLE)
+        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_COORDS_TUPLE, {})
         self.assertEqual(loc[0], GRAND_CENTRAL_STR)
         self.assertEqual(loc[1][0], GRAND_CENTRAL_COORDS_TUPLE[0])
         self.assertEqual(loc[1][1], GRAND_CENTRAL_COORDS_TUPLE[1])
 
     def test_location_properties(self):
-        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT)
+        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT, {})
         self._location_properties_test(loc)
 
     def test_location_raw(self):
@@ -84,21 +83,21 @@ class LocationTestCase(unittest.TestCase):
         self._location_properties_test(loc, GRAND_CENTRAL_RAW)
 
     def test_location_string(self):
-        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT)
+        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT, {})
         self.assertEqual(str(loc), loc.address)
 
     def test_location_len(self):
-        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT)
+        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT, {})
         self.assertEqual(len(loc), 2)
 
     def test_location_eq(self):
-        loc1 = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT)
-        loc2 = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_COORDS_TUPLE)
+        loc1 = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT, {})
+        loc2 = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_COORDS_TUPLE, {})
         self.assertEqual(loc1, loc2)
 
     def test_location_ne(self):
-        loc1 = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT)
-        loc2 = Location(GRAND_CENTRAL_STR, None)
+        loc1 = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT, {})
+        loc2 = Location(GRAND_CENTRAL_STR, Point(0, 0), {})
         self.assertNotEqual(loc1, loc2)
 
     def test_location_repr(self):
@@ -108,14 +107,14 @@ class LocationTestCase(unittest.TestCase):
             "\u015bl\u0105skie, 41-800, Polska"
         )
         point = (0.0, 0.0, 0.0)
-        loc = Location(address, point)
+        loc = Location(address, point, {})
         self.assertEqual(
             repr(loc),
             "Location(%s, %r)" % (address, point)
         )
 
     def test_location_is_picklable(self):
-        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT)
+        loc = Location(GRAND_CENTRAL_STR, GRAND_CENTRAL_POINT, {})
         # https://docs.python.org/2/library/pickle.html#data-stream-format
         for protocol in (0, 1, 2, -1):
             pickled = pickle.dumps(loc, protocol=protocol)

--- a/test/test_point.py
+++ b/test/test_point.py
@@ -80,29 +80,23 @@ class PointTestCase(unittest.TestCase):
         self.assertEqual(point.format_decimal('m'), "41.5, 81.0, 0.0m")
 
     def test_point_from_iterable(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.assertEqual(Point(1, 2, 3), Point([1, 2, 3]))
-            self.assertEqual(Point(1, 2, 0), Point([1, 2]))
-            self.assertEqual(0, len(w))
-            self.assertEqual(Point(1, 0, 0), Point([1]))
-            self.assertEqual(1, len(w))  # a single latitude is discouraged
-            self.assertEqual(Point(0, 0, 0), Point([]))
-            self.assertEqual(1, len(w))
+        self.assertEqual(Point(1, 2, 3), Point([1, 2, 3]))
+        self.assertEqual(Point(1, 2, 0), Point([1, 2]))
+        with self.assertRaises(ValueError):
+            Point([1])
+        self.assertEqual(Point(0, 0, 0), Point([]))
 
         with self.assertRaises(ValueError):
             Point([1, 2, 3, 4])
 
     def test_point_from_single_number(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with self.assertRaises(ValueError):
             # Point from a single number is probably a misuse,
             # thus it's discouraged.
-            self.assertEqual((5, 0, 0), tuple(Point(5)))
-            self.assertEqual(1, len(w))
-            # But an explicit zero longitude is fine
-            self.assertEqual((5, 0, 0), tuple(Point(5, 0)))
-            self.assertEqual(1, len(w))
+            Point(5)
+
+        # But an explicit zero longitude is fine
+        self.assertEqual((5, 0, 0), tuple(Point(5, 0)))
 
     def test_point_from_point(self):
         point = Point(self.lat, self.lon, self.alt)

--- a/test/test_timezone.py
+++ b/test/test_timezone.py
@@ -35,7 +35,7 @@ class TimezoneTestCase(unittest.TestCase):
 
     def test_create_from_pytz_timezone(self):
         pytz_timezone = pytz.timezone(self.timezone_name)
-        tz = Timezone(pytz_timezone)
+        tz = Timezone(pytz_timezone, {})
         self.assertIs(tz.pytz_timezone, pytz_timezone)
 
     def test_string(self):


### PR DESCRIPTION
(This PR contains a subset of commits from #335).

This PR removes all deprecation shims, warnings and replaces them with exceptions where appropriate.

Also `.. versionadded`/`.. versionchanged`/`.. deprecated` sphinxdoc directives for v1 are removed.