### PR TITLE
geopy 2.0: Add Adapters + RequestsAdapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - travis_retry pip install -U pip wheel setuptools
 
 install:
-  - travis_retry pip install -e ".[timezone]"
+  - travis_retry pip install -e ".[requests,timezone]"
 
 stages:
   - lint

--- a/docs/changelog_2xx.rst
+++ b/docs/changelog_2xx.rst
@@ -17,10 +17,31 @@ If you have checked your code on the latest 1.x release with enabled
 warnings (i.e. with ``-Wd`` key of the ``python`` command) and fixed
 all of them, then it should be safe to upgrade.
 
+New features
+~~~~~~~~~~~~
+
+- :mod:`geopy.adapters` module. Previously all geocoders used :mod:`urllib`
+  for HTTP requests, which doesn't support keepalives. Adapters is
+  a new mechanism which allows to use other HTTP client implementations.
+
+  There are 2 implementations coming out of the box:
+
+  + :class:`geopy.adapters.RequestsAdapter` -- uses ``requests`` library
+    which supports keepalives (thus it is significantly more effective
+    than ``urllib``). It is used by default if ``requests`` package
+    is installed.
+  + :class:`geopy.adapters.URLLibAdapter` -- uses ``urllib``, basically
+    it provides the same behavior as in geopy 1.x. It is used by default if
+    ``requests`` package is not installed.
+
+
 Packaging changes
 ~~~~~~~~~~~~~~~~~
 
 - Dropped support for Python 2.7 and 3.4.
+- New extras:
+
+  + ``geopy[requests]`` for :class:`geopy.adapters.RequestsAdapter`.
 
 Chores
 ~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -386,6 +386,31 @@ Exceptions
 .. autoclass:: geopy.exc.GeocoderNotFound
     :show-inheritance:
 
+Adapters
+~~~~~~~~
+
+.. automodule:: geopy.adapters
+    :members: __doc__
+
+Supported Adapters
+------------------
+
+.. autoclass:: geopy.adapters.URLLibAdapter
+    :show-inheritance:
+
+
+Base Classes
+------------
+
+.. autoclass:: geopy.adapters.AdapterHTTPError
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+.. autoclass:: geopy.adapters.BaseAdapter
+    :members:
+
+    .. automethod:: __init__
 
 Logging
 ~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -395,6 +395,9 @@ Adapters
 Supported Adapters
 ------------------
 
+.. autoclass:: geopy.adapters.RequestsAdapter
+    :show-inheritance:
+
 .. autoclass:: geopy.adapters.URLLibAdapter
     :show-inheritance:
 

