### PR TITLE
geopy 2.0: Convert `_call_geocoder` to callback style

### DIFF
--- a/geopy/geocoders/algolia.py
+++ b/geopy/geocoders/algolia.py
@@ -1,4 +1,5 @@
 import collections.abc
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -201,11 +202,8 @@ class AlgoliaPlaces(Geocoder):
             headers['X-Algolia-API-Key'] = self.api_key
 
         logger.debug('%s.geocode: %s', self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, headers=headers, timeout=timeout),
-            exactly_one,
-            language=language,
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one, language=language)
+        return self._call_geocoder(url, callback, headers=headers, timeout=timeout)
 
     def reverse(
             self,
@@ -264,11 +262,8 @@ class AlgoliaPlaces(Geocoder):
             headers['X-Algolia-API-Key'] = self.api_key
 
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, headers=headers, timeout=timeout),
-            exactly_one,
-            language=language,
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one, language=language)
+        return self._call_geocoder(url, callback, headers=headers, timeout=timeout)
 
     def _parse_feature(self, feature, language):
         # Parse each resource.

--- a/geopy/geocoders/baidu.py
+++ b/geopy/geocoders/baidu.py
@@ -1,4 +1,5 @@
 import hashlib
+from functools import partial
 from urllib.parse import quote_plus, urlencode
 
 from geopy.exc import (
@@ -125,9 +126,8 @@ class Baidu(Geocoder):
         url = self._construct_url(self.api, self.api_path, params)
 
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one=exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(self, query, *, exactly_one=True, timeout=DEFAULT_SENTINEL):
         """
@@ -159,9 +159,8 @@ class Baidu(Geocoder):
         url = self._construct_url(self.reverse_api, self.reverse_path, params)
 
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_reverse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one=exactly_one
-        )
+        callback = partial(self._parse_reverse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_reverse_json(self, page, exactly_one=True):
         """

--- a/geopy/geocoders/banfrance.py
+++ b/geopy/geocoders/banfrance.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -113,9 +114,8 @@ class BANFrance(Geocoder):
         url = "?".join((self.geocode_api, urlencode(params)))
 
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -157,9 +157,8 @@ class BANFrance(Geocoder):
 
         url = "?".join((self.reverse_api, urlencode(params)))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_feature(self, feature):
         # Parse each resource.

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -284,6 +284,7 @@ class Geocoder:
     def _call_geocoder(
             self,
             url,
+            callback,
             *,
             timeout=DEFAULT_SENTINEL,
             is_json=True,
@@ -302,9 +303,10 @@ class Geocoder:
 
         try:
             if is_json:
-                return self.adapter.get_json(url, timeout=timeout, headers=req_headers)
+                result = self.adapter.get_json(url, timeout=timeout, headers=req_headers)
             else:
-                return self.adapter.get_text(url, timeout=timeout, headers=req_headers)
+                result = self.adapter.get_text(url, timeout=timeout, headers=req_headers)
+            return callback(result)
         except AdapterHTTPError as error:
             if error.text:
                 logger.info(

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -1,3 +1,6 @@
+import functools
+import threading
+
 from geopy.adapters import AdapterHTTPError, RequestsAdapter, URLLibAdapter
 from geopy.exc import (
     ConfigurationError,
@@ -327,3 +330,19 @@ class Geocoder:
 
     # def reverse(self, query, *, exactly_one=True, timeout=DEFAULT_SENTINEL):
     #     raise NotImplementedError()
+
+
+def _synchronized(func):
+    """A decorator for geocoder methods which makes the method always run
+    under a lock. The lock is reentrant.
+
+    This decorator transparently handles sync and async working modes.
+    """
+    lock = threading.RLock()
+
+    @functools.wraps(func)
+    def f(self, *args, **kwargs):
+        with lock:
+            return func(self, *args, **kwargs)
+
+    return f

--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -1,4 +1,5 @@
 import collections.abc
+from functools import partial
 from urllib.parse import quote, urlencode
 
 from geopy.exc import (
@@ -156,10 +157,8 @@ class Bing(Geocoder):
 
         url = "?".join((self.geocode_api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -208,10 +207,8 @@ class Bing(Geocoder):
                         urlencode(params)))
 
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_json(self, doc, exactly_one=True):
         """

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.exc import GeocoderQueryError
@@ -119,8 +120,10 @@ class DataBC(Geocoder):
 
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        response = self._call_geocoder(url, timeout=timeout)
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
+    def _parse_json(self, response, exactly_one):
         # Success; convert from GeoJSON
         if not len(response['features']):
             return None

--- a/geopy/geocoders/geocodefarm.py
+++ b/geopy/geocoders/geocodefarm.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.exc import (
@@ -100,9 +101,8 @@ class GeocodeFarm(Geocoder):
             params['key'] = self.api_key
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(self, query, *, exactly_one=True, timeout=DEFAULT_SENTINEL):
         """
@@ -137,9 +137,8 @@ class GeocodeFarm(Geocoder):
             params['key'] = self.api_key
         url = "?".join((self.reverse_api, urlencode(params)))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_code(self, results):
         # Parse each resource.

--- a/geopy/geocoders/geolake.py
+++ b/geopy/geocoders/geolake.py
@@ -1,4 +1,5 @@
 import collections.abc
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -149,9 +150,8 @@ class Geolake(Geocoder):
         url = "?".join((self.api, urlencode(params)))
 
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_json(self, page, exactly_one):
         """Returns location, (latitude, longitude) from json feed."""

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.exc import (
@@ -152,10 +153,8 @@ class GeoNames(Geocoder):
             params.append(('maxRows', 1))
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one,
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -235,10 +234,8 @@ class GeoNames(Geocoder):
             )
 
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _reverse_find_nearby_params(self, lat, lng, feature_code):
         params = {
@@ -295,9 +292,7 @@ class GeoNames(Geocoder):
         url = "?".join((self.api_timezone, urlencode(params)))
 
         logger.debug("%s.reverse_timezone: %s", self.__class__.__name__, url)
-        return self._parse_json_timezone(
-            self._call_geocoder(url, timeout=timeout)
-        )
+        return self._call_geocoder(url, self._parse_json_timezone, timeout=timeout)
 
     def _raise_for_error(self, body):
         err = body.get('status')

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -5,6 +5,7 @@ import hmac
 import warnings
 from calendar import timegm
 from datetime import datetime
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.exc import ConfigurationError, GeocoderQueryError, GeocoderQuotaExceeded
@@ -261,9 +262,8 @@ class GoogleV3(Geocoder):
             url = "?".join((self.api, urlencode(params)))
 
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -314,9 +314,8 @@ class GoogleV3(Geocoder):
             url = self._get_signed_url(params)
 
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse_timezone(self, query, *, at_time=None, timeout=DEFAULT_SENTINEL):
         """
@@ -357,9 +356,7 @@ class GoogleV3(Geocoder):
         url = "?".join((self.tz_api, urlencode(params)))
 
         logger.debug("%s.reverse_timezone: %s", self.__class__.__name__, url)
-        return self._parse_json_timezone(
-            self._call_geocoder(url, timeout=timeout)
-        )
+        return self._call_geocoder(url, self._parse_json_timezone, timeout=timeout)
 
     def _parse_json_timezone(self, response):
         status = response.get('status')

--- a/geopy/geocoders/here.py
+++ b/geopy/geocoders/here.py
@@ -1,5 +1,6 @@
 import collections.abc
 import warnings
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.exc import (
@@ -238,10 +239,8 @@ class Here(Geocoder):
 
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -319,10 +318,8 @@ class Here(Geocoder):
             params['app_code'] = self.app_code
         url = "%s?%s" % (self.reverse_api, urlencode(params))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_json(self, doc, exactly_one=True):
         """

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -1,5 +1,6 @@
 import base64
 import xml.etree.ElementTree as ET
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.exc import ConfigurationError, GeocoderQueryError
@@ -222,14 +223,10 @@ class IGNFrance(Geocoder):
         url = "?".join((self.api, urlencode(params)))
 
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-
-        raw_xml = self._request_raw_content(url, timeout)
-
-        return self._parse_xml(
-            raw_xml,
-            is_freeform=is_freeform,
-            exactly_one=exactly_one
+        callback = partial(
+            self._parse_xml, is_freeform=is_freeform, exactly_one=exactly_one
         )
+        return self._request_raw_content(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -315,15 +312,13 @@ class IGNFrance(Geocoder):
         url = "?".join((self.api, urlencode({'xls': request_string})))
 
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-
-        raw_xml = self._request_raw_content(url, timeout)
-
-        return self._parse_xml(
-            raw_xml,
+        callback = partial(
+            self._parse_xml,
             exactly_one=exactly_one,
             is_reverse=True,
             is_freeform='false'
         )
+        return self._request_raw_content(url, callback, timeout=timeout)
 
     def _parse_xml(self,
                    page,
@@ -450,7 +445,7 @@ class IGNFrance(Geocoder):
 
         return places
 
-    def _request_raw_content(self, url, timeout):
+    def _request_raw_content(self, url, callback, *, timeout):
         """
         Send the request to get raw content.
         """
@@ -463,14 +458,13 @@ class IGNFrance(Geocoder):
             auth_str = base64.standard_b64encode(credentials).decode()
             headers['Authorization'] = 'Basic {}'.format(auth_str.strip())
 
-        raw_xml = self._call_geocoder(
+        return self._call_geocoder(
             url,
+            callback,
             headers=headers,
             timeout=timeout,
             is_json=False,
         )
-
-        return raw_xml
 
     def _parse_place(self, place, is_freeform=None):
         """

--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import quote, urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -150,10 +151,8 @@ class MapBox(Geocoder):
         url = "?".join((self.api % dict(query=quoted_query),
                         urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -189,7 +188,5 @@ class MapBox(Geocoder):
         url = "?".join((self.api % dict(query=quoted_query),
                         urlencode(params)))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)

--- a/geopy/geocoders/mapquest.py
+++ b/geopy/geocoders/mapquest.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -168,10 +169,8 @@ class MapQuest(Geocoder):
         url = '?'.join((self.geocode_api, urlencode(params)))
 
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -208,7 +207,5 @@ class MapQuest(Geocoder):
         url = '?'.join((self.reverse_api, urlencode(params)))
 
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)

--- a/geopy/geocoders/maptiler.py
+++ b/geopy/geocoders/maptiler.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import quote, urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -147,9 +148,8 @@ class MapTiler(Geocoder):
         url = "?".join((self.api % dict(query=quoted_query),
                         urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -194,6 +194,5 @@ class MapTiler(Geocoder):
         url = "?".join((self.api % dict(query=quoted_query),
                         urlencode(params)))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.exc import GeocoderQueryError, GeocoderQuotaExceeded
@@ -139,9 +140,8 @@ class OpenCage(Geocoder):
         url = "?".join((self.api, urlencode(params)))
 
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -183,9 +183,8 @@ class OpenCage(Geocoder):
 
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_json(self, page, exactly_one=True):
         '''Returns location, (latitude, longitude) from json feed.'''

--- a/geopy/geocoders/osm.py
+++ b/geopy/geocoders/osm.py
@@ -1,4 +1,5 @@
 import collections.abc
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.exc import ConfigurationError, GeocoderQueryError
@@ -289,10 +290,8 @@ class Nominatim(Geocoder):
 
         url = self._construct_url(self.api, params)
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -356,10 +355,8 @@ class Nominatim(Geocoder):
 
         url = self._construct_url(self.reverse_api, params)
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_code(self, place):
         # Parse each resource.

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -143,9 +144,8 @@ class Pelias(Geocoder):
 
         url = "?".join((self.geocode_api, urlencode(params)))
         logger.debug("%s.geocode_api: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -199,9 +199,8 @@ class Pelias(Geocoder):
 
         url = "?".join((self.reverse_api, urlencode(params)))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_code(self, feature):
         # Parse each resource.

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -1,4 +1,5 @@
 import collections.abc
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -141,10 +142,8 @@ class Photon(Geocoder):
                 params['osm_tag'] = list(osm_tag)
         url = "?".join((self.api, urlencode(params, doseq=True)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -195,9 +194,8 @@ class Photon(Geocoder):
             params['lang'] = language
         url = "?".join((self.reverse_api, urlencode(params)))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_json(self, resources, exactly_one=True):
         """

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.adapters import AdapterHTTPError
@@ -108,8 +109,8 @@ class LiveAddress(Geocoder):
         url = '{url}?{query}'.format(url=self.api, query=urlencode(query))
 
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(self._call_geocoder(url, timeout=timeout),
-                                exactly_one)
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _geocoder_exception_handler(self, error):
         search = "no active subscriptions found"

--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import quote, urlencode
 
 from geopy.adapters import AdapterHTTPError
@@ -124,10 +125,8 @@ class TomTom(Geocoder):
         url = "?".join((self.api % dict(query=quoted_query),
                         urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -172,10 +171,8 @@ class TomTom(Geocoder):
         url = "?".join((self.api_reverse % dict(position=quoted_position),
                         urlencode(params)))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-
-        return self._parse_reverse_json(
-            self._call_geocoder(url, timeout=timeout), exactly_one
-        )
+        callback = partial(self._parse_reverse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _boolean_value(self, bool_value):
         return 'true' if bool_value else 'false'

--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -1,4 +1,5 @@
 import re
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy import exc
@@ -125,10 +126,8 @@ class What3Words(Geocoder):
 
         url = "?".join((self.geocode_api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one=exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_json(self, resources, exactly_one=True):
         """
@@ -214,10 +213,8 @@ class What3Words(Geocoder):
         url = "?".join((self.reverse_api, urlencode(params)))
 
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_reverse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one=exactly_one
-        )
+        callback = partial(self._parse_reverse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_reverse_json(self, resources, exactly_one=True):
         """

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -1,3 +1,4 @@
+from functools import partial
 from urllib.parse import urlencode
 
 from geopy.exc import GeocoderParseError, GeocoderServiceError
@@ -115,10 +116,8 @@ class Yandex(Geocoder):
             params['results'] = 1
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one,
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def reverse(
             self,
@@ -177,10 +176,8 @@ class Yandex(Geocoder):
             params['kind'] = kind
         url = "?".join((self.api, urlencode(params)))
         logger.debug("%s.reverse: %s", self.__class__.__name__, url)
-        return self._parse_json(
-            self._call_geocoder(url, timeout=timeout),
-            exactly_one
-        )
+        callback = partial(self._parse_json, exactly_one=exactly_one)
+        return self._call_geocoder(url, callback, timeout=timeout)
 
     def _parse_json(self, doc, exactly_one):
         """

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -103,15 +103,15 @@ class GeocoderTestCase(unittest.TestCase):
         with ExitStack() as stack:
             mock_get_json = stack.enter_context(patch.object(g.adapter, 'get_json'))
 
-            g._call_geocoder(url)
+            g._call_geocoder(url, lambda res: res)
             args, kwargs = mock_get_json.call_args
             assert kwargs['timeout'] == 12
 
-            g._call_geocoder(url, timeout=7)
+            g._call_geocoder(url, lambda res: res, timeout=7)
             args, kwargs = mock_get_json.call_args
             assert kwargs['timeout'] == 7
 
-            g._call_geocoder(url, timeout=None)
+            g._call_geocoder(url, lambda res: res, timeout=None)
             args, kwargs = mock_get_json.call_args
             assert kwargs['timeout'] is None
 

--- a/test/geocoders/geocodefarm.py
+++ b/test/geocoders/geocodefarm.py
@@ -64,19 +64,19 @@ class GeocodeFarmTestCase(GeocoderTestBase):
 
     def test_quota_exceeded(self):
 
-        def mock_call_geocoder(*args, **kwargs):
-            return {
+        def mock_call_geocoder(url, callback, **kwargs):
+            return callback({
                 "geocoding_results": {
                     "STATUS": {
                         "access": "OVER_QUERY_LIMIT",
                         "status": "FAILED, ACCESS_DENIED"
                     }
                 }
-            }
+            })
 
-        with patch.object(self.geocoder, '_call_geocoder', mock_call_geocoder), \
-                pytest.raises(exc.GeocoderQuotaExceeded):
-            self.geocoder.geocode('435 north michigan ave, chicago il 60611')
+        with patch.object(self.geocoder, '_call_geocoder', mock_call_geocoder):
+            with pytest.raises(exc.GeocoderQuotaExceeded):
+                self.geocoder.geocode('435 north michigan ave, chicago il 60611')
 
     def test_no_results(self):
         self.geocode_run(
@@ -87,16 +87,16 @@ class GeocodeFarmTestCase(GeocoderTestBase):
 
     def test_unhandled_api_error(self):
 
-        def mock_call_geocoder(*args, **kwargs):
-            return {
+        def mock_call_geocoder(url, callback, **kwargs):
+            return callback({
                 "geocoding_results": {
                     "STATUS": {
                         "access": "BILL_PAST_DUE",
                         "status": "FAILED, ACCESS_DENIED"
                     }
                 }
-            }
+            })
 
-        with patch.object(self.geocoder, '_call_geocoder', mock_call_geocoder), \
-                pytest.raises(exc.GeocoderServiceError):
-            self.geocoder.geocode('435 north michigan ave, chicago il 60611')
+        with patch.object(self.geocoder, '_call_geocoder', mock_call_geocoder):
+            with pytest.raises(exc.GeocoderServiceError):
+                self.geocoder.geocode('435 north michigan ave, chicago il 60611')

--- a/test/test_adapters.py
+++ b/test/test_adapters.py
@@ -25,8 +25,9 @@ WITH_SYSTEM_PROXIES = bool(getproxies())
 
 class DummyGeocoder(Geocoder):
     def geocode(self, location, *, is_json=False):
-        geo_html = self._call_geocoder(location, is_json=is_json)
-        return geo_html if geo_html else None
+        return self._call_geocoder(
+            location, lambda res: res if res else None, is_json=is_json
+        )
 
 
 @pytest.mark.usefixtures("skip_if_internet_access_is_not_allowed")


### PR DESCRIPTION
(This PR contains a subset of commits from #335).

This would allow to add an optional asyncio support on the Adapters level transparently to Geocoders.

All geocoders except ArcGIS always perform exacly 1 request per method call, so the conversion is rather simple.