### PR TITLE
geopy 2.0: Add optional asyncio support via AioHTTPAdapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - travis_retry pip install -U pip wheel setuptools
 
 install:
-  - travis_retry pip install -e ".[requests,timezone]"
+  - travis_retry pip install -e ".[aiohttp,requests,timezone]"
 
 stages:
   - lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,3 +49,8 @@ jobs:
 
     # The `test` stage using the `python` matrix above is included implicitly.
 
+    # Run a single job with asyncio adapter:
+    # (not the whole matrix, to avoid spending extra quota)
+    - stage: test
+      python: "3.5"
+      env: GEOPY_TEST_ADAPTER=geopy.adapters.AioHTTPAdapter

--- a/docs/changelog_2xx.rst
+++ b/docs/changelog_2xx.rst
@@ -24,7 +24,7 @@ New features
   for HTTP requests, which doesn't support keepalives. Adapters is
   a new mechanism which allows to use other HTTP client implementations.
 
-  There are 2 implementations coming out of the box:
+  There are 3 implementations coming out of the box:
 
   + :class:`geopy.adapters.RequestsAdapter` -- uses ``requests`` library
     which supports keepalives (thus it is significantly more effective
@@ -33,7 +33,11 @@ New features
   + :class:`geopy.adapters.URLLibAdapter` -- uses ``urllib``, basically
     it provides the same behavior as in geopy 1.x. It is used by default if
     ``requests`` package is not installed.
+  + :class:`geopy.adapters.AioHTTPAdapter` -- uses ``aiohttp`` library.
 
+- Added optional asyncio support in all geocoders via
+  :class:`.AioHTTPAdapter`, see the new :ref:`Async Mode <async_mode>`
+  doc section.
 
 Packaging changes
 ~~~~~~~~~~~~~~~~~
@@ -42,6 +46,7 @@ Packaging changes
 - New extras:
 
   + ``geopy[requests]`` for :class:`geopy.adapters.RequestsAdapter`.
+  + ``geopy[aiohttp]`` for :class:`geopy.adapters.AioHTTPAdapter`.
 
 Chores
 ~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -415,6 +415,14 @@ Base Classes
 
     .. automethod:: __init__
 
+.. autoclass:: geopy.adapters.BaseSyncAdapter
+    :show-inheritance:
+    :members:
+
+.. autoclass:: geopy.adapters.BaseAsyncAdapter
+    :show-inheritance:
+    :members:
+
 Logging
 ~~~~~~~
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -401,6 +401,9 @@ Supported Adapters
 .. autoclass:: geopy.adapters.URLLibAdapter
     :show-inheritance:
 
+.. autoclass:: geopy.adapters.AioHTTPAdapter
+    :show-inheritance:
+
 
 Base Classes
 ------------

--- a/geopy/adapters.py
+++ b/geopy/adapters.py
@@ -116,7 +116,6 @@ class BaseAdapter(abc.ABC):
             See :attr:`geopy.geocoders.options.default_ssl_context`.
 
         """
-        pass
 
     @abc.abstractmethod
     def get_json(self, url, *, timeout, headers):
@@ -133,7 +132,6 @@ class BaseAdapter(abc.ABC):
 
         :param dict headers: A dict with custom HTTP request headers.
         """
-        pass
 
     @abc.abstractmethod
     def get_text(self, url, *, timeout, headers):
@@ -157,7 +155,6 @@ class BaseAdapter(abc.ABC):
 
         :param dict headers: A dict with custom HTTP request headers.
         """
-        pass
 
 
 class BaseSyncAdapter(BaseAdapter):

--- a/geopy/adapters.py
+++ b/geopy/adapters.py
@@ -454,6 +454,8 @@ class AioHTTPAdapter(BaseAsyncAdapter):
         if self.proxies:
             scheme = urlparse(url).scheme
             proxy = self.proxies.get(scheme.lower())
+            if proxy and "://" not in proxy:
+                proxy = "http://%s" % proxy
         else:
             proxy = None
         return self.session.get(

--- a/geopy/compat.py
+++ b/geopy/compat.py
@@ -1,0 +1,7 @@
+try:
+    # >=3.7
+    from asyncio import current_task
+except ImportError:
+    from asyncio import Task
+    current_task = Task.current_task
+    del Task

--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -142,6 +142,32 @@ Therefore:
 If you face any problem with your current geocoding service provider, you can
 always try a different one.
 
+Async Mode
+~~~~~~~~~~
+
+By default geopy geocoders are synchronous (i.e. they use an Adapter
+based on :class:`.BaseSyncAdapter`).
+
+All geocoders can be used with asyncio by simply switching to an
+Adapter based on :class:`.BaseAsyncAdapter` (like :class:`.AioHTTPAdapter`).
+
+Example::
+
+    from geopy.adapters import AioHTTPAdapter
+    from geopy.geocoders import Nominatim
+
+    async with Nominatim(
+        user_agent="specify_your_app_name_here",
+        adapter_factory=AioHTTPAdapter,
+    ) as geolocator:
+        location = await geolocator.geocode("175 5th Avenue NYC")
+        print(location.address)
+
+Basically the usage is the same as in synchronous mode, except that
+all geocoder calls should be used with ``await``, and the geocoder
+instance should be created by ``async with``. The context manager is optional,
+however, it is strongly advised to use it to avoid resources leaks.
+
 """
 
 __all__ = (

--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -142,6 +142,8 @@ Therefore:
 If you face any problem with your current geocoding service provider, you can
 always try a different one.
 
+.. _async_mode:
+
 Async Mode
 ~~~~~~~~~~
 

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -94,7 +94,7 @@ class options:
             By default the system proxies are respected (e.g.
             `HTTP_PROXY` and `HTTPS_PROXY` env vars or platform-specific
             proxy settings, such as macOS or Windows native
-            preferences -- see :class:`urllib.request.ProxyHandler` for
+            preferences -- see :func:`urllib.request.getproxies` for
             more details). The `proxies` value for using system proxies
             is ``None``.
 
@@ -128,7 +128,7 @@ class options:
               `proxies` dict.
 
             For more information, see
-            documentation on :class:`urllib.request.ProxyHandler`.
+            documentation on :func:`urllib.request.getproxies`.
 
         default_scheme
             Use ``'https'`` or ``'http'`` as the API URL's scheme.

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ INSTALL_REQUIRES = [
 ]
 
 EXTRAS_DEV_TESTFILES_COMMON = [
+    "async_generator",
 ]
 
 EXTRAS_DEV_LINT = [
@@ -32,6 +33,7 @@ EXTRAS_DEV_LINT = [
 
 EXTRAS_DEV_TEST = [
     "coverage",
+    "pytest-aiohttp",  # for `async def` tests
     "pytest>=3.10",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "dev-test": (EXTRAS_DEV_TESTFILES_COMMON +
                      EXTRAS_DEV_TEST),
         "dev-docs": EXTRAS_DEV_DOCS,
+        "aiohttp": ["aiohttp"],
         "requests": [
             "urllib3>=1.24.2",
             # ^^^ earlier versions would work, but a custom ssl

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 import pytest
 
 import geopy.geocoders
-from geopy.adapters import AdapterHTTPError, BaseAdapter
+from geopy.adapters import AdapterHTTPError, BaseAdapter, BaseSyncAdapter
 from geopy.geocoders.base import _DEFAULT_ADAPTER_CLASS
 
 max_retries = int(os.getenv('GEOPY_TEST_RETRIES', 2))
@@ -235,6 +235,9 @@ class InjectableProxy:
 
     def __getattr__(self, name):
         return getattr(self.target, name)
+
+
+BaseSyncAdapter.register(InjectableProxy)
 
 
 # InjectableProxy allows to substitute an Adapter instance for already

--- a/test/geocoders/algolia.py
+++ b/test/geocoders/algolia.py
@@ -1,13 +1,9 @@
 from geopy.geocoders import AlgoliaPlaces
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-class AlgoliaPlacesTestCase(GeocoderTestBase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.geocoder = cls.make_geocoder()
+class TestAlgoliaPlaces(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
@@ -17,44 +13,44 @@ class AlgoliaPlacesTestCase(GeocoderTestBase):
             timeout=3,
             **kwargs)
 
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = self.make_geocoder(
             user_agent='my_user_agent/1.0'
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_geocode(self):
-        location = self.geocode_run(
+    async def test_geocode(self):
+        location = await self.geocode_run(
             {'query': 'москва'},
             {'latitude': 55.75587, 'longitude': 37.61768},
         )
         assert 'Москва' in location.address
 
-    def test_reverse(self):
-        location = self.reverse_run(
+    async def test_reverse(self):
+        location = await self.reverse_run(
             {'query': '51, -0.13', 'language': 'en'},
             {'latitude': 51, 'longitude': -0.13},
         )
         assert 'A272' in location.address
 
-    def test_reverse_no_result(self):
-        self.reverse_run(
+    async def test_reverse_no_result(self):
+        await self.reverse_run(
             # North Atlantic Ocean
             {'query': (35.173809, -37.485351)},
             {},
             expect_failure=True
         )
 
-    def test_explicit_type(self):
-        location = self.geocode_run(
+    async def test_explicit_type(self):
+        location = await self.geocode_run(
             {'query': 'Madrid', 'type': 'city', 'language': 'en'},
             {},
         )
         assert 'Madrid' in location.address
 
-    def test_limit(self):
+    async def test_limit(self):
         limit = 5
-        locations = self.geocode_run(
+        locations = await self.geocode_run(
             {'query': 'Madrid', 'type': 'city',
              'language': 'en', 'exactly_one': False,
              'limit': limit},
@@ -62,37 +58,37 @@ class AlgoliaPlacesTestCase(GeocoderTestBase):
         )
         assert len(locations) == limit
 
-    def test_countries(self):
+    async def test_countries(self):
         countries = ["ES"]
-        location = self.geocode_run(
+        location = await self.geocode_run(
             {'query': 'Madrid', 'language': 'en',
              'countries': countries},
             {},
         )
         assert "Madrid" in location.address
 
-    def test_countries_no_result(self):
+    async def test_countries_no_result(self):
         countries = ["NO", "IT"]
-        self.geocode_run(
+        await self.geocode_run(
             {'query': 'Madrid', 'language': 'en',
              'countries': countries},
             {},
             expect_failure=True
         )
 
-    def test_geocode_no_result(self):
-        self.geocode_run(
+    async def test_geocode_no_result(self):
+        await self.geocode_run(
             {'query': 'sldkfhdskjfhsdkhgflaskjgf'},
             {},
             expect_failure=True,
         )
 
-    def test_around(self):
-        self.geocode_run(
+    async def test_around(self):
+        await self.geocode_run(
             {'query': 'maple street', 'language': 'en', 'around': Point(51.1, -0.1)},
             {'latitude': 51.5299, 'longitude': -0.0628044, "delta": 1},
         )
-        self.geocode_run(
+        await self.geocode_run(
             {'query': 'maple street', 'language': 'en', 'around': Point(50.1, 10.1)},
             {'latitude': 50.0517, 'longitude': 10.1966, "delta": 1},
         )

--- a/test/geocoders/azure.py
+++ b/test/geocoders/azure.py
@@ -1,15 +1,15 @@
-import unittest
+import pytest
 
 from geopy.geocoders import AzureMaps
-from test.geocoders.tomtom import BaseTomTomTestCase
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.tomtom import BaseTestTomTom
+from test.geocoders.util import env
 
 
-@unittest.skipUnless(
-    bool(env.get('AZURE_SUBSCRIPTION_KEY')),
-    "No AZURE_SUBSCRIPTION_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('AZURE_SUBSCRIPTION_KEY')),
+    reason="No AZURE_SUBSCRIPTION_KEY env variable set"
 )
-class AzureMapsTestCase(BaseTomTomTestCase, GeocoderTestBase):
+class TestAzureMaps(BaseTestTomTom):
 
     @classmethod
     def make_geocoder(cls, **kwargs):

--- a/test/geocoders/baidu.py
+++ b/test/geocoders/baidu.py
@@ -1,30 +1,29 @@
-import unittest
-
 import pytest
 
 from geopy.exc import GeocoderAuthenticationFailure
 from geopy.geocoders import Baidu, BaiduV3
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-class BaiduTestCaseUnitTest(GeocoderTestBase):
+class TestUnitBaidu(BaseTestGeocoder):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = Baidu(
+    def make_geocoder(cls, **kwargs):
+        return Baidu(
             api_key='DUMMYKEY1234',
-            user_agent='my_user_agent/1.0'
+            user_agent='my_user_agent/1.0',
+            **kwargs
         )
 
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         assert self.geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
 
-class BaiduQueriesTestCaseMixin:
+class BaseTestBaidu(BaseTestGeocoder):
 
-    def test_basic_address(self):
-        self.geocode_run(
+    async def test_basic_address(self):
+        await self.geocode_run(
             {"query": (
                 "\u5317\u4eac\u5e02\u6d77\u6dc0\u533a"
                 "\u4e2d\u5173\u6751\u5927\u885727\u53f7"
@@ -32,53 +31,55 @@ class BaiduQueriesTestCaseMixin:
             {"latitude": 39.983615544507, "longitude": 116.32295155093},
         )
 
-    def test_reverse_point(self):
-        self.reverse_run(
+    async def test_reverse_point(self):
+        await self.reverse_run(
             {"query": Point(39.983615544507, 116.32295155093)},
             {"latitude": 39.983615544507, "longitude": 116.32295155093},
         )
-        self.reverse_run(
+        await self.reverse_run(
             {"query": Point(39.983615544507, 116.32295155093), "exactly_one": False},
             {"latitude": 39.983615544507, "longitude": 116.32295155093},
         )
 
 
-@unittest.skipUnless(
-    bool(env.get('BAIDU_KEY')),
-    "No BAIDU_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('BAIDU_KEY')),
+    reason="No BAIDU_KEY env variable set"
 )
-class BaiduTestCase(BaiduQueriesTestCaseMixin, GeocoderTestBase):
+class TestBaidu(BaseTestBaidu):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = Baidu(
+    def make_geocoder(cls, **kwargs):
+        return Baidu(
             api_key=env['BAIDU_KEY'],
             timeout=3,
+            **kwargs,
         )
 
-    def test_invalid_ak(self):
-        self.geocoder = Baidu(api_key='DUMMYKEY1234')
-        with pytest.raises(GeocoderAuthenticationFailure) as exc_info:
-            self.geocode_run({"query": "baidu"}, None)
-        assert str(exc_info.value) == 'Invalid AK'
+    async def test_invalid_ak(self):
+        async with self.inject_geocoder(Baidu(api_key='DUMMYKEY1234')):
+            with pytest.raises(GeocoderAuthenticationFailure) as exc_info:
+                await self.geocode_run({"query": "baidu"}, None)
+            assert str(exc_info.value) == 'Invalid AK'
 
 
-@unittest.skipUnless(
-    bool(env.get('BAIDU_KEY_REQUIRES_SK')) and bool(env.get('BAIDU_SEC_KEY')),
-    "BAIDU_KEY_REQUIRES_SK and BAIDU_SEC_KEY env variables not set"
+@pytest.mark.skipif(
+    not bool(env.get('BAIDU_KEY_REQUIRES_SK') and env.get('BAIDU_SEC_KEY')),
+    reason="BAIDU_KEY_REQUIRES_SK and BAIDU_SEC_KEY env variables not set"
 )
-class BaiduSKTestCase(BaiduQueriesTestCaseMixin, GeocoderTestBase):
+class TestBaiduSK(BaseTestBaidu):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = Baidu(
+    def make_geocoder(cls, **kwargs):
+        return Baidu(
             api_key=env['BAIDU_KEY_REQUIRES_SK'],
             security_key=env['BAIDU_SEC_KEY'],
             timeout=3,
+            **kwargs,
         )
 
-    def test_sn_with_peculiar_chars(self):
-        self.geocode_run(
+    async def test_sn_with_peculiar_chars(self):
+        await self.geocode_run(
             {"query": (
                 "\u5317\u4eac\u5e02\u6d77\u6dc0\u533a"
                 "\u4e2d\u5173\u6751\u5927\u885727\u53f7"
@@ -88,30 +89,32 @@ class BaiduSKTestCase(BaiduQueriesTestCaseMixin, GeocoderTestBase):
         )
 
 
-@unittest.skipUnless(
-    bool(env.get('BAIDU_V3_KEY')),
-    "No BAIDU_V3_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('BAIDU_V3_KEY')),
+    reason="No BAIDU_V3_KEY env variable set"
 )
-class BaiduV3TestCase(BaiduTestCase):
+class TestBaiduV3(TestBaidu):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = BaiduV3(
+    def make_geocoder(cls, **kwargs):
+        return BaiduV3(
             api_key=env['BAIDU_V3_KEY'],
             timeout=3,
+            **kwargs,
         )
 
 
-@unittest.skipUnless(
-    bool(env.get('BAIDU_V3_KEY_REQUIRES_SK')) and bool(env.get('BAIDU_V3_SEC_KEY')),
-    "BAIDU_V3_KEY_REQUIRES_SK and BAIDU_V3_SEC_KEY env variables not set"
+@pytest.mark.skipif(
+    not bool(env.get('BAIDU_V3_KEY_REQUIRES_SK') and env.get('BAIDU_V3_SEC_KEY')),
+    reason="BAIDU_V3_KEY_REQUIRES_SK and BAIDU_V3_SEC_KEY env variables not set"
 )
-class BaiduV3SKTestCase(BaiduSKTestCase):
+class TestBaiduV3SK(TestBaiduSK):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = BaiduV3(
+    def make_geocoder(cls, **kwargs):
+        return BaiduV3(
             api_key=env['BAIDU_V3_KEY_REQUIRES_SK'],
             security_key=env['BAIDU_V3_SEC_KEY'],
             timeout=3,
+            **kwargs,
         )

--- a/test/geocoders/banfrance.py
+++ b/test/geocoders/banfrance.py
@@ -1,35 +1,35 @@
 from geopy.geocoders import BANFrance
-from test.geocoders.util import GeocoderTestBase
+from test.geocoders.util import BaseTestGeocoder
 
 
-class BANFranceTestCase(GeocoderTestBase):
+class TestBANFrance(BaseTestGeocoder):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = BANFrance(timeout=10)
+    def make_geocoder(cls, **kwargs):
+        return BANFrance(timeout=10, **kwargs)
 
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = BANFrance(
             user_agent='my_user_agent/1.0'
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_geocode_with_address(self):
-        location = self.geocode_run(
+    async def test_geocode_with_address(self):
+        location = await self.geocode_run(
             {"query": "Camp des Landes, 41200 VILLEFRANCHE-SUR-CHER"},
             {"latitude": 47.293048, "longitude": 1.718985},
         )
         assert "Camp des Landes" in location.address
 
-    def test_reverse(self):
-        location = self.reverse_run(
+    async def test_reverse(self):
+        location = await self.reverse_run(
             {"query": "48.154587,3.221237"},
             {"latitude": 48.154587, "longitude": 3.221237},
         )
         assert "Rue des Fontaines" in location.address
 
-    def test_geocode_limit(self):
-        result = self.geocode_run(
+    async def test_geocode_limit(self):
+        result = await self.geocode_run(
             {"query": "8 bd du port", "limit": 2, "exactly_one": False},
             {}
         )

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -14,18 +14,18 @@ from geopy.point import Point
 
 
 class DummySyncAdapter(BaseSyncAdapter):
-    def get_json(self, *args, **kwargs):
+    def get_json(self, *args, **kwargs):  # pragma: no cover
         raise NotImplementedError
 
-    def get_text(self, *args, **kwargs):
+    def get_text(self, *args, **kwargs):  # pragma: no cover
         raise NotImplementedError
 
 
 class DummyAsyncAdapter(BaseAsyncAdapter):
-    async def get_json(self, *args, **kwargs):
+    async def get_json(self, *args, **kwargs):  # pragma: no cover
         raise NotImplementedError
 
-    async def get_text(self, *args, **kwargs):
+    async def get_text(self, *args, **kwargs):  # pragma: no cover
         raise NotImplementedError
 
 

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -115,7 +115,7 @@ class GeocoderTestCase(unittest.TestCase):
     def test_call_geocoder_timeout(self):
         url = 'spam://ham/eggs'
 
-        g = Geocoder()
+        g = Geocoder(adapter_factory=DummySyncAdapter)
         assert g.timeout == 12
 
         with ExitStack() as stack:

--- a/test/geocoders/base.py
+++ b/test/geocoders/base.py
@@ -6,11 +6,27 @@ import pytest
 
 import geopy.geocoders
 import geopy.geocoders.base
-from geopy.adapters import URLLibAdapter
+from geopy.adapters import BaseAsyncAdapter, BaseSyncAdapter
 from geopy.exc import GeocoderNotFound, GeocoderQueryError
 from geopy.geocoders import GoogleV3, get_geocoder_for_service
 from geopy.geocoders.base import Geocoder, _synchronized
 from geopy.point import Point
+
+
+class DummySyncAdapter(BaseSyncAdapter):
+    def get_json(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_text(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class DummyAsyncAdapter(BaseAsyncAdapter):
+    async def get_json(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def get_text(self, *args, **kwargs):
+        raise NotImplementedError
 
 
 class GetGeocoderTestCase(unittest.TestCase):
@@ -36,6 +52,7 @@ class GeocoderTestCase(unittest.TestCase):
         proxies = {'https': '192.0.2.0'}
         user_agent = 'test app'
         ssl_context = sentinel.some_ssl_context
+        adapter = DummySyncAdapter(proxies=None, ssl_context=None)
 
         geocoder = Geocoder(
             scheme=scheme,
@@ -43,15 +60,15 @@ class GeocoderTestCase(unittest.TestCase):
             proxies=proxies,
             user_agent=user_agent,
             ssl_context=ssl_context,
-            adapter_factory=lambda **kw: sentinel.local_adapter,
+            adapter_factory=lambda **kw: adapter,
         )
         for attr in ('scheme', 'timeout', 'proxies', 'ssl_context'):
             assert locals()[attr] == getattr(geocoder, attr)
         assert user_agent == geocoder.headers['User-Agent']
-        assert sentinel.local_adapter is geocoder.adapter
+        assert adapter is geocoder.adapter
 
     @patch.object(geopy.geocoders.options, 'default_adapter_factory',
-                  lambda **kw: sentinel.default_adapter)
+                  DummySyncAdapter)
     def test_init_with_defaults(self):
         attr_to_option = {
             'scheme': 'default_scheme',
@@ -70,7 +87,7 @@ class GeocoderTestCase(unittest.TestCase):
             geopy.geocoders.options.default_user_agent ==
             geocoder.headers['User-Agent']
         )
-        assert sentinel.default_adapter is geocoder.adapter
+        assert DummySyncAdapter is type(geocoder.adapter)  # noqa
 
     @patch.object(geopy.geocoders.options, 'default_proxies', {'https': '192.0.2.0'})
     @patch.object(geopy.geocoders.options, 'default_timeout', 10)
@@ -119,7 +136,11 @@ class GeocoderTestCase(unittest.TestCase):
     def test_ssl_context(self):
         with ExitStack() as stack:
             mock_adapter = stack.enter_context(
-                patch.object(geopy.geocoders.base.options, 'default_adapter_factory')
+                patch.object(
+                    geopy.geocoders.base.options,
+                    'default_adapter_factory',
+                    return_value=DummySyncAdapter(proxies=None, ssl_context=None),
+                )
             )
 
             for ssl_context in (None, sentinel.some_ssl_context):
@@ -210,8 +231,9 @@ class GeocoderFormatBoundingBoxTestCase(unittest.TestCase):
         assert bbox == " 170.0|50.0 -- 30.0|160.0 "
 
 
-def test_synchronize_decorator_sync_simple():
-    geocoder = Geocoder(adapter_factory=URLLibAdapter)
+@pytest.mark.parametrize("adapter_factory", [DummySyncAdapter, DummyAsyncAdapter])
+async def test_synchronize_decorator_sync_simple(adapter_factory):
+    geocoder = Geocoder(adapter_factory=adapter_factory)
     calls = []
 
     @_synchronized
@@ -219,22 +241,57 @@ def test_synchronize_decorator_sync_simple():
         calls.append((one, two))
         return 42
 
-    assert 42 == f(geocoder, 1, two=2)
+    res = f(geocoder, 1, two=2)
+    if adapter_factory is DummyAsyncAdapter:
+        res = await res
+    assert 42 == res
     assert calls == [(1, 2)]
 
 
-def test_synchronize_decorator_sync_exception():
-    geocoder = Geocoder(adapter_factory=URLLibAdapter)
+async def test_synchronize_decorator_async_simple():
+    geocoder = Geocoder(adapter_factory=DummyAsyncAdapter)
+    calls = []
+
+    @_synchronized
+    def f(self, one, *, two):
+        async def coro():
+            calls.append((one, two))
+            return 42
+        return coro()
+
+    assert 42 == await f(geocoder, 1, two=2)
+    assert calls == [(1, 2)]
+
+
+@pytest.mark.parametrize("adapter_factory", [DummySyncAdapter, DummyAsyncAdapter])
+async def test_synchronize_decorator_sync_exception(adapter_factory):
+    geocoder = Geocoder(adapter_factory=adapter_factory)
 
     @_synchronized
     def f(self, one, *, two):
         raise RuntimeError("test")
 
     with pytest.raises(RuntimeError):
-        f(geocoder, 1, two=2)
+        res = f(geocoder, 1, two=2)
+        if adapter_factory is DummyAsyncAdapter:
+            await res
 
 
-def test_synchronize_decorator_sync_reentrance():
+async def test_synchronize_decorator_async_exception():
+    geocoder = Geocoder(adapter_factory=DummyAsyncAdapter)
+
+    @_synchronized
+    def f(self, one, *, two):
+        async def coro():
+            raise RuntimeError("test")
+        return coro()
+
+    with pytest.raises(RuntimeError):
+        await f(geocoder, 1, two=2)
+
+
+@pytest.mark.parametrize("adapter_factory", [DummySyncAdapter, DummyAsyncAdapter])
+async def test_synchronize_decorator_sync_reentrance(adapter_factory):
     calls = []
 
     class DummyGeocoder(Geocoder):
@@ -245,7 +302,29 @@ def test_synchronize_decorator_sync_reentrance():
                 return self.f(i + 1)
             return 42
 
-    geocoder = DummyGeocoder(adapter_factory=URLLibAdapter)
+    geocoder = DummyGeocoder(adapter_factory=adapter_factory)
 
-    assert 42 == geocoder.f()
+    res = geocoder.f()
+    if adapter_factory is DummyAsyncAdapter:
+        res = await res
+    assert 42 == res
+    assert calls == list(range(5))
+
+
+async def test_synchronize_decorator_async_reentrance():
+    calls = []
+
+    class DummyGeocoder(Geocoder):
+        @_synchronized
+        def f(self, i=0):
+            async def coro():
+                calls.append(i)
+                if len(calls) < 5:
+                    return await self.f(i + 1)
+                return 42
+            return coro()
+
+    geocoder = DummyGeocoder(adapter_factory=DummyAsyncAdapter)
+
+    assert 42 == await geocoder.f()
     assert calls == list(range(5))

--- a/test/geocoders/bing.py
+++ b/test/geocoders/bing.py
@@ -1,11 +1,11 @@
-import unittest
+import pytest
 
 from geopy.geocoders import Bing
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-class BingTestCaseUnitTest(GeocoderTestBase):
+class TestUnitBing:
 
     def test_user_agent_custom(self):
         geocoder = Bing(
@@ -15,59 +15,60 @@ class BingTestCaseUnitTest(GeocoderTestBase):
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
 
-@unittest.skipUnless(
-    bool(env.get('BING_KEY')),
-    "No BING_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('BING_KEY')),
+    reason="No BING_KEY env variable set"
 )
-class BingTestCase(GeocoderTestBase):
+class TestBing(BaseTestGeocoder):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = Bing(
-            api_key=env['BING_KEY']
+    def make_geocoder(cls, **kwargs):
+        return Bing(
+            api_key=env['BING_KEY'],
+            **kwargs
         )
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "\u043c\u043e\u0441\u043a\u0432\u0430"},
             {"latitude": 55.756, "longitude": 37.615},
         )
 
-    def test_reverse_point(self):
-        self.reverse_run(
+    async def test_reverse_point(self):
+        await self.reverse_run(
             {"query": Point(40.753898, -73.985071)},
             {"latitude": 40.753, "longitude": -73.984},
         )
 
-    def test_reverse_with_culture_de(self):
-        res = self.reverse_run(
+    async def test_reverse_with_culture_de(self):
+        res = await self.reverse_run(
             {"query": Point(40.753898, -73.985071), "culture": "DE"},
             {},
         )
         assert "Vereinigte Staaten von Amerika" in res.address
 
-    def test_reverse_with_culture_en(self):
-        res = self.reverse_run(
+    async def test_reverse_with_culture_en(self):
+        res = await self.reverse_run(
             {"query": Point(40.753898, -73.985071), "culture": "EN"},
             {},
         )
         assert "United States" in res.address
 
-    def test_reverse_with_include_country_code(self):
-        res = self.reverse_run(
+    async def test_reverse_with_include_country_code(self):
+        res = await self.reverse_run(
             {"query": Point(40.753898, -73.985071),
              "include_country_code": True},
             {},
         )
         assert res.raw["address"].get("countryRegionIso2", 'missing') == 'US'
 
-    def test_user_location(self):
+    async def test_user_location(self):
         pennsylvania = (40.98327, -74.96064)
         colorado = (40.1602849999851, -105.102491162672)
 
@@ -76,15 +77,15 @@ class BingTestCase(GeocoderTestBase):
         for expected, bias in ((pennsylvania, pennsylvania_bias),
                                (colorado, colorado_bias)):
             try:
-                self.geocode_run(
+                await self.geocode_run(
                     {"query": "20 Main Street", "user_location": Point(bias)},
                     {"latitude": expected[0], "longitude": expected[1]},
                 )
             except AssertionError as e:
-                self.skipTest("Bing ignored user_location: %s" % str(e))
+                pytest.xfail("Bing ignored user_location: %s" % str(e))
 
-    def test_optional_params(self):
-        res = self.geocode_run(
+    async def test_optional_params(self):
+        res = await self.geocode_run(
             {"query": "Badeniho 1, Prague, Czech Republic",
              "culture": 'cs',
              "include_neighborhood": True,
@@ -95,8 +96,8 @@ class BingTestCase(GeocoderTestBase):
         assert address['neighborhood'] == "Praha 6"
         assert address['countryRegionIso2'] == "CZ"
 
-    def test_structured_query(self):
-        res = self.geocode_run(
+    async def test_structured_query(self):
+        res = await self.geocode_run(
             {"query": {'postalCode': '80020', 'countryRegion': 'United States'}},
             {},
         )

--- a/test/geocoders/bing.py
+++ b/test/geocoders/bing.py
@@ -76,13 +76,10 @@ class TestBing(BaseTestGeocoder):
         colorado_bias = (39.914231, -105.070104)
         for expected, bias in ((pennsylvania, pennsylvania_bias),
                                (colorado, colorado_bias)):
-            try:
-                await self.geocode_run(
-                    {"query": "20 Main Street", "user_location": Point(bias)},
-                    {"latitude": expected[0], "longitude": expected[1]},
-                )
-            except AssertionError as e:
-                pytest.xfail("Bing ignored user_location: %s" % str(e))
+            await self.geocode_run(
+                {"query": "20 Main Street", "user_location": Point(bias)},
+                {"latitude": expected[0], "longitude": expected[1]},
+            )
 
     async def test_optional_params(self):
         res = await self.geocode_run(

--- a/test/geocoders/databc.py
+++ b/test/geocoders/databc.py
@@ -2,51 +2,51 @@ import pytest
 
 from geopy.exc import GeocoderQueryError
 from geopy.geocoders import DataBC
-from test.geocoders.util import GeocoderTestBase
+from test.geocoders.util import BaseTestGeocoder
 
 
-class DataBCTestCase(GeocoderTestBase):
+class TestDataBC(BaseTestGeocoder):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = DataBC()
+    def make_geocoder(cls, **kwargs):
+        return DataBC(**kwargs)
 
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = DataBC(
             user_agent='my_user_agent/1.0'
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "135 North Pym Road, Parksville"},
             {"latitude": 49.321, "longitude": -124.337},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "Barri\u00e8re"},
             {"latitude": 51.179, "longitude": -120.123},
         )
 
-    def test_multiple_results(self):
-        res = self.geocode_run(
+    async def test_multiple_results(self):
+        res = await self.geocode_run(
             {"query": "1st St", "exactly_one": False},
             {},
         )
         assert len(res) > 1
 
-    def test_optional_params(self):
-        self.geocode_run(
+    async def test_optional_params(self):
+        await self.geocode_run(
             {"query": "5670 malibu terrace nanaimo bc",
              "location_descriptor": "accessPoint",
              "set_back": 100},
             {"latitude": 49.2299, "longitude": -124.0163},
         )
 
-    def test_query_error(self):
+    async def test_query_error(self):
         with pytest.raises(GeocoderQueryError):
-            self.geocode_run(
+            await self.geocode_run(
                 {"query": "1 Main St, Vancouver",
                  "location_descriptor": "access_Point"},
                 {},

--- a/test/geocoders/geocodeearth.py
+++ b/test/geocoders/geocodeearth.py
@@ -1,15 +1,15 @@
-import unittest
+import pytest
 
 from geopy.geocoders import GeocodeEarth
-from test.geocoders.pelias import BasePeliasTestCase
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.pelias import BaseTestPelias
+from test.geocoders.util import env
 
 
-@unittest.skipUnless(
-    bool(env['GEOCODEEARTH_KEY']),
-    "No GEOCODEEARTH_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env['GEOCODEEARTH_KEY']),
+    reason="No GEOCODEEARTH_KEY env variable set"
 )
-class GeocodeEarthTestCase(BasePeliasTestCase, GeocoderTestBase):
+class TestGeocodeEarth(BaseTestPelias):
 
     @classmethod
     def make_geocoder(cls, **kwargs):

--- a/test/geocoders/geocodefarm.py
+++ b/test/geocoders/geocodefarm.py
@@ -5,7 +5,7 @@ import pytest
 from geopy import exc
 from geopy.geocoders import GeocodeFarm
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
 @pytest.mark.xfail(
@@ -14,55 +14,55 @@ from test.geocoders.util import GeocoderTestBase, env
         "geocodefarm service is unstable at times"
     )
 )
-class GeocodeFarmTestCase(GeocoderTestBase):
+class TestGeocodeFarm(BaseTestGeocoder):
 
     @classmethod
-    def setUpClass(cls):
-        cls.delta = 0.04
-        cls.geocoder = GeocodeFarm(
+    def make_geocoder(cls, **kwargs):
+        return GeocodeFarm(
             # None api_key will use free tier on GeocodeFarm.
             api_key=env.get('GEOCODEFARM_KEY'),
             timeout=10,
+            **kwargs
         )
 
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = GeocodeFarm(
             user_agent='my_user_agent/1.0'
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_geocode(self):
-        location = self.geocode_run(
+    async def test_geocode(self):
+        location = await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890, "longitude": -87.624},
         )
         assert "chicago" in location.address.lower()
 
-    def test_location_address(self):
-        self.geocode_run(
+    async def test_location_address(self):
+        await self.geocode_run(
             {"query": "moscow"},
             {"address": "Moscow, Russia",
              "latitude": 55.7558913503453, "longitude": 37.6172961632184}
         )
 
-    def test_reverse(self):
-        location = self.reverse_run(
+    async def test_reverse(self):
+        location = await self.reverse_run(
             {"query": Point(40.75376406311989, -73.98489005863667)},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667},
             skiptest_on_failure=True,  # sometimes the result is empty
         )
         assert "new york" in location.address.lower()
 
-    def test_authentication_failure(self):
-        self.geocoder = GeocodeFarm(api_key="invalid")
-        with pytest.raises(exc.GeocoderAuthenticationFailure):
-            self.geocode_run(
-                {"query": '435 north michigan ave, chicago il 60611'},
-                {},
-                expect_failure=True,
-            )
+    async def test_authentication_failure(self):
+        async with self.inject_geocoder(GeocodeFarm(api_key="invalid")):
+            with pytest.raises(exc.GeocoderAuthenticationFailure):
+                await self.geocode_run(
+                    {"query": '435 north michigan ave, chicago il 60611'},
+                    {},
+                    expect_failure=True,
+                )
 
-    def test_quota_exceeded(self):
+    async def test_quota_exceeded(self):
 
         def mock_call_geocoder(url, callback, **kwargs):
             return callback({
@@ -78,14 +78,14 @@ class GeocodeFarmTestCase(GeocoderTestBase):
             with pytest.raises(exc.GeocoderQuotaExceeded):
                 self.geocoder.geocode('435 north michigan ave, chicago il 60611')
 
-    def test_no_results(self):
-        self.geocode_run(
+    async def test_no_results(self):
+        await self.geocode_run(
             {"query": "gibberish kdjhsakdjh skjdhsakjdh"},
             {},
             expect_failure=True
         )
 
-    def test_unhandled_api_error(self):
+    async def test_unhandled_api_error(self):
 
         def mock_call_geocoder(url, callback, **kwargs):
             return callback({

--- a/test/geocoders/geolake.py
+++ b/test/geocoders/geolake.py
@@ -1,10 +1,10 @@
-import unittest
+import pytest
 
 from geopy.geocoders import Geolake
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-class GeolakeTestCaseUnitTest(GeocoderTestBase):
+class TestUnitGeolake:
 
     def test_user_agent_custom(self):
         geocoder = Geolake(
@@ -14,38 +14,39 @@ class GeolakeTestCaseUnitTest(GeocoderTestBase):
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
 
-@unittest.skipUnless(
-    bool(env.get('GEOLAKE_KEY')),
-    "No GEOLAKE_KEY env variables set"
+@pytest.mark.skipif(
+    not bool(env.get('GEOLAKE_KEY')),
+    reason="No GEOLAKE_KEY env variables set"
 )
-class GeolakeTestCase(GeocoderTestBase):
+class TestGeolake(BaseTestGeocoder):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = Geolake(
+    def make_geocoder(cls, **kwargs):
+        return Geolake(
             api_key=env['GEOLAKE_KEY'],
             timeout=10,
+            **kwargs
         )
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890344, "longitude": -87.623234, "address": "Chicago, US"},
         )
 
-    def test_geocode_country_codes_str(self):
-        self.geocode_run(
+    async def test_geocode_country_codes_str(self):
+        await self.geocode_run(
             {"query": "Toronto", "country_codes": "US"},
             {"latitude": 40.46, "longitude": -80.6, "address": "Toronto, US"},
         )
 
-    def test_geocode_country_codes_list(self):
-        self.geocode_run(
+    async def test_geocode_country_codes_list(self):
+        await self.geocode_run(
             {"query": "Toronto", "country_codes": ["CN", "US"]},
             {"latitude": 40.46, "longitude": -80.6, "address": "Toronto, US"},
         )
 
-    def test_geocode_structured(self):
+    async def test_geocode_structured(self):
         query = {
             "street": "north michigan ave",
             "houseNumber": "435",
@@ -54,20 +55,20 @@ class GeolakeTestCase(GeocoderTestBase):
             "zipcode": 60611,
             "country": "US"
         }
-        self.geocode_run(
+        await self.geocode_run(
             {"query": query},
             {"latitude": 41.890344, "longitude": -87.623234}
         )
 
-    def test_geocode_empty_result(self):
-        self.geocode_run(
+    async def test_geocode_empty_result(self):
+        await self.geocode_run(
             {"query": "xqj37"},
             {},
             expect_failure=True
         )
 
-    def test_geocode_missing_city_in_result(self):
-        self.geocode_run(
+    async def test_geocode_missing_city_in_result(self):
+        await self.geocode_run(
             {"query": "H1W 0B4"},
             {"latitude": 45.544952, "longitude": -73.546694, "address": "CA"}
         )

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -1,5 +1,4 @@
 import base64
-import unittest
 import warnings
 from datetime import datetime
 from urllib.parse import parse_qs, urlparse
@@ -10,54 +9,45 @@ from pytz import timezone
 from geopy import exc
 from geopy.geocoders import GoogleV3
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-@unittest.skipUnless(
-    bool(env['GOOGLE_KEY']),
-    "No GOOGLE_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env['GOOGLE_KEY']),
+    reason="No GOOGLE_KEY env variable set"
 )
-class GoogleV3TestCase(GeocoderTestBase):
+class TestGoogleV3(BaseTestGeocoder):
     new_york_point = Point(40.75376406311989, -73.98489005863667)
     america_new_york = timezone("America/New_York")
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = GoogleV3(api_key=env.get('GOOGLE_KEY'))
+    def make_geocoder(cls, **kwargs):
+        return GoogleV3(api_key=env.get('GOOGLE_KEY'), **kwargs)
 
-    def reverse_timezone_run(self, payload, expected):
-        timezone = self._make_request(self.geocoder.reverse_timezone, **payload)
-        if expected is None:
-            assert timezone is None
-        else:
-            assert timezone.pytz_timezone == expected
-
-        return timezone
-
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = GoogleV3(
             api_key='mock',
             user_agent='my_user_agent/1.0'
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_configuration_error(self):
+    async def test_configuration_error(self):
         with pytest.raises(exc.ConfigurationError):
             GoogleV3(api_key='mock', client_id='a')
         with pytest.raises(exc.ConfigurationError):
             GoogleV3(api_key='mock', secret_key='a')
 
-    def test_warning_with_no_api_key(self):
+    async def test_warning_with_no_api_key(self):
         with warnings.catch_warnings(record=True) as w:
             GoogleV3()
         assert len(w) == 1
 
-    def test_no_warning_with_no_api_key_but_using_premier(self):
+    async def test_no_warning_with_no_api_key_but_using_premier(self):
         with warnings.catch_warnings(record=True) as w:
             GoogleV3(client_id='client_id', secret_key='secret_key')
         assert len(w) == 0
 
-    def test_check_status(self):
+    async def test_check_status(self):
         assert self.geocoder._check_status("ZERO_RESULTS") is None
         with pytest.raises(exc.GeocoderQuotaExceeded):
             self.geocoder._check_status("OVER_QUERY_LIMIT")
@@ -68,7 +58,7 @@ class GoogleV3TestCase(GeocoderTestBase):
         with pytest.raises(exc.GeocoderQueryError):
             self.geocoder._check_status("_")
 
-    def test_get_signed_url(self):
+    async def test_get_signed_url(self):
         geocoder = GoogleV3(
             api_key='mock',
             client_id='my_client_id',
@@ -89,7 +79,7 @@ class GoogleV3TestCase(GeocoderTestBase):
             "signature=D3PL0cZJrJYfveGSNoGqrrMsz0M="
         )
 
-    def test_get_signed_url_with_channel(self):
+    async def test_get_signed_url_with_channel(self):
         geocoder = GoogleV3(
             api_key='mock',
             client_id='my_client_id',
@@ -104,7 +94,7 @@ class GoogleV3TestCase(GeocoderTestBase):
         assert 'signature' in params
         assert 'client' in params
 
-    def test_format_components_param(self):
+    async def test_format_components_param(self):
         f = self.geocoder._format_components_param
         assert f({}) == ''
         assert f([]) == ''
@@ -134,20 +124,20 @@ class GoogleV3TestCase(GeocoderTestBase):
         with pytest.raises(ValueError):
             f('administrative_area:CA|country:FR')
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "\u6545\u5bab"},
             {"latitude": 39.916, "longitude": 116.390},
         )
 
-    def test_geocode_with_conflicting_components(self):
-        self.geocode_run(
+    async def test_geocode_with_conflicting_components(self):
+        await self.geocode_run(
             {
                 "query": "santa cruz",
                 "components": {
@@ -159,7 +149,7 @@ class GoogleV3TestCase(GeocoderTestBase):
             expect_failure=True
         )
 
-        self.geocode_run(
+        await self.geocode_run(
             {
                 "query": "santa cruz",
                 "components": [
@@ -171,8 +161,8 @@ class GoogleV3TestCase(GeocoderTestBase):
             expect_failure=True
         )
 
-    def test_components(self):
-        self.geocode_run(
+    async def test_components(self):
+        await self.geocode_run(
             {
                 "query": "santa cruz",
                 "components": {
@@ -182,7 +172,7 @@ class GoogleV3TestCase(GeocoderTestBase):
             {"latitude": 28.4636296, "longitude": -16.2518467},
         )
 
-        self.geocode_run(
+        await self.geocode_run(
             {
                 "query": "santa cruz",
                 "components": [
@@ -192,43 +182,43 @@ class GoogleV3TestCase(GeocoderTestBase):
             {"latitude": 28.4636296, "longitude": -16.2518467},
         )
 
-    def test_components_without_query(self):
-        self.geocode_run(
+    async def test_components_without_query(self):
+        await self.geocode_run(
             {
                 "components": {"city": "Paris", "country": "FR"},
             },
             {"latitude": 46.227638, "longitude": 2.213749},
         )
 
-        self.geocode_run(
+        await self.geocode_run(
             {
                 "components": [("city", "Paris"), ("country", "FR")],
             },
             {"latitude": 46.227638, "longitude": 2.213749},
         )
 
-    def test_reverse(self):
-        self.reverse_run(
+    async def test_reverse(self):
+        await self.reverse_run(
             {"query": self.new_york_point},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667},
         )
 
-    def test_zero_results(self):
+    async def test_zero_results(self):
         with pytest.raises(exc.GeocoderQueryError):
-            self.geocode_run(
+            await self.geocode_run(
                 {"query": ''},
                 {},
                 expect_failure=True,
             )
 
-    def test_timezone_datetime(self):
-        self.reverse_timezone_run(
+    async def test_timezone_datetime(self):
+        await self.reverse_timezone_run(
             {"query": self.new_york_point,
              "at_time": datetime.utcfromtimestamp(0)},
             self.america_new_york,
         )
 
-    def test_timezone_at_time_normalization(self):
+    async def test_timezone_at_time_normalization(self):
         utc_naive_dt = datetime(2010, 1, 1, 0, 0, 0)
         utc_timestamp = 1262304000
         assert (
@@ -245,86 +235,86 @@ class GoogleV3TestCase(GeocoderTestBase):
             utc_timestamp == self.geocoder._normalize_timezone_at_time(local_aware_dt)
         )
 
-    def test_timezone_integer_raises(self):
+    async def test_timezone_integer_raises(self):
         # In geopy 1.x `at_time` could be an integer -- a unix timestamp.
         # This is an error since geopy 2.0.
         with pytest.raises(exc.GeocoderQueryError):
-            self.reverse_timezone_run(
+            await self.reverse_timezone_run(
                 {"query": self.new_york_point, "at_time": 0},
                 self.america_new_york,
             )
 
-    def test_timezone_no_date(self):
-        self.reverse_timezone_run(
+    async def test_timezone_no_date(self):
+        await self.reverse_timezone_run(
             {"query": self.new_york_point},
             self.america_new_york,
         )
 
-    def test_timezone_invalid_at_time(self):
+    async def test_timezone_invalid_at_time(self):
         with pytest.raises(exc.GeocoderQueryError):
             self.geocoder.reverse_timezone(self.new_york_point, at_time="eek")
 
-    def test_reverse_timezone_unknown(self):
-        self.reverse_timezone_run(
+    async def test_reverse_timezone_unknown(self):
+        await self.reverse_timezone_run(
             # Google doesn't return a timezone for Antarctica.
             {"query": "89.0, 1.0"},
             None,
         )
 
-    def test_geocode_bounds(self):
-        self.geocode_run(
+    async def test_geocode_bounds(self):
+        await self.geocode_run(
             {"query": "221b Baker St", "bounds": [[50, -2], [55, 2]]},
             {"latitude": 51.52, "longitude": -0.15},
         )
 
-    def test_geocode_bounds_invalid(self):
+    async def test_geocode_bounds_invalid(self):
         with pytest.raises(exc.GeocoderQueryError):
-            self.geocode_run(
+            await self.geocode_run(
                 {"query": "221b Baker St", "bounds": [50, -2, 55]},
                 {"latitude": 51.52, "longitude": -0.15},
             )
 
-    def test_geocode_place_id_invalid(self):
-        self.geocode_run(
+    async def test_geocode_place_id_invalid(self):
+        await self.geocode_run(
             {"place_id": "ChIJOcfP0Iq2j4ARDrXUa7ZWs34"},
             {"latitude": 37.22, "longitude": -122.05}
         )
 
-    def test_geocode_place_id_not_invalid(self):
+    async def test_geocode_place_id_not_invalid(self):
         with pytest.raises(exc.GeocoderQueryError):
-            self.geocode_run(
+            await self.geocode_run(
                 {"place_id": "xxxxx"},
                 {},
                 expect_failure=True,
             )
 
-    def test_place_id_zero_result(self):
+    async def test_place_id_zero_result(self):
         with pytest.raises(exc.GeocoderQueryError):
-            self.geocode_run(
+            await self.geocode_run(
                 {"place_id": ""},
                 {},
                 expect_failure=True,
             )
 
-    def test_geocode_place_id_with_query(self):
+    async def test_geocode_place_id_with_query(self):
         with pytest.raises(ValueError):
-            self.geocode_run(
+            await self.geocode_run(
                 {"place_id": "ChIJOcfP0Iq2j4ARDrXUa7ZWs34",
                  "query": "silicon valley"},
                 {}
             )
 
-    def test_geocode_place_id_with_bounds(self):
+    async def test_geocode_place_id_with_bounds(self):
         with pytest.raises(ValueError):
-            self.geocode_run(
+            await self.geocode_run(
                 {"place_id": "ChIJOcfP0Iq2j4ARDrXUa7ZWs34",
                  "bounds": [50, -2, 55, 2]},
                 {}
             )
 
-    def test_geocode_place_id_with_query_and_bounds(self):
+    async def test_geocode_place_id_with_query_and_bounds(self):
         with pytest.raises(ValueError):
-            self.geocode_run(
+            await self.geocode_run(
                 {"place_id": "ChIJOcfP0Iq2j4ARDrXUa7ZWs34",
                  "query": "silicon valley",
                  "bounds": [50, -2, 55, 2]},

--- a/test/geocoders/ignfrance.py
+++ b/test/geocoders/ignfrance.py
@@ -1,15 +1,13 @@
-import unittest
-from abc import ABC, abstractmethod
-
 import pytest
+from async_generator import async_generator, yield_
 
 from geopy.exc import ConfigurationError, GeocoderQueryError
 from geopy.geocoders import IGNFrance
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 from test.proxy_server import ProxyServerThread
 
 
-class IGNFranceTestCaseUnitTest(GeocoderTestBase):
+class TestUnitIGNFrance:
 
     def test_user_agent_custom(self):
         geocoder = IGNFrance(
@@ -33,52 +31,43 @@ class IGNFranceTestCaseUnitTest(GeocoderTestBase):
             IGNFrance(api_key="a", username="b")
 
 
-class BaseIGNFranceTestCase(ABC):
+class BaseTestIGNFrance(BaseTestGeocoder):
 
-    @classmethod
-    @abstractmethod
-    def make_geocoder(cls, **kwargs):
-        pass
-
-    @classmethod
-    def setUpClass(cls):
-        cls.geocoder = cls.make_geocoder()
-
-    def test_invalid_query_type(self):
+    async def test_invalid_query_type(self):
         with pytest.raises(GeocoderQueryError):
             self.geocoder.geocode("44109000EX0114", query_type="invalid")
 
-    def test_invalid_query_parcel(self):
+    async def test_invalid_query_parcel(self):
         with pytest.raises(GeocoderQueryError):
             self.geocoder.geocode(
                 "incorrect length string",
                 query_type="CadastralParcel",
             )
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "44109000EX0114",
              "query_type": "CadastralParcel"},
             {"latitude": 47.222482, "longitude": -1.556303},
         )
 
-    def test_geocode_no_result(self):
-        self.geocode_run(
+    async def test_geocode_no_result(self):
+        await self.geocode_run(
             {"query": 'asdfasdfasdf'},
             {},
             expect_failure=True,
         )
 
-    def test_reverse_no_result(self):
-        self.reverse_run(
+    async def test_reverse_no_result(self):
+        await self.reverse_run(
             # North Atlantic Ocean
             {"query": (35.173809, -37.485351)},
             {},
             expect_failure=True
         )
 
-    def test_geocode_with_address(self):
-        self.geocode_run(
+    async def test_geocode_with_address(self):
+        await self.geocode_run(
             {"query": "Camp des Landes, 41200 VILLEFRANCHE-SUR-CHER",
              "query_type": "StreetAddress"},
             {"latitude": 47.293048,
@@ -86,16 +75,16 @@ class BaseIGNFranceTestCase(ABC):
              "address": "le camp des landes, 41200 Villefranche-sur-Cher"},
         )
 
-    def test_geocode_freeform(self):
-        self.geocode_run(
+    async def test_geocode_freeform(self):
+        await self.geocode_run(
             {"query": "8 rue Général Buat, Nantes",
              "query_type": "StreetAddress",
              "is_freeform": True},
             {"address": "8 r general buat , 44000 Nantes"},
         )
 
-    def test_geocode_position_of_interest(self):
-        res = self.geocode_run(
+    async def test_geocode_position_of_interest(self):
+        res = await self.geocode_run(
             {"query": "Chambéry",
              "query_type": "PositionOfInterest",
              "exactly_one": False},
@@ -106,8 +95,8 @@ class BaseIGNFranceTestCase(ABC):
         assert "02000 Chambry" in addresses
         assert "16420 Saint-Christophe" in addresses
 
-    def test_geocode_filter_by_attribute(self):
-        res = self.geocode_run(
+    async def test_geocode_filter_by_attribute(self):
+        res = await self.geocode_run(
             {"query": "Les Molettes",
              "query_type": "PositionOfInterest",
              "maximum_responses": 10,
@@ -122,7 +111,7 @@ class BaseIGNFranceTestCase(ABC):
         assert len(unique) == 1
         assert unique[0] == "38"
 
-    def test_geocode_filter_by_envelope(self):
+    async def test_geocode_filter_by_envelope(self):
         lat_min, lng_min, lat_max, lng_max = 45.00, 5, 46, 6.40
 
         spatial_filtering_envelope = """
@@ -137,7 +126,7 @@ class BaseIGNFranceTestCase(ABC):
             lng_max=lng_max
         )
 
-        res_spatial_filter = self.geocode_run(
+        res_spatial_filter = await self.geocode_run(
             {"query": 'Les Molettes',
              "query_type": 'PositionOfInterest',
              "maximum_responses": 10,
@@ -150,7 +139,7 @@ class BaseIGNFranceTestCase(ABC):
             {i.raw['departement'] for i in res_spatial_filter}
         )
 
-        res_no_spatial_filter = self.geocode_run(
+        res_no_spatial_filter = await self.geocode_run(
             {"query": 'Les Molettes',
              "query_type": 'PositionOfInterest',
              "maximum_responses": 10,
@@ -167,22 +156,22 @@ class BaseIGNFranceTestCase(ABC):
 
         assert len(departements_no_spatial) > len(departements_spatial)
 
-    def test_reverse(self):
-        res = self.reverse_run(
+    async def test_reverse(self):
+        res = await self.reverse_run(
             {"query": '47.229554,-1.541519'},
             {},
         )
         assert res.address == '7 av camille guerin, 44000 Nantes'
 
-    def test_reverse_invalid_preference(self):
+    async def test_reverse_invalid_preference(self):
         with pytest.raises(GeocoderQueryError):
             self.geocoder.reverse(
                 query='47.229554,-1.541519',
                 reverse_geocode_preference=['a']  # invalid
             )
 
-    def test_reverse_preference(self):
-        res = self.reverse_run(
+    async def test_reverse_preference(self):
+        res = await self.reverse_run(
             {"query": '47.229554,-1.541519',
              "exactly_one": False,
              "reverse_geocode_preference": ['StreetAddress', 'PositionOfInterest']},
@@ -192,7 +181,7 @@ class BaseIGNFranceTestCase(ABC):
         assert "3 av camille guerin, 44000 Nantes" in addresses
         assert "5 av camille guerin, 44000 Nantes" in addresses
 
-    def test_reverse_by_radius(self):
+    async def test_reverse_by_radius(self):
         spatial_filtering_radius = """
         <gml:CircleByCenterPoint>
             <gml:pos>{coord}</gml:pos>
@@ -200,7 +189,7 @@ class BaseIGNFranceTestCase(ABC):
         </gml:CircleByCenterPoint>
         """.format(coord='48.8033333 2.3241667', radius='50')
 
-        res_call_radius = self.reverse_run(
+        res_call_radius = await self.reverse_run(
             {"query": '48.8033333,2.3241667',
              "exactly_one": False,
              "maximum_responses": 10,
@@ -208,7 +197,7 @@ class BaseIGNFranceTestCase(ABC):
             {},
         )
 
-        res_call = self.reverse_run(
+        res_call = await self.reverse_run(
             {"query": '48.8033333,2.3241667',
              "exactly_one": False,
              "maximum_responses": 10},
@@ -227,11 +216,11 @@ class BaseIGNFranceTestCase(ABC):
         assert coordinates_couples_radius.issubset(coordinates_couples)
 
 
-@unittest.skipUnless(
-    bool(env.get('IGNFRANCE_KEY') and env.get('IGNFRANCE_REFERER')),
-    "No IGNFRANCE_KEY or IGNFRANCE_REFERER env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('IGNFRANCE_KEY') and env.get('IGNFRANCE_REFERER')),
+    reason="No IGNFRANCE_KEY or IGNFRANCE_REFERER env variable set"
 )
-class IGNFranceApiKeyAuthTestCase(BaseIGNFranceTestCase, GeocoderTestBase):
+class TestIGNFranceApiKeyAuth(BaseTestIGNFrance):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
@@ -242,31 +231,13 @@ class IGNFranceApiKeyAuthTestCase(BaseIGNFranceTestCase, GeocoderTestBase):
         )
 
 
-@unittest.skipUnless(
-    bool(env.get('IGNFRANCE_USERNAME_KEY') and env.get('IGNFRANCE_USERNAME')
-         and env.get('IGNFRANCE_PASSWORD')),
-    "No IGNFRANCE_USERNAME_KEY or IGNFRANCE_USERNAME "
+@pytest.mark.skipif(
+    not bool(env.get('IGNFRANCE_USERNAME_KEY') and env.get('IGNFRANCE_USERNAME')
+             and env.get('IGNFRANCE_PASSWORD')),
+    reason="No IGNFRANCE_USERNAME_KEY or IGNFRANCE_USERNAME "
     "or IGNFRANCE_PASSWORD env variable set"
 )
-class IGNFranceUsernameAuthTestCase(BaseIGNFranceTestCase, GeocoderTestBase):
-
-    @classmethod
-    def make_geocoder(cls, **kwargs):
-        return IGNFrance(
-            api_key=env['IGNFRANCE_USERNAME_KEY'],
-            username=env['IGNFRANCE_USERNAME'],
-            password=env['IGNFRANCE_PASSWORD'],
-            timeout=10
-        )
-
-
-@unittest.skipUnless(
-    bool(env.get('IGNFRANCE_USERNAME_KEY') and env.get('IGNFRANCE_USERNAME')
-         and env.get('IGNFRANCE_PASSWORD')),
-    "No IGNFRANCE_USERNAME_KEY or IGNFRANCE_USERNAME "
-    "or IGNFRANCE_PASSWORD env variable set"
-)
-class IGNFranceUsernameAuthProxyTestCase(GeocoderTestBase):
+class TestIGNFranceUsernameAuth(BaseTestIGNFrance):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
@@ -278,21 +249,41 @@ class IGNFranceUsernameAuthProxyTestCase(GeocoderTestBase):
             **kwargs
         )
 
+
+@pytest.mark.skipif(
+    not bool(env.get('IGNFRANCE_USERNAME_KEY') and env.get('IGNFRANCE_USERNAME')
+             and env.get('IGNFRANCE_PASSWORD')),
+    reason="No IGNFRANCE_USERNAME_KEY or IGNFRANCE_USERNAME "
+    "or IGNFRANCE_PASSWORD env variable set"
+)
+class TestIGNFranceUsernameAuthProxy(BaseTestGeocoder):
     proxy_timeout = 5
 
-    def setUp(self):
-        self.proxy_server = ProxyServerThread(timeout=self.proxy_timeout)
-        self.proxy_server.start()
-        self.proxy_url = self.proxy_server.get_proxy_url()
-        self.geocoder = self.make_geocoder(proxies=self.proxy_url)
+    @classmethod
+    def make_geocoder(cls, **kwargs):
+        return IGNFrance(
+            api_key=env['IGNFRANCE_USERNAME_KEY'],
+            username=env['IGNFRANCE_USERNAME'],
+            password=env['IGNFRANCE_PASSWORD'],
+            timeout=10,
+            **kwargs
+        )
 
-    def tearDown(self):
-        self.proxy_server.stop()
-        self.proxy_server.join()
+    @pytest.fixture(scope='class', autouse=True)
+    @async_generator
+    async def start_proxy(_, request, class_geocoder):
+        cls = request.cls
+        cls.proxy_server = ProxyServerThread(timeout=cls.proxy_timeout)
+        cls.proxy_server.start()
+        cls.proxy_url = cls.proxy_server.get_proxy_url()
+        async with cls.inject_geocoder(cls.make_geocoder(proxies=cls.proxy_url)):
+            await yield_()
+        cls.proxy_server.stop()
+        cls.proxy_server.join()
 
-    def test_proxy_is_respected(self):
+    async def test_proxy_is_respected(self):
         assert 0 == len(self.proxy_server.requests)
-        self.geocode_run(
+        await self.geocode_run(
             {"query": "Camp des Landes, 41200 VILLEFRANCHE-SUR-CHER",
              "query_type": "StreetAddress"},
             {"latitude": 47.293048,

--- a/test/geocoders/mapbox.py
+++ b/test/geocoders/mapbox.py
@@ -1,50 +1,48 @@
-import unittest
-
 import pytest
 
 from geopy.geocoders import MapBox
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-@unittest.skipUnless(
-    bool(env.get('MAPBOX_KEY')),
-    "No MAPBOX_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('MAPBOX_KEY')),
+    reason="No MAPBOX_KEY env variable set"
 )
-class MapBoxTestCase(GeocoderTestBase):
+class TestMapBox(BaseTestGeocoder):
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = MapBox(api_key=env['MAPBOX_KEY'], timeout=3)
+    def make_geocoder(cls, **kwargs):
+        return MapBox(api_key=env['MAPBOX_KEY'], timeout=3, **kwargs)
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "\u6545\u5bab"},
             {"latitude": 39.916, "longitude": 116.390},
         )
 
-    def test_reverse(self):
+    async def test_reverse(self):
         new_york_point = Point(40.75376406311989, -73.98489005863667)
-        location = self.reverse_run(
+        location = await self.reverse_run(
             {"query": new_york_point},
             {"latitude": 40.7537640, "longitude": -73.98489, "delta": 1},
         )
         assert "New York" in location.address
 
-    def test_zero_results(self):
-        self.geocode_run(
+    async def test_zero_results(self):
+        await self.geocode_run(
             {"query": 'asdfasdfasdf'},
             {},
             expect_failure=True,
         )
 
-    def test_geocode_outside_bbox(self):
-        self.geocode_run(
+    async def test_geocode_outside_bbox(self):
+        await self.geocode_run(
             {
                 "query": "435 north michigan ave, chicago il 60611 usa",
                 "bbox": [[34.172684, -118.604794],
@@ -54,8 +52,8 @@ class MapBoxTestCase(GeocoderTestBase):
             expect_failure=True,
         )
 
-    def test_geocode_bbox(self):
-        self.geocode_run(
+    async def test_geocode_bbox(self):
+        await self.geocode_run(
             {
                 "query": "435 north michigan ave, chicago il 60611 usa",
                 "bbox": [Point(35.227672, -103.271484),
@@ -64,32 +62,32 @@ class MapBoxTestCase(GeocoderTestBase):
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_geocode_proximity(self):
-        self.geocode_run(
+    async def test_geocode_proximity(self):
+        await self.geocode_run(
             {"query": "200 queen street", "proximity": Point(45.3, -66.1)},
             {"latitude": 45.270208, "longitude": -66.050289, "delta": 0.1},
         )
 
-    def test_geocode_country_str(self):
-        self.geocode_run(
+    async def test_geocode_country_str(self):
+        await self.geocode_run(
             {"query": "kazan", "country": "TR"},
             {"latitude": 40.2317, "longitude": 32.6839},
         )
 
-    def test_geocode_country_list(self):
-        self.geocode_run(
+    async def test_geocode_country_list(self):
+        await self.geocode_run(
             {"query": "kazan", "country": ["CN", "TR"]},
             {"latitude": 40.2317, "longitude": 32.6839},
         )
 
-    def test_geocode_raw(self):
-        result = self.geocode_run({"query": "New York"}, {})
+    async def test_geocode_raw(self):
+        result = await self.geocode_run({"query": "New York"}, {})
         delta = 1.0
         expected = pytest.approx((-73.8784155, 40.6930727), abs=delta)
         assert expected == result.raw['center']
 
-    def test_geocode_exactly_one_false(self):
-        list_result = self.geocode_run(
+    async def test_geocode_exactly_one_false(self):
+        list_result = await self.geocode_run(
             {"query": "maple street", "exactly_one": False},
             {},
         )

--- a/test/geocoders/mapquest.py
+++ b/test/geocoders/mapquest.py
@@ -1,55 +1,55 @@
-import unittest
+import pytest
 
 from geopy.geocoders import MapQuest
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-@unittest.skipUnless(
-    bool(env.get('MAPQUEST_KEY')),
-    "No MAPQUEST_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('MAPQUEST_KEY')),
+    reason="No MAPQUEST_KEY env variable set"
 )
-class MapQuestTestCase(GeocoderTestBase):
+class TestMapQuest(BaseTestGeocoder):
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = MapQuest(api_key=env['MAPQUEST_KEY'], timeout=3)
+    def make_geocoder(cls, **kwargs):
+        return MapQuest(api_key=env['MAPQUEST_KEY'], timeout=3, **kwargs)
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.89036, "longitude": -87.624043},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "\u6545\u5bab"},
             {"latitude": 25.0968, "longitude": 121.54714},
         )
 
-    def test_reverse(self):
+    async def test_reverse(self):
         new_york_point = Point(40.75376406311989, -73.98489005863667)
-        location = self.reverse_run(
+        location = await self.reverse_run(
             {"query": new_york_point},
             {"latitude": 40.7537640, "longitude": -73.98489, "delta": 1},
         )
         assert "New York" in location.address
 
-    def test_zero_results(self):
-        self.geocode_run(
+    async def test_zero_results(self):
+        await self.geocode_run(
             {"query": ''},
             {},
             expect_failure=True,
         )
 
-    def test_geocode_empty(self):
-        self.geocode_run(
+    async def test_geocode_empty(self):
+        await self.geocode_run(
             {'query': 'sldkfhdskjfhsdkhgflaskjgf'},
             {},
             expect_failure=True,
         )
 
-    def test_geocode_bbox(self):
-        self.geocode_run(
+    async def test_geocode_bbox(self):
+        await self.geocode_run(
             {
                 "query": "435 north michigan ave, chicago il 60611 usa",
                 "bounds": [Point(35.227672, -103.271484),
@@ -58,21 +58,21 @@ class MapQuestTestCase(GeocoderTestBase):
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_geocode_raw(self):
-        result = self.geocode_run(
+    async def test_geocode_raw(self):
+        result = await self.geocode_run(
             {"query": "New York"},
             {"latitude": 40.713054, "longitude": -74.007228, "delta": 1},
         )
         assert result.raw['adminArea1'] == "US"
 
-    def test_geocode_limit(self):
-        list_result = self.geocode_run(
+    async def test_geocode_limit(self):
+        list_result = await self.geocode_run(
             {"query": "maple street", "exactly_one": False, "limit": 2},
             {},
         )
         assert len(list_result) == 2
 
-        list_result = self.geocode_run(
+        list_result = await self.geocode_run(
             {"query": "maple street", "exactly_one": False, "limit": 4},
             {},
         )

--- a/test/geocoders/maptiler.py
+++ b/test/geocoders/maptiler.py
@@ -1,50 +1,48 @@
-import unittest
-
 import pytest
 
 from geopy.geocoders import MapTiler
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-@unittest.skipUnless(
-    bool(env.get('MAPTILER_KEY')),
-    "No MAPTILER_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('MAPTILER_KEY')),
+    reason="No MAPTILER_KEY env variable set"
 )
-class MapTilerTestCase(GeocoderTestBase):
+class TestMapTiler(BaseTestGeocoder):
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = MapTiler(api_key=env['MAPTILER_KEY'], timeout=3)
+    def make_geocoder(cls, **kwargs):
+        return MapTiler(api_key=env['MAPTILER_KEY'], timeout=3, **kwargs)
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "Stadelhoferstrasse 8, 8001 Z\u00fcrich"},
             {"latitude": 47.36649, "longitude": 8.54855},
         )
 
-    def test_reverse(self):
+    async def test_reverse(self):
         new_york_point = Point(40.75376406311989, -73.98489005863667)
-        location = self.reverse_run(
+        location = await self.reverse_run(
             {"query": new_york_point},
             {"latitude": 40.7537640, "longitude": -73.98489, "delta": 1},
         )
         assert "New York" in location.address
 
-    def test_zero_results(self):
-        self.geocode_run(
+    async def test_zero_results(self):
+        await self.geocode_run(
             {"query": 'asdfasdfasdf'},
             {},
             expect_failure=True,
         )
 
-    def test_geocode_outside_bbox(self):
-        self.geocode_run(
+    async def test_geocode_outside_bbox(self):
+        await self.geocode_run(
             {
                 "query": "435 north michigan ave, chicago il 60611 usa",
                 "bbox": [[34.172684, -118.604794],
@@ -54,8 +52,8 @@ class MapTilerTestCase(GeocoderTestBase):
             expect_failure=True,
         )
 
-    def test_geocode_bbox(self):
-        self.geocode_run(
+    async def test_geocode_bbox(self):
+        await self.geocode_run(
             {
                 "query": "435 north michigan ave, chicago il 60611 usa",
                 "bbox": [Point(35.227672, -103.271484),
@@ -64,37 +62,37 @@ class MapTilerTestCase(GeocoderTestBase):
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_geocode_proximity(self):
-        self.geocode_run(
+    async def test_geocode_proximity(self):
+        await self.geocode_run(
             {"query": "200 queen street", "proximity": Point(45.3, -66.1)},
             {"latitude": 44.038901, "longitude": -64.73052, "delta": 0.1},
         )
 
-    def test_reverse_language(self):
+    async def test_reverse_language(self):
         zurich_point = Point(47.3723, 8.5422)
-        location = self.reverse_run(
+        location = await self.reverse_run(
             {"query": zurich_point, "language": "ja"},
             {"latitude": 47.3723, "longitude": 8.5422, "delta": 1},
         )
         assert "\u30c1\u30e5\u30fc\u30ea\u30c3\u30d2" in location.address
 
-    def test_geocode_language(self):
-        location = self.geocode_run(
+    async def test_geocode_language(self):
+        location = await self.geocode_run(
             {"query": "Z\u00fcrich", "language": "ja",
              "proximity": Point(47.3723, 8.5422)},
             {"latitude": 47.3723, "longitude": 8.5422, "delta": 1},
         )
         assert "\u30c1\u30e5\u30fc\u30ea\u30c3\u30d2" in location.address
 
-    def test_geocode_raw(self):
-        result = self.geocode_run({"query": "New York"}, {})
+    async def test_geocode_raw(self):
+        result = await self.geocode_run({"query": "New York"}, {})
         delta = 1.0
         expected = pytest.approx((-73.8784155, 40.6930727), abs=delta)
         assert expected == result.raw['center']
         assert "relation175905" == result.raw['properties']['osm_id']
 
-    def test_geocode_exactly_one_false(self):
-        list_result = self.geocode_run(
+    async def test_geocode_exactly_one_false(self):
+        list_result = await self.geocode_run(
             {"query": "maple street", "exactly_one": False},
             {},
         )

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -1,4 +1,3 @@
-from abc import ABC, abstractmethod
 from unittest.mock import patch
 
 import pytest
@@ -7,51 +6,42 @@ import geopy.geocoders
 from geopy.exc import ConfigurationError
 from geopy.geocoders import Nominatim
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase
+from test.geocoders.util import BaseTestGeocoder
 
 
-class BaseNominatimTestCase(ABC):
+class BaseTestNominatim(BaseTestGeocoder):
     # Common test cases for Nominatim-based geocoders.
     # Assumes that Nominatim uses the OSM data.
 
     delta = 0.04
 
-    @classmethod
-    @abstractmethod
-    def make_geocoder(cls, **kwargs):
-        pass
-
-    @classmethod
-    def setUpClass(cls):
-        cls.geocoder = cls.make_geocoder()
-
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "\u6545\u5bab \u5317\u4eac"},
             {"latitude": 39.916, "longitude": 116.390},
         )
 
-    def test_geocode_empty_result(self):
-        self.geocode_run(
+    async def test_geocode_empty_result(self):
+        await self.geocode_run(
             {"query": "dsadjkasdjasd"},
             {},
             expect_failure=True,
         )
 
-    def test_limit(self):
+    async def test_limit(self):
         with pytest.raises(ValueError):  # non-positive limit
-            self.geocode_run(
+            await self.geocode_run(
                 {"query": "does not matter", "limit": 0, "exactly_one": False},
                 {}
             )
 
-        result = self.geocode_run(
+        result = await self.geocode_run(
             {"query": "second street", "limit": 4, "exactly_one": False},
             {}
         )
@@ -64,29 +54,29 @@ class BaseNominatimTestCase(ABC):
         geocoder = self.make_geocoder(user_agent=None)
         assert geocoder.headers['User-Agent'] == 'mocked_user_agent/0.0.0'
 
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = self.make_geocoder(
             user_agent='my_test_application'
         )
         assert geocoder.headers['User-Agent'] == 'my_test_application'
 
-    def test_reverse(self):
-        location = self.reverse_run(
+    async def test_reverse(self):
+        location = await self.reverse_run(
             {"query": Point(40.75376406311989, -73.98489005863667)},
             {"latitude": 40.753, "longitude": -73.984}
         )
         assert "New York" in location.address
 
-    def test_structured_query(self):
-        self.geocode_run(
+    async def test_structured_query(self):
+        await self.geocode_run(
             {"query": {"country": "us", "city": "moscow",
                        "state": "idaho"}},
             {"latitude": 46.7323875, "longitude": -117.0001651},
         )
 
-    def test_city_district_with_dict_query(self):
+    async def test_city_district_with_dict_query(self):
         query = {'postalcode': 10117}
-        result = self.geocode_run(
+        result = await self.geocode_run(
             {"query": query, "addressdetails": True, "country_codes": "DE"},
             {},
         )
@@ -99,80 +89,80 @@ class BaseNominatimTestCase(ABC):
             city_district = result.raw['address']['suburb']
         assert city_district == 'Mitte'
 
-    def test_geocode_language_parameter(self):
+    async def test_geocode_language_parameter(self):
         query = "Mohrenstrasse Berlin"
-        result_geocode = self.geocode_run(
+        result_geocode = await self.geocode_run(
             {"query": query, "addressdetails": True,
              "language": "de"},
             {},
         )
         assert result_geocode.raw['address']['country'] == "Deutschland"
-        result_geocode = self.geocode_run(
+        result_geocode = await self.geocode_run(
             {"query": query, "addressdetails": True,
              "language": "en"},
             {},
         )
         assert result_geocode.raw['address']['country'] == "Germany"
 
-    def test_reverse_language_parameter(self):
+    async def test_reverse_language_parameter(self):
         query = "52.51693903613385, 13.3859332733135"
-        result_reverse_de = self.reverse_run(
+        result_reverse_de = await self.reverse_run(
             {"query": query, "language": "de"},
             {},
         )
         assert result_reverse_de.raw['address']['country'] == "Deutschland"
 
-        result_reverse_en = self.reverse_run(
+        result_reverse_en = await self.reverse_run(
             {"query": query, "language": "en"},
             {},
         )
         # have had a change in the exact authority name
         assert "Germany" in result_reverse_en.raw['address']['country']
 
-    def test_geocode_geometry_wkt(self):
-        result_geocode = self.geocode_run(
+    async def test_geocode_geometry_wkt(self):
+        result_geocode = await self.geocode_run(
             {"query": "Halensee,Berlin", "geometry": 'WKT'},
             {},
         )
         assert result_geocode.raw['geotext'].startswith('POLYGON((')
 
-    def test_geocode_geometry_svg(self):
-        result_geocode = self.geocode_run(
+    async def test_geocode_geometry_svg(self):
+        result_geocode = await self.geocode_run(
             {"query": "Halensee,Berlin", "geometry": 'svg'},
             {},
         )
         assert result_geocode.raw['svg'].startswith('M 13.')
 
-    def test_geocode_geometry_kml(self):
-        result_geocode = self.geocode_run(
+    async def test_geocode_geometry_kml(self):
+        result_geocode = await self.geocode_run(
             {"query": "Halensee,Berlin", "geometry": 'kml'},
             {},
         )
         assert result_geocode.raw['geokml'].startswith('<Polygon>')
 
-    def test_geocode_geometry_geojson(self):
-        result_geocode = self.geocode_run(
+    async def test_geocode_geometry_geojson(self):
+        result_geocode = await self.geocode_run(
             {"query": "Halensee,Berlin", "geometry": 'geojson'},
             {},
         )
         assert result_geocode.raw['geojson'].get('type') == 'Polygon'
 
-    def test_missing_reverse_details(self):
+    async def test_missing_reverse_details(self):
         query = (46.46131, 6.84311)
-        res = self.reverse_run(
+        res = await self.reverse_run(
             {"query": query},
             {}
         )
         assert "address" in res.raw
 
-        res = self.reverse_run(
+        res = await self.reverse_run(
             {"query": query, "addressdetails": False},
             {},
         )
         assert 'address' not in res.raw
 
-    def test_viewbox(self):
-        res = self.geocode_run(
+    async def test_viewbox(self):
+        res = await self.geocode_run(
             {"query": "Maple Street"},
             {},
         )
@@ -184,36 +174,36 @@ class BaseNominatimTestCase(ABC):
             [Point(52, -0.11), Point(50, -0.15)],
             (("52", "-0.11"), ("50", "-0.15"))
         ]:
-            self.geocode_run(
+            await self.geocode_run(
                 {"query": "Maple Street", "viewbox": viewbox},
                 {"latitude": 51.5223513, "longitude": -0.1382104}
             )
 
-    def test_bounded(self):
+    async def test_bounded(self):
         bb = (Point('56.588456', '84.719353'), Point('56.437293', '85.296822'))
         query = (
             '\u0441\u0442\u0440\u043e\u0438\u0442\u0435\u043b\u044c '
             '\u0442\u043e\u043c\u0441\u043a'
         )
 
-        self.geocode_run(
+        await self.geocode_run(
             {"query": query, "viewbox": bb},
             {"latitude": 56.4129459, "longitude": 84.847831069814},
         )
 
-        self.geocode_run(
+        await self.geocode_run(
             {"query": query, "viewbox": bb, "bounded": True},
             {"latitude": 56.4803224, "longitude": 85.0060457653324},
         )
 
-    def test_extratags(self):
+    async def test_extratags(self):
         query = "175 5th Avenue NYC"
-        location = self.geocode_run(
+        location = await self.geocode_run(
             {"query": query},
             {},
         )
         assert location.raw.get('extratags') is None
-        location = self.geocode_run(
+        location = await self.geocode_run(
             {"query": query, "extratags": True},
             {},
         )
@@ -225,14 +215,14 @@ class BaseNominatimTestCase(ABC):
         # in response a success.
         assert location.raw['extratags']['wikidata']
 
-    def test_country_codes_moscow(self):
-        self.geocode_run(
+    async def test_country_codes_moscow(self):
+        await self.geocode_run(
             {"query": "moscow", "country_codes": "RU"},
             {"latitude": 55.7507178, "longitude": 37.6176606,
              "delta": 0.3},
         )
 
-        location = self.geocode_run(
+        location = await self.geocode_run(
             {"query": "moscow", "country_codes": "US"},
             # There are two possible results:
             # Moscow Idaho: 46.7323875,-117.0001651
@@ -245,69 +235,69 @@ class BaseNominatimTestCase(ABC):
         assert -119 < location.longitude
         assert location.longitude < -70
 
-    def test_country_codes_str(self):
-        self.geocode_run(
+    async def test_country_codes_str(self):
+        await self.geocode_run(
             {"query": "kazan",
              "country_codes": 'tr'},
             {"latitude": 40.2317, "longitude": 32.6839, "delta": 2},
         )
 
-    def test_country_codes_list(self):
-        self.geocode_run(
+    async def test_country_codes_list(self):
+        await self.geocode_run(
             {"query": "kazan",
              "country_codes": ['cn', 'tr']},
             {"latitude": 40.2317, "longitude": 32.6839, "delta": 2},
         )
 
-    def test_featuretype_param(self):
-        self.geocode_run(
+    async def test_featuretype_param(self):
+        await self.geocode_run(
             {"query": "mexico",
              "featuretype": 'country'},
             {"latitude": 22.5000485, "longitude": -100.0000375},
         )
 
-        self.geocode_run(
+        await self.geocode_run(
             {"query": "mexico",
              "featuretype": 'state'},
             {"latitude": 19.4839446, "longitude": -99.6899716},
         )
 
-        self.geocode_run(
+        await self.geocode_run(
             {"query": "mexico",
              "featuretype": 'city'},
             {"latitude": 19.4326009, "longitude": -99.1333416},
         )
 
-        self.geocode_run(
+        await self.geocode_run(
             {"query": "georgia",
              "featuretype": 'settlement'},
             {"latitude": 32.3293809, "longitude": -83.1137366},
         )
 
-    def test_namedetails(self):
+    async def test_namedetails(self):
         query = "Kyoto, Japan"
-        result = self.geocode_run(
+        result = await self.geocode_run(
             {"query": query, "namedetails": True},
             {},
         )
         assert 'namedetails' in result.raw
 
-        result = self.geocode_run(
+        result = await self.geocode_run(
             {"query": query, "namedetails": False},
             {},
         )
         assert 'namedetails' not in result.raw
 
-    def test_reverse_zoom_parameter(self):
+    async def test_reverse_zoom_parameter(self):
         query = "40.689253199999996, -74.04454817144321"
-        result_reverse = self.reverse_run(
+        result_reverse = await self.reverse_run(
             {"query": query, "zoom": 10},
             {},
         )
         assert "New York" in result_reverse.address
         assert "Statue of Liberty" not in result_reverse.address
 
-        result_reverse = self.reverse_run(
+        result_reverse = await self.reverse_run(
             {"query": query},
             {},
         )
@@ -315,22 +305,22 @@ class BaseNominatimTestCase(ABC):
         assert "Statue of Liberty" in result_reverse.address
 
 
-class NominatimTestCase(BaseNominatimTestCase, GeocoderTestBase):
+class TestNominatim(BaseTestNominatim):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
         kwargs.setdefault('user_agent', 'geopy-test')
         return Nominatim(**kwargs)
 
-    def test_default_user_agent_error(self):
+    async def test_default_user_agent_error(self):
         with pytest.raises(ConfigurationError):
             Nominatim()
 
-    def test_example_user_agent_error(self):
+    async def test_example_user_agent_error(self):
         with pytest.raises(ConfigurationError):
             Nominatim(user_agent="specify_your_app_name_here")
 
-    def test_custom_user_agent_works(self):
+    async def test_custom_user_agent_works(self):
         Nominatim(user_agent='my_application')
 
         with patch.object(geopy.geocoders.options, 'default_user_agent',

--- a/test/geocoders/opencage.py
+++ b/test/geocoders/opencage.py
@@ -1,10 +1,10 @@
-import unittest
+import pytest
 
 from geopy.geocoders import OpenCage
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-class OpenCageTestCaseUnitTest(GeocoderTestBase):
+class TestUnitOpenCage:
 
     def test_user_agent_custom(self):
         geocoder = OpenCage(
@@ -14,54 +14,55 @@ class OpenCageTestCaseUnitTest(GeocoderTestBase):
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
 
-@unittest.skipUnless(
-    bool(env.get('OPENCAGE_KEY')),
-    "No OPENCAGE_KEY env variables set"
+@pytest.mark.skipif(
+    not bool(env.get('OPENCAGE_KEY')),
+    reason="No OPENCAGE_KEY env variables set"
 )
-class OpenCageTestCase(GeocoderTestBase):
+class TestOpenCage(BaseTestGeocoder):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = OpenCage(
+    def make_geocoder(cls, **kwargs):
+        return OpenCage(
             api_key=env['OPENCAGE_KEY'],
             timeout=10,
+            **kwargs
         )
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "\u6545\u5bab"},
             {"latitude": 39.916, "longitude": 116.390},
         )
 
-    def test_geocode_empty_result(self):
-        self.geocode_run(
+    async def test_geocode_empty_result(self):
+        await self.geocode_run(
             {"query": "xqj37"},
             {},
             expect_failure=True
         )
 
-    def test_bounds(self):
-        self.geocode_run(
+    async def test_bounds(self):
+        await self.geocode_run(
             {"query": "moscow",  # Idaho USA
              "bounds": [[50.1, -130.1], [44.1, -100.9]]},
             {"latitude": 46.7323875, "longitude": -117.0001651},
         )
 
-    def test_country_str(self):
-        self.geocode_run(
+    async def test_country_str(self):
+        await self.geocode_run(
             {"query": "kazan",
              "country": 'tr'},
             {"latitude": 40.2317, "longitude": 32.6839},
         )
 
-    def test_country_list(self):
-        self.geocode_run(
+    async def test_country_list(self):
+        await self.geocode_run(
             {"query": "kazan",
              "country": ['cn', 'tr']},
             {"latitude": 40.2317, "longitude": 32.6839},

--- a/test/geocoders/openmapquest.py
+++ b/test/geocoders/openmapquest.py
@@ -1,11 +1,11 @@
-import unittest
+import pytest
 
 from geopy.geocoders import OpenMapQuest
-from test.geocoders.nominatim import BaseNominatimTestCase
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.nominatim import BaseTestNominatim
+from test.geocoders.util import env
 
 
-class OpenMapQuestNoNetTestCase(GeocoderTestBase):
+class TestUnitOpenMapQuest:
 
     def test_user_agent_custom(self):
         geocoder = OpenMapQuest(
@@ -15,11 +15,11 @@ class OpenMapQuestNoNetTestCase(GeocoderTestBase):
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
 
-@unittest.skipUnless(
-    bool(env.get('OPENMAPQUEST_APIKEY')),
-    "No OPENMAPQUEST_APIKEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('OPENMAPQUEST_APIKEY')),
+    reason="No OPENMAPQUEST_APIKEY env variable set"
 )
-class OpenMapQuestTestCase(BaseNominatimTestCase, GeocoderTestBase):
+class TestOpenMapQuest(BaseTestNominatim):
 
     @classmethod
     def make_geocoder(cls, **kwargs):

--- a/test/geocoders/pelias.py
+++ b/test/geocoders/pelias.py
@@ -1,84 +1,73 @@
-import unittest
-from abc import ABC, abstractmethod
+import pytest
 
 from geopy.geocoders import Pelias
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-class BasePeliasTestCase(ABC):
+class BaseTestPelias(BaseTestGeocoder):
 
     delta = 0.04
+    known_state_de = "Verwaltungsregion Ionische Inseln"
+    known_state_en = "Ionian Islands Periphery"
 
-    @classmethod
-    @abstractmethod
-    def make_geocoder(cls, **kwargs):
-        pass
-
-    @classmethod
-    def setUpClass(cls):
-        cls.geocoder = cls.make_geocoder()
-
-        cls.known_state_de = "Verwaltungsregion Ionische Inseln"
-        cls.known_state_en = "Ionian Islands Periphery"
-
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890, "longitude": -87.624},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "san josé california"},
             {"latitude": 37.33939, "longitude": -121.89496},
         )
 
-    def test_reverse(self):
-        self.reverse_run(
+    async def test_reverse(self):
+        await self.reverse_run(
             {"query": Point(40.75376406311989, -73.98489005863667)},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667}
         )
 
-    def test_boundary_rect(self):
-        self.geocode_run(
+    async def test_boundary_rect(self):
+        await self.geocode_run(
             {"query": "moscow",  # Idaho USA
              "boundary_rect": [[50.1, -130.1], [44.1, -100.9]]},
             {"latitude": 46.7323875, "longitude": -117.0001651},
         )
 
-    def test_geocode_language_parameter(self):
+    async def test_geocode_language_parameter(self):
         query = "Graben 7, Wien"
-        result_geocode = self.geocode_run(
+        result_geocode = await self.geocode_run(
             {"query": query, "language": "de"}, {}
         )
         assert result_geocode.raw['properties']['country'] == "Österreich"
 
-        result_geocode = self.geocode_run(
+        result_geocode = await self.geocode_run(
             {"query": query, "language": "en"}, {}
         )
         assert result_geocode.raw['properties']['country'] == "Austria"
 
-    def test_reverse_language_parameter(self):
+    async def test_reverse_language_parameter(self):
         query = "48.198674, 16.348388"
-        result_reverse_de = self.reverse_run(
+        result_reverse_de = await self.reverse_run(
             {"query": query, "language": "de"},
             {},
         )
         assert result_reverse_de.raw['properties']['country'] == "Österreich"
 
-        result_reverse_en = self.reverse_run(
+        result_reverse_en = await self.reverse_run(
             {"query": query, "language": "en"},
             {},
         )
         assert result_reverse_en.raw['properties']['country'] == "Austria"
 
 
-@unittest.skipUnless(
-    bool(env.get('PELIAS_DOMAIN')),
-    "No PELIAS_DOMAIN env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('PELIAS_DOMAIN')),
+    reason="No PELIAS_DOMAIN env variable set"
 )
-class PeliasTestCase(BasePeliasTestCase, GeocoderTestBase):
+class TestPelias(BaseTestPelias):
 
     @classmethod
     def make_geocoder(cls, **kwargs):

--- a/test/geocoders/photon.py
+++ b/test/geocoders/photon.py
@@ -1,55 +1,55 @@
 from geopy.geocoders import Photon
 from geopy.point import Point
-from test.geocoders.util import GeocoderTestBase
+from test.geocoders.util import BaseTestGeocoder
 
 
-class PhotonTestCase(GeocoderTestBase):
+class TestPhoton(BaseTestGeocoder):
+    known_country_de = "Frankreich"
+    known_country_fr = "France"
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = Photon()
-        cls.known_country_de = "Frankreich"
-        cls.known_country_fr = "France"
+    def make_geocoder(cls, **kwargs):
+        return Photon(**kwargs)
 
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = Photon(
             user_agent='my_user_agent/1.0'
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_geocode(self):
-        location = self.geocode_run(
+    async def test_geocode(self):
+        location = await self.geocode_run(
             {"query": "14 rue pelisson villeurbanne"},
             {"latitude": 45.7733963, "longitude": 4.88612369},
         )
         assert "France" in location.address
 
-    def test_osm_tag(self):
-        self.geocode_run(
+    async def test_osm_tag(self):
+        await self.geocode_run(
             {"query": "Freedom", "osm_tag": "place"},
             {"latitude": 44.3862491, "longitude": -88.290994},
         )
 
-        self.geocode_run(
+        await self.geocode_run(
             {"query": "Freedom", "osm_tag": ["!place", "tourism"]},
             {"latitude": 38.8898061, "longitude": -77.009088},
         )
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "\u6545\u5bab"},
             {"latitude": 39.916, "longitude": 116.390},
         )
 
-    def test_reverse(self):
-        result = self.reverse_run(
+    async def test_reverse(self):
+        result = await self.reverse_run(
             {"query": Point(45.7733105, 4.8869339)},
             {"latitude": 45.7733105, "longitude": 4.8869339}
         )
         assert "France" in result.address
 
-    def test_geocode_language_parameter(self):
-        result_geocode = self.geocode_run(
+    async def test_geocode_language_parameter(self):
+        result_geocode = await self.geocode_run(
             {"query": self.known_country_fr, "language": "de"},
             {},
         )
@@ -58,9 +58,9 @@ class PhotonTestCase(GeocoderTestBase):
             self.known_country_de
         )
 
-    def test_reverse_language_parameter(self):
+    async def test_reverse_language_parameter(self):
 
-        result_reverse_it = self.reverse_run(
+        result_reverse_it = await self.reverse_run(
             {"query": "45.7733105, 4.8869339",
              "language": "de"},
             {},
@@ -70,7 +70,7 @@ class PhotonTestCase(GeocoderTestBase):
             self.known_country_de
         )
 
-        result_reverse_fr = self.reverse_run(
+        result_reverse_fr = await self.reverse_run(
             {"query": "45.7733105, 4.8869339",
              "language": "fr"},
             {},

--- a/test/geocoders/pickpoint.py
+++ b/test/geocoders/pickpoint.py
@@ -1,23 +1,24 @@
-import unittest
 import warnings
 
+import pytest
+
 from geopy.geocoders import PickPoint
-from test.geocoders.nominatim import BaseNominatimTestCase
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.nominatim import BaseTestNominatim
+from test.geocoders.util import env
 
 
-@unittest.skipUnless(
-    bool(env['PICKPOINT_KEY']),
-    "No PICKPOINT_KEY env variable set"
+@pytest.mark.skipif(
+    not env['PICKPOINT_KEY'],
+    reason="No PICKPOINT_KEY env variable set"
 )
-class PickPointTestCase(BaseNominatimTestCase, GeocoderTestBase):
+class TestPickPoint(BaseTestNominatim):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
         return PickPoint(api_key=env['PICKPOINT_KEY'],
                          timeout=3, **kwargs)
 
-    def test_no_nominatim_user_agent_warning(self):
+    async def test_no_nominatim_user_agent_warning(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             PickPoint(api_key=env['PICKPOINT_KEY'])

--- a/test/geocoders/smartystreets.py
+++ b/test/geocoders/smartystreets.py
@@ -1,12 +1,13 @@
-import unittest
 from unittest.mock import patch
+
+import pytest
 
 import geopy.geocoders
 from geopy.geocoders import LiveAddress
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-class LiveAddressTestCaseUnitTest(GeocoderTestBase):
+class TestUnitLiveAddress:
     dummy_id = 'DUMMY12345'
     dummy_token = 'DUMMY67890'
 
@@ -24,22 +25,22 @@ class LiveAddressTestCaseUnitTest(GeocoderTestBase):
         assert geocoder.scheme == 'https'
 
 
-@unittest.skipUnless(
-    env.get('LIVESTREETS_AUTH_ID') and env.get('LIVESTREETS_AUTH_TOKEN'),
-    "No LIVESTREETS_AUTH_ID AND LIVESTREETS_AUTH_TOKEN env variables set"
+@pytest.mark.skipif(
+    not (env.get('LIVESTREETS_AUTH_ID') and env.get('LIVESTREETS_AUTH_TOKEN')),
+    reason="No LIVESTREETS_AUTH_ID AND LIVESTREETS_AUTH_TOKEN env variables set"
 )
-class LiveAddressTestCase(GeocoderTestBase):
+class TestLiveAddress(BaseTestGeocoder):
 
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = LiveAddress(
+    def make_geocoder(cls, **kwargs):
+        return LiveAddress(
             auth_id=env['LIVESTREETS_AUTH_ID'],
             auth_token=env['LIVESTREETS_AUTH_TOKEN'],
+            **kwargs
         )
-        cls.delta = 0.04
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "435 north michigan ave, chicago il 60611 usa"},
             {"latitude": 41.890, "longitude": -87.624},
         )

--- a/test/geocoders/tomtom.py
+++ b/test/geocoders/tomtom.py
@@ -1,36 +1,26 @@
-import unittest
-from abc import ABC, abstractmethod
+import pytest
 
 from geopy.geocoders import TomTom
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-class BaseTomTomTestCase(ABC):
+class BaseTestTomTom(BaseTestGeocoder):
 
-    @classmethod
-    @abstractmethod
-    def make_geocoder(cls, **kwargs):
-        pass
-
-    @classmethod
-    def setUpClass(cls):
-        cls.geocoder = cls.make_geocoder()
-
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = self.make_geocoder(
             user_agent='my_user_agent/1.0'
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_geocode(self):
-        location = self.geocode_run(
+    async def test_geocode(self):
+        location = await self.geocode_run(
             {'query': 'москва'},
             {'latitude': 55.75587, 'longitude': 37.61768},
         )
         assert 'Москва' in location.address
 
-    def test_reverse(self):
-        location = self.reverse_run(
+    async def test_reverse(self):
+        location = await self.reverse_run(
             {'query': '51.5285057, -0.1369635', 'language': 'en-US'},
             {'latitude': 51.5285057, 'longitude': -0.1369635,
              "delta": 0.3},
@@ -46,19 +36,19 @@ class BaseTomTomTestCase(ABC):
         # the cyrillic variant, even when the `en-US` language is
         # requested.
 
-    def test_geocode_empty(self):
-        self.geocode_run(
+    async def test_geocode_empty(self):
+        await self.geocode_run(
             {'query': 'sldkfhdskjfhsdkhgflaskjgf'},
             {},
             expect_failure=True,
         )
 
 
-@unittest.skipUnless(
-    bool(env.get('TOMTOM_KEY')),
-    "No TOMTOM_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('TOMTOM_KEY')),
+    reason="No TOMTOM_KEY env variable set"
 )
-class TomTomTestCase(BaseTomTomTestCase, GeocoderTestBase):
+class TestTomTom(BaseTestTomTom):
 
     @classmethod
     def make_geocoder(cls, **kwargs):

--- a/test/geocoders/util.py
+++ b/test/geocoders/util.py
@@ -69,7 +69,7 @@ class BaseTestGeocoder(ABC):
 
     @classmethod
     @abstractmethod
-    def make_geocoder(cls, **kwargs):
+    def make_geocoder(cls, **kwargs):  # pragma: no cover
         pass
 
     async def geocode_run(

--- a/test/geocoders/util.py
+++ b/test/geocoders/util.py
@@ -1,13 +1,14 @@
-
 import json
 import os
-import unittest
+from abc import ABC, abstractmethod
 from collections import defaultdict
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
 
 import pytest
+from async_generator import async_generator, asynccontextmanager, yield_
 
 from geopy import exc
+from geopy.adapters import BaseAsyncAdapter
 from geopy.location import Location
 
 env = defaultdict(lambda: None)
@@ -18,7 +19,7 @@ except IOError:
     env.update(os.environ)
 
 
-class GeocoderTestBase(unittest.TestCase):
+class BaseTestGeocoder(ABC):
     """
     Base for geocoder-specific test cases.
     """
@@ -26,72 +27,120 @@ class GeocoderTestBase(unittest.TestCase):
     geocoder = None
     delta = 0.5
 
-    def tearDown(self):
-        # Typically geocoder instance is created in the setUpClass
-        # method and is assigned to the TestCase as a class attribute.
-        #
-        # Individual test methods might assign a custom instance of
-        # geocoder to the `self.geocoder` instance attribute, which
-        # will shadow the class's `geocoder` attribute, used by
-        # the `geocode_run`/`reverse_run` methods.
-        #
-        # The code below cleans up the possibly assigned instance
-        # attribute.
-        try:
-            del self.geocoder
-        except AttributeError:
-            pass
+    @pytest.fixture(scope='class', autouse=True)
+    @async_generator
+    async def class_geocoder(_, request, patch_adapter):
+        """Prepare a class-level Geocoder instance."""
+        cls = request.cls
+        geocoder = cls.make_geocoder()
+        cls.geocoder = geocoder
 
-    def geocode_run(self, payload, expected, expect_failure=False,
-                    skiptest_on_failure=False):
+        run_async = isinstance(geocoder.adapter, BaseAsyncAdapter)
+        if run_async:
+            async with geocoder:
+                await yield_(geocoder)
+        else:
+            await yield_(geocoder)
+
+    @classmethod
+    @asynccontextmanager
+    @async_generator
+    async def inject_geocoder(cls, geocoder):
+        """An async context manager allowing to inject a custom
+        geocoder instance in a single test method which will
+        be used by the `geocode_run`/`reverse_run` methods.
+        """
+        with patch.object(cls, 'geocoder', geocoder):
+            run_async = isinstance(geocoder.adapter, BaseAsyncAdapter)
+            if run_async:
+                async with geocoder:
+                    await yield_(geocoder)
+            else:
+                await yield_(geocoder)
+
+    @pytest.fixture(autouse=True)
+    def ensure_no_geocoder_assignment(self):
+        yield
+        assert self.geocoder is type(self).geocoder, (
+            "Detected `self.geocoder` assignment. "
+            "Please use `async with inject_geocoder(my_geocoder):` "
+            "instead, whish supports async adapters."
+        )
+
+    @classmethod
+    @abstractmethod
+    def make_geocoder(cls, **kwargs):
+        pass
+
+    async def geocode_run(
+        self, payload, expected, expect_failure=False,
+        skiptest_on_failure=False
+    ):
         """
         Calls geocoder.geocode(**payload), then checks against `expected`.
         """
         cls = type(self)
-        result = self._make_request(self.geocoder.geocode, **payload)
+        result = await self._make_request(self.geocoder, 'geocode', **payload)
         if result is None:
             if expect_failure:
                 return
             elif skiptest_on_failure:
-                self.skipTest('%s: Skipping test due to empty result' % cls.__name__)
+                pytest.skip('%s: Skipping test due to empty result' % cls.__name__)
             else:
-                self.fail('%s: No result found' % cls.__name__)
+                pytest.fail('%s: No result found' % cls.__name__)
         if result == []:
-            self.fail('%s returned an empty list instead of None' % cls.__name__)
+            pytest.fail('%s returned an empty list instead of None' % cls.__name__)
         self._verify_request(result, exactly_one=payload.get('exactly_one', True),
                              **expected)
         return result
 
-    def reverse_run(self, payload, expected, expect_failure=False,
-                    skiptest_on_failure=False):
+    async def reverse_run(
+        self, payload, expected, expect_failure=False,
+        skiptest_on_failure=False
+    ):
         """
         Calls geocoder.reverse(**payload), then checks against `expected`.
         """
         cls = type(self)
-        result = self._make_request(self.geocoder.reverse, **payload)
+        result = await self._make_request(self.geocoder, 'reverse', **payload)
         if result is None:
             if expect_failure:
                 return
             elif skiptest_on_failure:
-                self.skipTest('%s: Skipping test due to empty result' % cls.__name__)
+                pytest.skip('%s: Skipping test due to empty result' % cls.__name__)
             else:
-                self.fail('%s: No result found' % cls.__name__)
+                pytest.fail('%s: No result found' % cls.__name__)
         if result == []:
-            self.fail('%s returned an empty list instead of None' % cls.__name__)
+            pytest.fail('%s returned an empty list instead of None' % cls.__name__)
         self._verify_request(result, exactly_one=payload.get('exactly_one', True),
                              **expected)
         return result
 
-    @classmethod
-    def _make_request(cls, call, *args, **kwargs):
+    async def reverse_timezone_run(self, payload, expected):
+        timezone = await self._make_request(
+            self.geocoder, 'reverse_timezone', **payload)
+        if expected is None:
+            assert timezone is None
+        else:
+            assert timezone.pytz_timezone == expected
+
+        return timezone
+
+    async def _make_request(self, geocoder, method, *args, **kwargs):
+        cls = type(self)
+        call = getattr(geocoder, method)
+        run_async = isinstance(geocoder.adapter, BaseAsyncAdapter)
         try:
-            result = call(*args, **kwargs)
+            if run_async:
+                result = await call(*args, **kwargs)
+            else:
+                result = call(*args, **kwargs)
         except exc.GeocoderQuotaExceeded:
-            raise unittest.SkipTest("%s: Quota exceeded" % cls.__name__)
+            pytest.skip("%s: Quota exceeded" % cls.__name__)
         except exc.GeocoderTimedOut:
-            raise unittest.SkipTest("%s: Service timed out" % cls.__name__)
+            pytest.skip("%s: Service timed out" % cls.__name__)
         except exc.GeocoderUnavailable:
-            raise unittest.SkipTest("%s: Service unavailable" % cls.__name__)
+            pytest.skip("%s: Service unavailable" % cls.__name__)
         return result
 
     def _verify_request(

--- a/test/geocoders/what3words.py
+++ b/test/geocoders/what3words.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import patch
 
 import pytest
@@ -6,13 +5,13 @@ import pytest
 import geopy.exc
 import geopy.geocoders
 from geopy.geocoders import What3Words
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-class What3WordsTestCaseUnitTest(GeocoderTestBase):
+class TestUnitWhat3Words:
     dummy_api_key = 'DUMMYKEY1234'
 
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = What3Words(
             api_key=self.dummy_api_key,
             user_agent='my_user_agent/1.0'
@@ -25,33 +24,33 @@ class What3WordsTestCaseUnitTest(GeocoderTestBase):
         assert geocoder.scheme == 'https'
 
 
-@unittest.skipUnless(
-    bool(env.get('WHAT3WORDS_KEY')),
-    "No WHAT3WORDS_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env.get('WHAT3WORDS_KEY')),
+    reason="No WHAT3WORDS_KEY env variable set"
 )
-class What3WordsTestCase(GeocoderTestBase):
+class TestWhat3Words(BaseTestGeocoder):
     @classmethod
-    def setUpClass(cls):
-        cls.geocoder = What3Words(
+    def make_geocoder(cls, **kwargs):
+        return What3Words(
             env['WHAT3WORDS_KEY'],
-            timeout=3
+            timeout=3,
+            **kwargs
         )
-        cls.delta = 0.7
 
-    def test_geocode(self):
-        self.geocode_run(
+    async def test_geocode(self):
+        await self.geocode_run(
             {"query": "piped.gains.jangle"},
             {"latitude": 53.037611, "longitude": 11.565012},
         )
 
-    def test_reverse(self):
-        self.reverse_run(
+    async def test_reverse(self):
+        await self.reverse_run(
             {"query": "53.037611,11.565012", "lang": 'DE'},
             {"address": 'fortschrittliche.voll.schnitt'},
         )
 
-    def test_unicode_query(self):
-        self.geocode_run(
+    async def test_unicode_query(self):
+        await self.geocode_run(
             {
                 "query": (
                     "\u0070\u0069\u0070\u0065\u0064\u002e\u0067"
@@ -62,31 +61,31 @@ class What3WordsTestCase(GeocoderTestBase):
             {"latitude": 53.037611, "longitude": 11.565012},
         )
 
-    def test_empty_response(self):
+    async def test_empty_response(self):
         with pytest.raises(geopy.exc.GeocoderQueryError):
-            self.geocode_run(
+            await self.geocode_run(
                 {"query": "definitely.not.existingiswearrrr"},
                 {},
                 expect_failure=True
             )
 
-    def test_not_exactly_one(self):
-        self.geocode_run(
+    async def test_not_exactly_one(self):
+        await self.geocode_run(
             {"query": "piped.gains.jangle", "exactly_one": False},
             {"latitude": 53.037611, "longitude": 11.565012},
         )
-        self.reverse_run(
+        await self.reverse_run(
             {"query": (53.037611, 11.565012), "exactly_one": False},
             {"address": "piped.gains.jangle"},
         )
 
-    def test_result_language(self):
-        self.geocode_run(
+    async def test_result_language(self):
+        await self.geocode_run(
             {"query": "piped.gains.jangle", "lang": 'DE'},
             {"address": 'fortschrittliche.voll.schnitt'},
         )
 
-    def test_check_query(self):
+    async def test_check_query(self):
         result_check_threeword_query = self.geocoder._check_query(
             "\u0066\u0061\u0068\u0072\u0070\u0072"
             "\u0065\u0069\u0073\u002e\u006c\u00fc"

--- a/test/geocoders/yandex.py
+++ b/test/geocoders/yandex.py
@@ -1,67 +1,62 @@
-import unittest
-
 import pytest
 
 from geopy.exc import GeocoderInsufficientPrivileges
 from geopy.geocoders import Yandex
-from test.geocoders.util import GeocoderTestBase, env
+from test.geocoders.util import BaseTestGeocoder, env
 
 
-@unittest.skipUnless(
-    bool(env['YANDEX_KEY']),
-    "No YANDEX_KEY env variable set"
+@pytest.mark.skipif(
+    not bool(env['YANDEX_KEY']),
+    reason="No YANDEX_KEY env variable set"
 )
-class YandexTestCase(GeocoderTestBase):
+class TestYandex(BaseTestGeocoder):
 
     @classmethod
-    def setUpClass(cls):
-        cls.delta = 0.04
-        cls.geocoder = Yandex(api_key=env.get('YANDEX_KEY'))
+    def make_geocoder(cls, **kwargs):
+        return Yandex(api_key=env.get('YANDEX_KEY'), **kwargs)
 
-    def test_user_agent_custom(self):
+    async def test_user_agent_custom(self):
         geocoder = Yandex(
             api_key='mock',
             user_agent='my_user_agent/1.0'
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 
-    def test_unicode_name(self):
-        self.geocode_run(
+    async def test_unicode_name(self):
+        await self.geocode_run(
             {"query": "площадь Ленина Донецк"},
             {"latitude": 48.002104, "longitude": 37.805186},
         )
 
-    def test_failure_with_invalid_api_key(self):
-        self.geocoder = Yandex(
-            api_key='bad key'
-        )
-        with pytest.raises(GeocoderInsufficientPrivileges):
-            self.geocode_run(
-                {"query": "площадь Ленина Донецк"},
-                {}
-            )
+    async def test_failure_with_invalid_api_key(self):
+        async with self.inject_geocoder(Yandex(api_key='bad key')):
+            with pytest.raises(GeocoderInsufficientPrivileges):
+                await self.geocode_run(
+                    {"query": "площадь Ленина Донецк"},
+                    {}
+                )
 
-    def test_reverse(self):
-        self.reverse_run(
+    async def test_reverse(self):
+        await self.reverse_run(
             {"query": "40.75376406311989, -73.98489005863667"},
             {"latitude": 40.75376406311989, "longitude": -73.98489005863667},
         )
 
-    def test_geocode_lang(self):
-        self.geocode_run(
+    async def test_geocode_lang(self):
+        await self.geocode_run(
             {"query": "площа Леніна Донецьк", "lang": "uk_UA"},
             {"address": "площа Леніна, Донецьк, Україна",
              "latitude": 48.002104, "longitude": 37.805186},
         )
 
-    def test_reverse_kind(self):
-        self.reverse_run(
+    async def test_reverse_kind(self):
+        await self.reverse_run(
             {"query": (55.743659, 37.408055), "kind": "locality"},
             {"address": "Москва, Россия"}
         )
 
-    def test_reverse_lang(self):
-        self.reverse_run(
+    async def test_reverse_lang(self):
+        await self.reverse_run(
             {"query": (55.743659, 37.408055), "kind": "locality",
              "lang": "uk_UA"},
             {"address": "Москва, Росія"}

--- a/test/proxy_server.py
+++ b/test/proxy_server.py
@@ -70,6 +70,10 @@ class ProxyServerThread(threading.Thread):
         super().__init__()
         self.daemon = True
 
+    def reset(self):
+        self.requests.clear()
+        self.auth = None
+
     def __enter__(self):
         self.start()
         return self

--- a/test/proxy_server.py
+++ b/test/proxy_server.py
@@ -1,3 +1,4 @@
+import base64
 import http.server as SimpleHTTPServer
 import select
 import socket
@@ -64,6 +65,7 @@ class ProxyServerThread(threading.Thread):
         self.proxy_server = None
         self.socket_created_future = Future()
         self.requests = []
+        self.auth = None
 
         super().__init__()
         self.daemon = True
@@ -76,20 +78,51 @@ class ProxyServerThread(threading.Thread):
         self.stop()
         self.join()
 
+    def set_auth(self, username, password):
+        self.auth = "%s:%s" % (username, password)
+
     def get_proxy_url(self):
         assert self.socket_created_future.result(self.spinup_timeout)
-        return "http://%s:%s" % (self.proxy_host, self.proxy_port)
+        if self.auth:
+            auth = "%s@" % self.auth
+        else:
+            auth = ""
+        return "http://%s%s:%s" % (auth, self.proxy_host, self.proxy_port)
 
     def run(self):
         assert not self.proxy_server, ("This class is not reentrable. "
                                        "Please create a new instance.")
 
         requests = self.requests
+        proxy_thread = self
 
         class Proxy(SimpleHTTPServer.SimpleHTTPRequestHandler):
             timeout = self.timeout
 
+            def check_auth(self):
+                if proxy_thread.auth is not None:
+                    auth_header = self.headers.get('Proxy-Authorization')
+                    b64_auth = base64.standard_b64encode(
+                        proxy_thread.auth.encode()
+                    ).decode()
+                    expected_auth = "Basic %s" % b64_auth
+                    if auth_header != expected_auth:
+                        self.send_response(401)
+                        self.send_header('Connection', 'close')
+                        self.end_headers()
+                        self.wfile.write(
+                            (
+                                "not authenticated. Expected %r, received %r"
+                                % (expected_auth, auth_header)
+                            ).encode()
+                        )
+                        self.connection.close()
+                        return False
+                return True
+
             def do_GET(self):
+                if not self.check_auth():
+                    return
                 requests.append(self.path)
 
                 req = urlopen(self.path, timeout=self.timeout)
@@ -104,6 +137,8 @@ class ProxyServerThread(threading.Thread):
                 req.close()
 
             def do_CONNECT(self):
+                if not self.check_auth():
+                    return
                 requests.append(self.path)
 
                 # Make a raw TCP connection to the target server
@@ -192,6 +227,12 @@ class HttpServerThread(threading.Thread):
                 elif self.path == "/json":
                     self.send_response(200)
                     self.send_header('Content-type', 'application/json')
+                    self.send_header('Connection', 'close')
+                    self.end_headers()
+                    self.wfile.write(b'{"hello":"world"}')
+                elif self.path == "/json/plain":
+                    self.send_response(200)
+                    self.send_header('Content-type', 'text/plain;charset=utf-8')
                     self.send_header('Connection', 'close')
                     self.end_headers()
                     self.wfile.write(b'{"hello":"world"}')

--- a/test/proxy_server.py
+++ b/test/proxy_server.py
@@ -85,13 +85,17 @@ class ProxyServerThread(threading.Thread):
     def set_auth(self, username, password):
         self.auth = "%s:%s" % (username, password)
 
-    def get_proxy_url(self):
+    def get_proxy_url(self, with_scheme=True):
         assert self.socket_created_future.result(self.spinup_timeout)
         if self.auth:
             auth = "%s@" % self.auth
         else:
             auth = ""
-        return "http://%s%s:%s" % (auth, self.proxy_host, self.proxy_port)
+        if with_scheme:
+            scheme = "http://"
+        else:
+            scheme = ""
+        return "%s%s%s:%s" % (scheme, auth, self.proxy_host, self.proxy_port)
 
     def run(self):
         assert not self.proxy_server, ("This class is not reentrable. "

--- a/test/test_adapters.py
+++ b/test/test_adapters.py
@@ -39,15 +39,21 @@ class DummyGeocoder(Geocoder):
         return self._call_geocoder(location, lambda res: res, is_json=is_json)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def timeout():
     return 5
 
 
-@pytest.fixture
-def proxy_server(timeout):
+@pytest.fixture(scope="session")
+def proxy_server_thread(timeout):
     with ProxyServerThread(timeout=timeout) as proxy_server:
         yield proxy_server
+
+
+@pytest.fixture
+def proxy_server(proxy_server_thread):
+    proxy_server_thread.reset()
+    return proxy_server_thread
 
 
 @pytest.fixture
@@ -69,7 +75,7 @@ def inject_proxy_to_system_env(proxy_url):
     os.environ.pop("https_proxy", None)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def http_server(timeout):
     with HttpServerThread(timeout=timeout) as http_server:
         yield http_server

--- a/test/test_point.py
+++ b/test/test_point.py
@@ -148,7 +148,7 @@ class PointTestCase(unittest.TestCase):
             self.assertEqual(2, len(w))
 
     def test_point_degrees_normalization_does_not_lose_precision(self):
-        if sys.float_info.mant_dig != 53:
+        if sys.float_info.mant_dig != 53:  # pragma: no cover
             raise unittest.SkipTest('This platform does not store floats as '
                                     'IEEE 754 double')
         # IEEE 754 double is stored like this:

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=py{35,36,37,38,39},pypy3,lint,rst
 [testenv]
 extras =
     dev-test
+    aiohttp
     requests
     timezone
 whitelist_externals = make


### PR DESCRIPTION
(This PR contains a subset of commits from #335).

Introduce asyncio support via `aiohttp`.

Usage:

```py
from geopy.adapters import AioHTTPAdapter
from geopy.geocoders import Nominatim

async with Nominatim(
    user_agent="specify_your_app_name_here",
    adapter_factory=AioHTTPAdapter,
) as geolocator:
    location = await geolocator.geocode("175 5th Avenue NYC")
    print(location.address)
```

Also tests have been converted from unittest to pytest classes to allow `async def` testcases. Tests now transparently support both sync and async adapters. 

A single test job with an async adapter has been added to the testing matrix on Travis.