--- a/geopy/adapters.py
+++ b/geopy/adapters.py
@@ -1,0 +1,214 @@
+"""
+Adapters are HTTP client implementations used by geocoders.
+
+Some adapters might support keep-alives, request retries, http2,
+persistence of Cookies, response compression and so on.
+
+Adapters should be considered an implementation detail. Most of the time
+you wouldn't need to know about their existence unless you want to tune
+HTTP client settings.
+
+.. versionadded:: 2.0
+   Adapters are currently provided on a `provisional basis`_.
+
+    .. _provisional basis: https://docs.python.org/3/glossary.html#term-provisional-api
+"""
+import abc
+import json
+from socket import timeout as SocketTimeout
+from ssl import SSLError
+from urllib.error import HTTPError
+from urllib.request import HTTPSHandler, ProxyHandler, Request, URLError, build_opener
+
+from geopy.exc import (
+    GeocoderParseError,
+    GeocoderServiceError,
+    GeocoderTimedOut,
+    GeocoderUnavailable,
+)
+from geopy.util import logger
+
+
+class AdapterHTTPError(IOError):
+    """An exception which must be raised by adapters when an HTTP response
+    with a non-successful status code has been received.
+
+    Base Geocoder class translates this exception to an instance of
+    :class:`geopy.exc.GeocoderServiceError`.
+
+    """
+
+    def __init__(self, message, *, status_code, text):
+        """
+
+        :param str message: Standard exception message.
+        :param int status_code: HTTP status code
+        :param str text: HTTP body text
+        """
+        self.status_code = status_code
+        self.text = text
+        super().__init__(message)
+
+
+class BaseAdapter(abc.ABC):
+    """Base class for an Adapter.
+
+    To make geocoders use a custom adapter, add an implementation
+    of this class and specify it in
+    the :attr:`geopy.geocoders.options.default_adapter_factory` value.
+
+    """
+
+    # A class attribute which tells if this Adapter's required dependencies
+    # are installed. By default assume that all Adapters are available.
+    is_available = True
+
+    def __init__(self, *, proxies, ssl_context):
+        """Initialize adapter.
+
+        :param dict proxies: An urllib-style proxies dict, e.g.
+            ``{"http": "192.0.2.0:8080", "https": "192.0.2.0:8080"}``,
+            ``{"https": "http://user:passw0rd@192.0.2.0:8080""}``.
+            See :attr:`geopy.geocoders.options.default_proxies` (note
+            that Adapters always receive a dict: the string proxy
+            is transformed to dict in the base
+            :class:`geopy.geocoders.base.Geocoder` class.).
+
+        :type ssl_context: :class:`ssl.SSLContext`
+        :param ssl_context:
+            See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_json(self, url, *, timeout, headers):
+        """Same as ``get_text`` except that the response is expected
+        to be a valid JSON. The value returned is the parsed JSON.
+
+        :class:`geopy.exc.GeocoderParseError` must be raised if
+        the response cannot be parsed.
+
+        :param str url: The target URL.
+
+        :param float timeout:
+            See :attr:`geopy.geocoders.options.default_timeout`.
+
+        :param dict headers: A dict with custom HTTP request headers.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_text(self, url, *, timeout, headers):
+        """Make a GET request and return the response as string.
+
+        This method should not raise any exceptions other than these:
+
+        - :class:`geopy.exc.AdapterHTTPError` should be raised if the response
+          was successfully retrieved but the status code was non-successful.
+        - :class:`geopy.exc.GeocoderTimedOut` should be raised when the request
+          times out.
+        - :class:`geopy.exc.GeocoderUnavailable` should be raised when the target
+          host is unreachable.
+        - :class:`geopy.exc.GeocoderServiceError` is the least specific error
+          in the exceptions hierarchy and should be raised in any other cases.
+
+        :param str url: The target URL.
+
+        :param float timeout:
+            See :attr:`geopy.geocoders.options.default_timeout`.
+
+        :param dict headers: A dict with custom HTTP request headers.
+        """
+        pass
+
+
+class URLLibAdapter(BaseAdapter):
+    """The fallback adapter which uses urllib from the Python standard
+    library, see :func:`urllib.request.urlopen`.
+
+    urllib doesn't support keep-alives, request retries,
+    doesn't persist Cookies and is HTTP/1.1 only.
+
+    urllib was the only available option
+    for making requests in geopy 1.x, so this adapter behaves the same
+    as geopy 1.x in terms of HTTP requests.
+    """
+
+    def __init__(self, *, proxies, ssl_context):
+        super().__init__(proxies=proxies, ssl_context=ssl_context)
+
+        # `ProxyHandler` should be present even when actually there're
+        # no proxies. `build_opener` contains it anyway. By specifying
+        # it here explicitly we can disable system proxies (i.e.
+        # from HTTP_PROXY env var) by setting `proxies` to `{}`.
+        # Otherwise, if we didn't specify ProxyHandler for empty
+        # `proxies` here, the `build_opener` would have used one internally
+        # which could have unwillingly picked up the system proxies.
+        opener = build_opener(
+            HTTPSHandler(context=ssl_context),
+            ProxyHandler(proxies),
+        )
+        self.urlopen = opener.open
+
+    def get_json(self, url, *, timeout, headers):
+        text = self.get_text(url, timeout=timeout, headers=headers)
+        try:
+            return json.loads(text)
+        except ValueError:
+            raise GeocoderParseError(
+                "Could not deserialize using deserializer:\n%s" % text
+            )
+
+    def get_text(self, url, *, timeout, headers):
+        req = Request(url=url, headers=headers)
+        try:
+            page = self.urlopen(req, timeout=timeout)
+        except Exception as error:
+            message = str(error.args[0]) if len(error.args) else str(error)
+            if isinstance(error, HTTPError):
+                code = error.getcode()
+                body = self._read_http_error_body(error)
+                raise AdapterHTTPError(message, status_code=code, text=body)
+            elif isinstance(error, URLError):
+                if "timed out" in message:
+                    raise GeocoderTimedOut("Service timed out")
+                elif "unreachable" in message:
+                    raise GeocoderUnavailable("Service not available")
+            elif isinstance(error, SocketTimeout):
+                raise GeocoderTimedOut("Service timed out")
+            elif isinstance(error, SSLError):
+                if "timed out" in message:
+                    raise GeocoderTimedOut("Service timed out")
+            raise GeocoderServiceError(message)
+        else:
+            text = self._decode_page(page)
+            status_code = page.getcode()
+            if status_code >= 400:
+                raise AdapterHTTPError(
+                    "Non-successful status code %s" % status_code,
+                    status_code=status_code, text=text
+                )
+
+        return text
+
+    def _read_http_error_body(self, error):
+        try:
+            return self._decode_page(error)
+        except Exception:
+            logger.debug(
+                "Unable to fetch body for a non-successful HTTP response", exc_info=True
+            )
+            return None
+
+    def _decode_page(self, page):
+        encoding = page.headers.get_content_charset() or "utf-8"
+        try:
+            body_bytes = page.read()
+        except Exception:
+            raise GeocoderServiceError("Unable to read the response")
+
+        try:
+            return str(body_bytes, encoding=encoding)
+        except ValueError:
+            raise GeocoderParseError("Unable to decode the response bytes")

--- a/geopy/geocoders/algolia.py
+++ b/geopy/geocoders/algolia.py
@@ -29,7 +29,8 @@ class AlgoliaPlaces(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
         :param str app_id: Unique application identifier. It's used to
@@ -57,6 +58,10 @@ class AlgoliaPlaces(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -64,6 +69,7 @@ class AlgoliaPlaces(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.domain = domain.strip('/')
 

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -42,6 +42,7 @@ class ArcGIS(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             auth_domain='www.arcgis.com',
             domain='geocode.arcgis.com'
     ):
@@ -79,6 +80,11 @@ class ArcGIS(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str auth_domain: Domain where the target ArcGIS auth service
             is hosted. Used only in authenticated mode (i.e. username,
             password and referer are set).
@@ -92,6 +98,7 @@ class ArcGIS(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         if username or password or referer:
             if not (username and password and referer):

--- a/geopy/geocoders/azure.py
+++ b/geopy/geocoders/azure.py
@@ -23,6 +23,7 @@ class AzureMaps(TomTom):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             domain='atlas.microsoft.com'
     ):
         """
@@ -44,6 +45,11 @@ class AzureMaps(TomTom):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str domain: Domain where the target Azure Maps service
             is hosted.
         """
@@ -54,6 +60,7 @@ class AzureMaps(TomTom):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
             domain=domain,
         )
 

--- a/geopy/geocoders/baidu.py
+++ b/geopy/geocoders/baidu.py
@@ -37,6 +37,7 @@ class Baidu(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             security_key=None
     ):
         """
@@ -61,6 +62,11 @@ class Baidu(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str security_key: The security key (SK) to calculate
             the SN parameter in request if authentication setting requires
             (http://lbsyun.baidu.com/index.php?title=lbscloud/api/appendix).
@@ -71,6 +77,7 @@ class Baidu(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.api_key = api_key
         self.api = '%s://api.map.baidu.com%s' % (self.scheme, self.api_path)

--- a/geopy/geocoders/banfrance.py
+++ b/geopy/geocoders/banfrance.py
@@ -25,7 +25,8 @@ class BANFrance(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -48,6 +49,11 @@ class BANFrance(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         """
         super().__init__(
             scheme=scheme,
@@ -55,6 +61,7 @@ class BANFrance(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.domain = domain.strip('/')
 

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -1,4 +1,4 @@
-from geopy.adapters import AdapterHTTPError, URLLibAdapter
+from geopy.adapters import AdapterHTTPError, RequestsAdapter, URLLibAdapter
 from geopy.exc import (
     ConfigurationError,
     GeocoderAuthenticationFailure,
@@ -20,7 +20,7 @@ _DEFAULT_USER_AGENT = "geopy/%s" % __version__
 
 _DEFAULT_ADAPTER_CLASS = next(
     adapter_cls
-    for adapter_cls in (URLLibAdapter,)
+    for adapter_cls in (RequestsAdapter, URLLibAdapter,)
     if adapter_cls.is_available
 )
 
@@ -69,7 +69,10 @@ class options:
                     )
                 )
 
-            Default adapter is :class:`geopy.adapters.URLLibAdapter`.
+            If `requests <https://requests.readthedocs.io>`_ package is
+            installed, the default adapter is
+            :class:`geopy.adapters.RequestsAdapter`. Otherwise it is
+            :class:`geopy.adapters.URLLibAdapter`.
 
             .. versionadded:: 2.0
 

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -203,7 +203,8 @@ class Geocoder:
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         self.scheme = scheme or options.default_scheme
         if self.scheme not in ('http', 'https'):
@@ -221,7 +222,8 @@ class Geocoder:
         if isinstance(self.proxies, str):
             self.proxies = {'http': self.proxies, 'https': self.proxies}
 
-        adapter_factory = options.default_adapter_factory
+        if adapter_factory is None:
+            adapter_factory = options.default_adapter_factory
         self.adapter = adapter_factory(
             proxies=self.proxies,
             ssl_context=self.ssl_context,

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -1,22 +1,15 @@
-import json
-from socket import timeout as SocketTimeout
-from ssl import SSLError
-from urllib.error import HTTPError
-from urllib.request import HTTPSHandler, ProxyHandler, Request, URLError, build_opener
-
+from geopy.adapters import AdapterHTTPError, URLLibAdapter
 from geopy.exc import (
     ConfigurationError,
     GeocoderAuthenticationFailure,
     GeocoderInsufficientPrivileges,
-    GeocoderParseError,
     GeocoderQueryError,
     GeocoderQuotaExceeded,
     GeocoderServiceError,
     GeocoderTimedOut,
-    GeocoderUnavailable,
 )
 from geopy.point import Point
-from geopy.util import __version__, decode_page, logger
+from geopy.util import __version__, logger
 
 __all__ = (
     "Geocoder",
@@ -24,6 +17,12 @@ __all__ = (
 )
 
 _DEFAULT_USER_AGENT = "geopy/%s" % __version__
+
+_DEFAULT_ADAPTER_CLASS = next(
+    adapter_cls
+    for adapter_cls in (URLLibAdapter,)
+    if adapter_cls.is_available
+)
 
 
 class options:
@@ -50,6 +49,29 @@ class options:
         7
 
     Attributes:
+        default_adapter_factory
+            A callable which returns a :class:`geopy.adapters.BaseAdapter`
+            instance. Adapters are different implementations of HTTP clients.
+            See :mod:`geopy.adapters` for more info.
+
+            This callable accepts two keyword args: ``proxies`` and ``ssl_context``.
+            A class might be specified as this callable as well.
+
+            Example::
+
+                import geopy.geocoders
+                geopy.geocoders.options.default_adapter_factory \
+= geopy.adapters.URLLibAdapter
+
+                geopy.geocoders.options.default_adapter_factory = (
+                    lambda proxies, ssl_context: MyAdapter(
+                        proxies=proxies, ssl_context=ssl_context, my_custom_arg=42
+                    )
+                )
+
+            Default adapter is :class:`geopy.adapters.URLLibAdapter`.
+
+            .. versionadded:: 2.0
 
         default_proxies
             Tunnel requests through HTTP proxy.
@@ -140,6 +162,7 @@ class options:
     #
     # [1]: http://www.sphinx-doc.org/en/master/ext/autodoc.html#directive-autoattribute
     # [2]: https://github.com/rtfd/readthedocs.org/issues/855#issuecomment-261337038
+    default_adapter_factory = _DEFAULT_ADAPTER_CLASS
     default_proxies = None
     default_scheme = 'https'
     default_ssl_context = None
@@ -198,18 +221,11 @@ class Geocoder:
         if isinstance(self.proxies, str):
             self.proxies = {'http': self.proxies, 'https': self.proxies}
 
-        # `ProxyHandler` should be present even when actually there're
-        # no proxies. `build_opener` contains it anyway. By specifying
-        # it here explicitly we can disable system proxies (i.e.
-        # from HTTP_PROXY env var) by setting `self.proxies` to `{}`.
-        # Otherwise, if we didn't specify ProxyHandler for empty
-        # `self.proxies` here, build_opener would have used one internally
-        # which could have unwillingly picked up the system proxies.
-        opener = build_opener(
-            HTTPSHandler(context=self.ssl_context),
-            ProxyHandler(self.proxies),
+        adapter_factory = options.default_adapter_factory
+        self.adapter = adapter_factory(
+            proxies=self.proxies,
+            ssl_context=self.ssl_context,
         )
-        self.urlopen = opener.open
 
     def _coerce_point_to_string(self, point, output_format="%(lat)s,%(lon)s"):
         """
@@ -251,9 +267,7 @@ class Geocoder:
                                     lat2=max(p1.latitude, p2.latitude),
                                     lon2=max(p1.longitude, p2.longitude))
 
-    def _geocoder_exception_handler(
-            self, error, message, http_code=None, http_body=None
-    ):
+    def _geocoder_exception_handler(self, error):
         """
         Geocoder-specific exceptions handler.
         Override if custom exceptions processing is needed.
@@ -277,74 +291,29 @@ class Geocoder:
         req_headers = self.headers.copy()
         if headers:
             req_headers.update(headers)
-        req = Request(url=url, headers=req_headers)
 
         timeout = (timeout if timeout is not DEFAULT_SENTINEL
                    else self.timeout)
 
         try:
-            page = self.urlopen(req, timeout=timeout)
-        except Exception as error:
-            message = (
-                str(error.args[0])
-                if len(error.args)
-                else str(error)
-            )
-            if isinstance(error, HTTPError):
-                http_code = error.getcode()
-                http_body = self._read_http_error_body(error)
-                if http_body:
-                    logger.info('Received an HTTP error (%s): %s', http_code, http_body,
-                                exc_info=False)
+            if is_json:
+                return self.adapter.get_json(url, timeout=timeout, headers=req_headers)
             else:
-                http_code = None
-                http_body = None
-            self._geocoder_exception_handler(error, message, http_code, http_body)
-            if isinstance(error, HTTPError):
-                try:
-                    raise ERROR_CODE_MAP[http_code](message)
-                except KeyError:
-                    raise GeocoderServiceError(message)
-            elif isinstance(error, URLError):
-                if "timed out" in message:
-                    raise GeocoderTimedOut('Service timed out')
-                elif "unreachable" in message:
-                    raise GeocoderUnavailable('Service not available')
-            elif isinstance(error, SocketTimeout):
-                raise GeocoderTimedOut('Service timed out')
-            elif isinstance(error, SSLError):
-                if "timed out" in message:
-                    raise GeocoderTimedOut('Service timed out')
-            raise GeocoderServiceError(message)
-
-        if hasattr(page, 'getcode'):
-            status_code = page.getcode()
-        elif hasattr(page, 'status_code'):
-            status_code = page.status_code
-        else:
-            status_code = None
-        if status_code in ERROR_CODE_MAP:
-            raise ERROR_CODE_MAP[page.status_code]("\n%s" % decode_page(page))
-
-        page = decode_page(page)
-
-        if is_json:
-            try:
-                return json.loads(page)
-            except ValueError:
-                raise GeocoderParseError(
-                    "Could not deserialize using deserializer:\n%s" % page
+                return self.adapter.get_text(url, timeout=timeout, headers=req_headers)
+        except AdapterHTTPError as error:
+            if error.text:
+                logger.info(
+                    'Received an HTTP error (%s): %s',
+                    error.status_code,
+                    error.text,
+                    exc_info=False,
                 )
-        else:
-            return page
-
-    def _read_http_error_body(self, error):
-        try:
-            return decode_page(error)
-        except Exception:
-            logger.debug('Unable to fetch body for a non-successful HTTP response',
-                         exc_info=True)
-            return None
+            self._geocoder_exception_handler(error)
+            exc_cls = ERROR_CODE_MAP.get(error.status_code, GeocoderServiceError)
+            raise exc_cls(str(error)) from error
+        except Exception as error:
+            self._geocoder_exception_handler(error)
+            raise
 
     # def geocode(self, query, *, exactly_one=True, timeout=DEFAULT_SENTINEL):
     #     raise NotImplementedError()

--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -41,7 +41,8 @@ class Bing(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -63,6 +64,11 @@ class Bing(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -70,6 +76,7 @@ class Bing(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.api_key = api_key
         domain = 'dev.virtualearth.net'

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -24,7 +24,8 @@ class DataBC(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -43,6 +44,11 @@ class DataBC(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -50,6 +56,7 @@ class DataBC(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         domain = 'apps.gov.bc.ca'
         self.api = '%s://%s%s' % (self.scheme, domain, self.geocode_path)

--- a/geopy/geocoders/geocodeearth.py
+++ b/geopy/geocoders/geocodeearth.py
@@ -18,7 +18,8 @@ class GeocodeEarth(Pelias):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             scheme=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
         :param str api_key: Geocode.earth API key, required.
@@ -41,6 +42,11 @@ class GeocodeEarth(Pelias):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         """
         super().__init__(
             api_key=api_key,
@@ -50,4 +56,5 @@ class GeocodeEarth(Pelias):
             user_agent=user_agent,
             scheme=scheme,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )

--- a/geopy/geocoders/geocodefarm.py
+++ b/geopy/geocoders/geocodefarm.py
@@ -30,6 +30,7 @@ class GeocodeFarm(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             scheme=None
     ):
         """
@@ -50,6 +51,11 @@ class GeocodeFarm(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`.
         """
@@ -59,6 +65,7 @@ class GeocodeFarm(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.api_key = api_key
         domain = 'www.geocode.farm'

--- a/geopy/geocoders/geolake.py
+++ b/geopy/geocoders/geolake.py
@@ -40,7 +40,8 @@ class Geolake(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -67,6 +68,11 @@ class Geolake(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         """
         super().__init__(
             scheme=scheme,
@@ -74,6 +80,7 @@ class Geolake(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -42,6 +42,7 @@ class GeoNames(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             scheme='http'
     ):
         """
@@ -62,6 +63,11 @@ class GeoNames(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str scheme:
             See :attr:`geopy.geocoders.options.default_scheme`. Note that
             at the time of writing GeoNames doesn't support `https`, so
@@ -76,6 +82,7 @@ class GeoNames(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.username = username
 

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -42,6 +42,7 @@ class GoogleV3(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             channel=''
     ):
         """
@@ -77,6 +78,11 @@ class GoogleV3(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str channel: If using premier, the channel identifier.
         """
         super().__init__(
@@ -85,6 +91,7 @@ class GoogleV3(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         if client_id and not secret_key:
             raise ConfigurationError('Must provide secret_key with client_id.')

--- a/geopy/geocoders/here.py
+++ b/geopy/geocoders/here.py
@@ -48,7 +48,8 @@ class Here(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -93,6 +94,11 @@ class Here(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -100,6 +106,7 @@ class Here(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         is_apikey = bool(apikey)
         is_app_code = app_id and app_code

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -47,7 +47,8 @@ class IGNFrance(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -85,6 +86,11 @@ class IGNFrance(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -92,6 +98,7 @@ class IGNFrance(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
 
         # Catch if no api key with username and password

--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -26,6 +26,7 @@ class MapBox(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             domain='api.mapbox.com'
     ):
         """
@@ -49,6 +50,11 @@ class MapBox(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str domain: base api domain for mapbox
         """
         super().__init__(
@@ -57,6 +63,7 @@ class MapBox(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.api_key = api_key
         self.domain = domain.strip('/')

--- a/geopy/geocoders/mapquest.py
+++ b/geopy/geocoders/mapquest.py
@@ -33,6 +33,7 @@ class MapQuest(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             domain='www.mapquestapi.com'
     ):
         """
@@ -56,6 +57,11 @@ class MapQuest(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str domain: base api domain for mapquest
         """
         super().__init__(
@@ -64,6 +70,7 @@ class MapQuest(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/maptiler.py
+++ b/geopy/geocoders/maptiler.py
@@ -26,6 +26,7 @@ class MapTiler(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             domain='api.maptiler.com'
     ):
         """
@@ -49,6 +50,11 @@ class MapTiler(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str domain: base api domain for Maptiler
         """
         super().__init__(
@@ -57,6 +63,7 @@ class MapTiler(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.api_key = api_key
         self.domain = domain.strip('/')

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -26,7 +26,8 @@ class OpenCage(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -52,6 +53,11 @@ class OpenCage(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -59,6 +65,7 @@ class OpenCage(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -30,7 +30,8 @@ class OpenMapQuest(Nominatim):
             domain='open.mapquestapi.com',
             scheme=None,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -54,6 +55,11 @@ class OpenMapQuest(Nominatim):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             timeout=timeout,
@@ -62,6 +68,7 @@ class OpenMapQuest(Nominatim):
             scheme=scheme,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.api_key = api_key
 

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -57,7 +57,8 @@ class Nominatim(Geocoder):
             domain=_DEFAULT_NOMINATIM_DOMAIN,
             scheme=None,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
             # Make sure to synchronize the changes of this signature in the
             # inheriting classes (e.g. PickPoint).
     ):
@@ -81,6 +82,11 @@ class Nominatim(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -88,6 +94,7 @@ class Nominatim(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
 
         self.domain = domain.strip('/')

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -29,7 +29,8 @@ class Pelias(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             scheme=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
             # Make sure to synchronize the changes of this signature in the
             # inheriting classes (e.g. GeocodeEarth).
     ):
@@ -54,6 +55,11 @@ class Pelias(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         """
         super().__init__(
             scheme=scheme,
@@ -61,6 +67,7 @@ class Pelias(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -30,7 +30,8 @@ class Photon(Geocoder):
             proxies=DEFAULT_SENTINEL,
             domain='photon.komoot.de',
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -53,6 +54,11 @@ class Photon(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -60,6 +66,7 @@ class Photon(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.domain = domain.strip('/')
         self.api = "%s://%s%s" % (self.scheme, self.domain, self.geocode_path)

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -23,7 +23,8 @@ class PickPoint(Nominatim):
             domain='api.pickpoint.io',
             scheme=None,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -48,6 +49,11 @@ class PickPoint(Nominatim):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
 
         super().__init__(
@@ -57,6 +63,7 @@ class PickPoint(Nominatim):
             scheme=scheme,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.api_key = api_key
 

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -26,7 +26,8 @@ class LiveAddress(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -46,6 +47,11 @@ class LiveAddress(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme='https',
@@ -53,6 +59,7 @@ class LiveAddress(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.auth_id = auth_id
         self.auth_token = auth_token

--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -28,6 +28,7 @@ class TomTom(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None,
             domain='api.tomtom.com'
     ):
         """
@@ -49,6 +50,11 @@ class TomTom(Geocoder):
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
+
         :param str domain: Domain where the target TomTom service
             is hosted.
         """
@@ -58,6 +64,7 @@ class TomTom(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.api_key = api_key
         self.api = "%s://%s%s" % (self.scheme, domain, self.geocode_path)

--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -1,5 +1,6 @@
 from urllib.parse import quote, urlencode
 
+from geopy.adapters import AdapterHTTPError
 from geopy.exc import GeocoderQuotaExceeded
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
 from geopy.location import Location
@@ -213,9 +214,10 @@ class TomTom(Geocoder):
         return Location(result['address']['freeformAddress'],
                         (latitude, longitude), result)
 
-    def _geocoder_exception_handler(
-            self, error, message, http_code=None, http_body=None
-    ):
-        if http_code is not None and http_body is not None:
-            if http_code >= 400 and "Developer Over Qps" in http_body:
-                raise GeocoderQuotaExceeded("Developer Over Qps")
+    def _geocoder_exception_handler(self, error):
+        if not isinstance(error, AdapterHTTPError):
+            return
+        if error.status_code is None or error.text is None:
+            return
+        if error.status_code >= 400 and "Developer Over Qps" in error.text:
+            raise GeocoderQuotaExceeded("Developer Over Qps") from error

--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -30,7 +30,8 @@ class What3Words(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -49,6 +50,11 @@ class What3Words(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme='https',
@@ -56,6 +62,7 @@ class What3Words(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -29,7 +29,8 @@ class Yandex(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             scheme=None,
-            ssl_context=DEFAULT_SENTINEL
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
     ):
         """
 
@@ -51,6 +52,11 @@ class Yandex(Geocoder):
         :type ssl_context: :class:`ssl.SSLContext`
         :param ssl_context:
             See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -58,6 +64,7 @@ class Yandex(Geocoder):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
         )
         self.api_key = api_key
         domain = 'geocode-maps.yandex.ru'

--- a/geopy/util.py
+++ b/geopy/util.py
@@ -24,20 +24,5 @@ def join_filter(sep, seq, pred=bool):
     return sep.join([str(i) for i in seq if pred(i)])
 
 
-def decode_page(page):
-    """
-    Return unicode string of geocoder results.
-
-    Nearly all services use JSON, so assume UTF8 encoding unless the
-    response specifies otherwise.
-    """
-    if hasattr(page, 'read'):  # urllib
-        encoding = page.headers.get_param("charset") or "utf-8"
-        return str(page.read(), encoding=encoding)
-    else:  # requests?
-        encoding = page.headers.get("charset") or "utf-8"
-        return str(page.content, encoding=encoding)
-
-
 def get_version():
     return __version__

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "dev-test": (EXTRAS_DEV_TESTFILES_COMMON +
                      EXTRAS_DEV_TEST),
         "dev-docs": EXTRAS_DEV_DOCS,
+        "requests": ["requests"],
         "timezone": ["pytz"],
     },
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,16 @@ setup(
         "dev-test": (EXTRAS_DEV_TESTFILES_COMMON +
                      EXTRAS_DEV_TEST),
         "dev-docs": EXTRAS_DEV_DOCS,
-        "requests": ["requests"],
+        "requests": [
+            "urllib3>=1.24.2",
+            # ^^^ earlier versions would work, but a custom ssl
+            # context would silently have system certificates be loaded as
+            # trusted: https://github.com/urllib3/urllib3/pull/1566
+
+            "requests>=2.16.2",
+            # ^^^ earlier versions would work, but they use an older
+            # vendored version of urllib3 (see note above)
+        ],
         "timezone": ["pytz"],
     },
     license='MIT',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -183,7 +183,9 @@ def patch_urllib(monkeypatch, requests_monitor, is_internet_access_allowed):
                         if record_request:
                             requests_monitor.record_response(req, resp, end - start)
                         return resp
-                except:  # noqa
+                except Exception as e:
+                    if "SSL" in str(e):  # Don't retry TLS verification errors
+                        raise
                     if i == retries:
                         raise
                 if record_request:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,21 +1,24 @@
 import atexit
+import contextlib
 import os
 from collections import defaultdict
-from statistics import mean
+from functools import partial
+from statistics import mean, median
 from time import sleep
 from timeit import default_timer
+from unittest.mock import patch
 from urllib.parse import urlparse
-from urllib.request import HTTPHandler, HTTPSHandler
 
 import pytest
+
+import geopy.geocoders
+from geopy.adapters import AdapterHTTPError, BaseAdapter
+from geopy.geocoders.base import _DEFAULT_ADAPTER_CLASS
 
 max_retries = int(os.getenv('GEOPY_TEST_RETRIES', 2))
 error_wait_seconds = float(os.getenv('GEOPY_TEST_ERROR_WAIT_SECONDS', 3))
 no_retries_for_hosts = set(os.getenv('GEOPY_TEST_NO_RETRIES_FOR_HOSTS', '').split(','))
 retry_status_codes = (429,)
-
-http_handler_do_open = 'urllib.request.HTTPHandler.do_open'
-https_handler_do_open = 'urllib.request.HTTPSHandler.do_open'
 
 
 def pytest_addoption(parser):
@@ -28,17 +31,20 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def is_internet_access_allowed(request):
     return not request.config.getoption("--skip-tests-requiring-internet")
 
 
-def netloc_from_req(req):  # urllib request
-    return urlparse(req.get_full_url()).netloc
+@pytest.fixture
+def skip_if_internet_access_is_not_allowed(is_internet_access_allowed):
+    # Used in test_adapters.py, which doesn't use the injected adapter below.
+    if not is_internet_access_allowed:
+        pytest.skip("Skipping a test requiring Internet access")
 
 
-def hostname_from_req(req):  # urllib request
-    return urlparse(req.get_full_url()).hostname
+def netloc_from_url(url):
+    return urlparse(url).netloc
 
 
 def pretty_dict_format(heading, dict_to_format,
@@ -60,42 +66,50 @@ def pretty_dict_format(heading, dict_to_format,
 
 
 class RequestsMonitor:
-    """RequestsMonitor holds statistics of urllib requests."""
+    """RequestsMonitor holds statistics of Adapter requests."""
 
     def __init__(self):
         self.host_stats = defaultdict(lambda: dict(count=0, retries=0, times=[]))
 
-    def record_request(self, req):
-        hostname = netloc_from_req(req)
+    def record_request(self, url):
+        hostname = netloc_from_url(url)
         self.host_stats[hostname]['count'] += 1
 
-    def record_retry(self, req):
-        hostname = netloc_from_req(req)
+    def record_retry(self, url):
+        hostname = netloc_from_url(url)
         self.host_stats[hostname]['retries'] += 1
 
-    def record_response(self, req, resp, seconds_elapsed):
-        hostname = netloc_from_req(req)
-        self.host_stats[hostname]['times'].append(seconds_elapsed)
+    @contextlib.contextmanager
+    def record_response(self, url):
+        start = default_timer()
+        try:
+            yield
+        finally:
+            end = default_timer()
+            hostname = netloc_from_url(url)
+            self.host_stats[hostname]['times'].append(end - start)
 
     def __str__(self):
         def value_mapper(v):
             tv = v['times']
-            times_format = "min:%5.2fs, max:%5.2fs, mean:%5.2fs, total:%5.2fs"
+            times_format = (
+                "min:%5.2fs, median:%5.2fs, max:%5.2fs, mean:%5.2fs, total:%5.2fs"
+            )
             if tv:
                 # min/max require a non-empty sequence.
-                times = times_format % (min(tv), max(tv), mean(tv), sum(tv))
+                times = times_format % (min(tv), median(tv), max(tv), mean(tv), sum(tv))
             else:
                 nan = float("nan")
-                times = times_format % (nan, nan, nan, 0)
+                times = times_format % (nan, nan, nan, nan, 0)
 
             count = "count:%3d" % v['count']
             retries = "retries:%3d" % v['retries'] if v['retries'] else ""
             return "; ".join(s for s in (count, times, retries) if s)
 
         legend = (
-            "count -- number of requests (excluding retries); "
-            "min, max, mean, total -- request duration statistics "
-            "(excluding failed requests); retries -- number of retries."
+            "count – number of requests (excluding retries); "
+            "min, median, max, mean, total – request duration statistics "
+            "(excluding failed requests); retries – number of retries."
         )
         return pretty_dict_format('Request statistics per hostname',
                                   self.host_stats,
@@ -120,58 +134,53 @@ def print_requests_monitor_report(requests_monitor):
     atexit.register(report)
 
 
-@pytest.fixture(autouse=True)
-def patch_urllib(monkeypatch, requests_monitor, is_internet_access_allowed):
+@pytest.fixture(autouse=True, scope='session')
+def patch_adapter(requests_monitor, is_internet_access_allowed):
     """
-    Patch urllib to provide the following features:
+    Patch the default Adapter to provide the following features:
         - Retry failed requests. Makes test runs more stable.
         - Track statistics with RequestsMonitor.
         - Skip tests requiring Internet access when Internet access is not allowed.
-
-    Retries could have been implemented differently:
-        - In test.geocoders.util.GeocoderTestBase._make_request. The issue
-          is that proxy tests use raw urlopen on the proxy server side,
-          which will not be covered by _make_request.
-        - With pytest plugins, such as pytest-rerunfailures. This
-          might be a good alternative, however, they don't distinguish
-          between network and test logic failures (the latter shouldn't
-          be re-run).
     """
 
-    def mock_factory(do_open):
-        def wrapped_do_open(self, conn, req, *args, **kwargs):
-            retries = max_retries
-            netloc = netloc_from_req(req)  # `localhost:8080`, `[::1]:8080`
-            hostname = hostname_from_req(req)  # `localhost`, `::1`
+    class AdapterProxy(BaseAdapter):
+        def __init__(self, *, proxies, ssl_context, adapter_factory):
+            self.adapter = adapter_factory(
+                proxies=proxies,
+                ssl_context=ssl_context,
+            )
 
-            is_hostname_localhost = hostname in ('localhost', '127.0.0.1', '::1')
+        def get_json(self, url, *, timeout, headers):
+            return self._wrapped_get(
+                url,
+                partial(self.adapter.get_json, url, timeout=timeout, headers=headers),
+            )
+
+        def get_text(self, url, *, timeout, headers):
+            return self._wrapped_get(
+                url,
+                partial(self.adapter.get_text, url, timeout=timeout, headers=headers),
+            )
+
+        def _wrapped_get(self, url, do_request):
             if not is_internet_access_allowed:
-                if not is_hostname_localhost:
-                    pytest.skip("Skipping a test requiring Internet access")
+                # Assume that *all* geocoders require Internet access
+                pytest.skip("Skipping a test requiring Internet access")
 
-            record_request = not is_hostname_localhost
-            if record_request:
-                requests_monitor.record_request(req)
-            is_proxied = req.host != netloc
+            requests_monitor.record_request(url)
 
-            if is_proxied or netloc in no_retries_for_hosts:
-                # XXX If there's a system proxy enabled, the failed requests
-                # won't be retried at all because of this check.
-                # We need to disable retries for proxies in order to
-                # not retry requests to the local proxy server set up in
-                # tests/proxy_server.py, which breaks request counters
-                # in tests/test_proxy.py.
-                # Perhaps we could also check that `req.host` points
-                # to localhost?
+            netloc = netloc_from_url(url)
+            retries = max_retries
+
+            if netloc in no_retries_for_hosts:
                 retries = 0
 
             for i in range(retries + 1):
                 try:
-                    start = default_timer()
-                    resp = do_open(self, conn, req, *args, **kwargs)
-                    end = default_timer()
-
-                    if i == retries or resp.getcode() not in retry_status_codes:
+                    with requests_monitor.record_response(url):
+                        resp = do_request()
+                except AdapterHTTPError as error:
+                    if i == retries or error.status_code not in retry_status_codes:
                         # Note: we shouldn't blindly retry on any >=400 code,
                         # because some of them are actually expected in tests
                         # (like input validation verification).
@@ -180,22 +189,60 @@ def patch_urllib(monkeypatch, requests_monitor, is_internet_access_allowed):
                         # Some geocoders return failures with 200 code
                         # (like GoogleV3 for Quota Exceeded).
                         # Should we detect this somehow to restart such requests?
-                        if record_request:
-                            requests_monitor.record_response(req, resp, end - start)
-                        return resp
-                except Exception as e:
-                    if "SSL" in str(e):  # Don't retry TLS verification errors
+                        #
+                        # Re-raise -- don't retry this request
                         raise
+                    else:
+                        # Swallow the error and retry the request
+                        pass
+                except Exception:
                     if i == retries:
                         raise
-                if record_request:
-                    requests_monitor.record_retry(req)
+                else:
+                    return resp
+
+                requests_monitor.record_retry(url)
                 sleep(error_wait_seconds)
             raise RuntimeError("Should not have been reached")
 
-        return wrapped_do_open
+    # In order to take advantage of Keep-Alives in tests, the actual Adapter
+    # should be persisted between the test runs, so this fixture must be
+    # in the "session" scope.
+    InjectableProxy.inject(partial(AdapterProxy, adapter_factory=_DEFAULT_ADAPTER_CLASS))
+    yield
+    InjectableProxy.inject(None)
 
-    original_http_do_open = HTTPHandler.do_open
-    original_https_do_open = HTTPSHandler.do_open
-    monkeypatch.setattr(http_handler_do_open, mock_factory(original_http_do_open))
-    monkeypatch.setattr(https_handler_do_open, mock_factory(original_https_do_open))
+
+class InjectableProxy:
+    _cls_factory = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._target_factory = None
+        self._target = None
+
+    @classmethod
+    def inject(cls, factory):
+        cls._cls_factory = factory
+
+    @property
+    def target(self):
+        cls = type(self)
+        if self._target is None or self._target_factory is not cls._cls_factory:
+            self._target = cls._cls_factory(**self.kwargs)
+            self._target_factory = cls._cls_factory
+        return self._target
+
+    def __getattr__(self, name):
+        return getattr(self.target, name)
+
+
+# InjectableProxy allows to substitute an Adapter instance for already
+# created geocoder classes. Geocoder testcases tend to create Geocoders
+# in the unittest's `setUpClass` method, so the geocoder instances
+# could be reused between test runs.
+#
+# Unfortunately `setUpClass` is executed before the fixtures, so we cannot
+# just patch `geopy.geocoders.options` in a fixture. This hack with
+# `InjectableProxy` allows to inject an Adapter from a pytest fixture.
+patch.object(geopy.geocoders.options, "default_adapter_factory", InjectableProxy).start()

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -42,11 +42,15 @@ class GeocoderTestCase(unittest.TestCase):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
+            adapter_factory=lambda **kw: sentinel.local_adapter,
         )
         for attr in ('scheme', 'timeout', 'proxies', 'ssl_context'):
             assert locals()[attr] == getattr(geocoder, attr)
         assert user_agent == geocoder.headers['User-Agent']
+        assert sentinel.local_adapter is geocoder.adapter
 
+    @patch.object(geopy.geocoders.options, 'default_adapter_factory',
+                  lambda **kw: sentinel.default_adapter)
     def test_init_with_defaults(self):
         attr_to_option = {
             'scheme': 'default_scheme',
@@ -65,6 +69,7 @@ class GeocoderTestCase(unittest.TestCase):
             geopy.geocoders.options.default_user_agent ==
             geocoder.headers['User-Agent']
         )
+        assert sentinel.default_adapter is geocoder.adapter
 
     @patch.object(geopy.geocoders.options, 'default_proxies', {'https': '192.0.2.0'})
     @patch.object(geopy.geocoders.options, 'default_timeout', 10)

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -1,5 +1,4 @@
 import unittest
-import urllib.request
 from contextlib import ExitStack
 from unittest.mock import patch, sentinel
 
@@ -97,45 +96,30 @@ class GeocoderTestCase(unittest.TestCase):
         assert g.timeout == 12
 
         with ExitStack() as stack:
-            mock_urlopen = stack.enter_context(patch.object(g, 'urlopen'))
-            stack.enter_context(
-                patch.object(geopy.geocoders.base, 'decode_page', return_value='{}')
-            )
+            mock_get_json = stack.enter_context(patch.object(g.adapter, 'get_json'))
 
             g._call_geocoder(url)
-            args, kwargs = mock_urlopen.call_args
+            args, kwargs = mock_get_json.call_args
             assert kwargs['timeout'] == 12
 
             g._call_geocoder(url, timeout=7)
-            args, kwargs = mock_urlopen.call_args
+            args, kwargs = mock_get_json.call_args
             assert kwargs['timeout'] == 7
 
             g._call_geocoder(url, timeout=None)
-            args, kwargs = mock_urlopen.call_args
+            args, kwargs = mock_get_json.call_args
             assert kwargs['timeout'] is None
 
     def test_ssl_context(self):
-
-        class HTTPSHandlerStub(urllib.request.HTTPSHandler):
-            def __init__(self, context=None):
-                super().__init__()
-
         with ExitStack() as stack:
-            stack.enter_context(
-                patch.object(geopy.geocoders.base, 'HTTPSHandler', HTTPSHandlerStub)
-            )
-            mock_https_handler_init = stack.enter_context(
-                patch.object(
-                    HTTPSHandlerStub, '__init__', autospec=True,
-                    side_effect=HTTPSHandlerStub.__init__
-                )
+            mock_adapter = stack.enter_context(
+                patch.object(geopy.geocoders.base.options, 'default_adapter_factory')
             )
 
             for ssl_context in (None, sentinel.some_ssl_context):
-                mock_https_handler_init.reset_mock()
                 Geocoder(ssl_context=ssl_context)
-                args, kwargs = mock_https_handler_init.call_args
-                assert kwargs['context'] is ssl_context
+                args, kwargs = mock_adapter.call_args
+                assert kwargs['ssl_context'] is ssl_context
 
 
 class GeocoderPointCoercionTestCase(unittest.TestCase):

--- a/test/test_adapters.py
+++ b/test/test_adapters.py
@@ -9,7 +9,7 @@ from urllib.request import getproxies, urlopen
 import pytest
 
 import geopy.geocoders
-from geopy.adapters import AdapterHTTPError, URLLibAdapter
+from geopy.adapters import AdapterHTTPError, RequestsAdapter, URLLibAdapter
 from geopy.exc import GeocoderParseError, GeocoderServiceError
 from geopy.geocoders.base import Geocoder
 from test.proxy_server import HttpServerThread, ProxyServerThread
@@ -77,7 +77,7 @@ class BaseSystemCATestCase:
         with self.assertRaises(GeocoderServiceError) as cm:
             geocoder_dummy.geocode(self.remote_website_https)
         self.assertIn('SSL', str(cm.exception))
-        self.assertEqual(1, len(self.proxy_server.requests))
+        self.assertLessEqual(1, len(self.proxy_server.requests))  # requests retries
 
     @unittest.skipUnless(not WITH_SYSTEM_PROXIES,
                          "There're active system proxies")
@@ -243,3 +243,15 @@ class URLLibAdapterLocalProxyTestCase(BaseLocalProxyTestCase, unittest.TestCase)
 
 class URLLibAdapterSystemProxiesTestCase(BaseSystemProxiesTestCase, unittest.TestCase):
     adapter_factory = URLLibAdapter
+
+
+class RequestsAdapterSystemCATestCase(BaseSystemCATestCase, unittest.TestCase):
+    adapter_factory = RequestsAdapter
+
+
+class RequestsAdapterLocalProxyTestCase(BaseLocalProxyTestCase, unittest.TestCase):
+    adapter_factory = RequestsAdapter
+
+
+class RequestsAdapterSystemProxiesTestCase(BaseSystemProxiesTestCase, unittest.TestCase):
+    adapter_factory = RequestsAdapter

--- a/test/test_adapters.py
+++ b/test/test_adapters.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 from urllib.parse import urljoin
 from urllib.request import getproxies, urlopen
 
+import pytest
+
 import geopy.geocoders
 from geopy.adapters import AdapterHTTPError, URLLibAdapter
 from geopy.exc import GeocoderParseError, GeocoderServiceError
@@ -27,6 +29,7 @@ class DummyGeocoder(Geocoder):
         return geo_html if geo_html else None
 
 
+@pytest.mark.usefixtures("skip_if_internet_access_is_not_allowed")
 class BaseSystemCATestCase:
     """Test TLS certificates validation using the system-trusted CAs.
     """

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=py{35,36,37,38,39},pypy3,lint,rst
 [testenv]
 extras =
     dev-test
+    requests
     timezone
 whitelist_externals = make
 commands = make test


### PR DESCRIPTION
(This PR contains a subset of commits from #335).

Adapters incapsulate HTTP clients and would allow to:
- replace ineffective `urllib` with a more effective `requests` library, which supports keepalives
- add optional asyncio support