### PR TITLE
geopy 2.0: RateLimiter: add thread-safety + add AsyncRateLimiter

### DIFF
--- a/docs/changelog_2xx.rst
+++ b/docs/changelog_2xx.rst
@@ -38,6 +38,8 @@ New features
 - Added optional asyncio support in all geocoders via
   :class:`.AioHTTPAdapter`, see the new :ref:`Async Mode <async_mode>`
   doc section.
+- :class:`.AsyncRateLimiter` -- an async counterpart of :class:`.RateLimiter`.
+- :class:`.RateLimiter` is now thread-safe.
 
 Packaging changes
 ~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Default Options Object
 Usage with Pandas
 -----------------
 
-It's possible to geocode a pandas DataFrame with geopy, however,
+It is possible to geocode a pandas DataFrame with geopy, however,
 rate-limiting must be taken into account.
 
 A large number of DataFrame rows might produce a significant amount of
@@ -63,14 +63,14 @@ geocoding requests to a Geocoding service, which might be throttled
 by the service (e.g. by returning `Too Many Requests` 429 HTTP error
 or timing out).
 
-:class:`geopy.extra.rate_limiter.RateLimiter` class provides a convenient
+:mod:`geopy.extra.rate_limiter` classes provide a convenient
 wrapper, which can be used to automatically add delays between geocoding
 calls to reduce the load on the Geocoding service. Also it can retry
 failed requests and swallow errors for individual rows.
 
 If you're having the `Too Many Requests` error, you may try the following:
 
-- Use :class:`geopy.extra.rate_limiter.RateLimiter` with non-zero
+- Use :mod:`geopy.extra.rate_limiter` with non-zero
   ``min_delay_seconds``.
 - Try a different Geocoding service (please consult with their ToS first,
   as some services prohibit bulk geocoding).
@@ -78,7 +78,17 @@ If you're having the `Too Many Requests` error, you may try the following:
   higher quota.
 - Provision your own local copy of the Geocoding service (such as Nominatim).
 
+Rate Limiter
+++++++++++++
+
+.. automodule:: geopy.extra.rate_limiter
+   :members: __doc__
+
 .. autoclass:: geopy.extra.rate_limiter.RateLimiter
+
+   .. automethod:: __init__
+
+.. autoclass:: geopy.extra.rate_limiter.AsyncRateLimiter
 
    .. automethod:: __init__
 

--- a/geopy/extra/__init__.py
+++ b/geopy/extra/__init__.py
@@ -1,0 +1,2 @@
+# Extra modules are intentionally not exported here, to avoid
+# them being always imported even when they are not needed.

--- a/geopy/extra/rate_limiter.py
+++ b/geopy/extra/rate_limiter.py
@@ -1,3 +1,56 @@
+""":class:`.RateLimiter` and :class:`.AsyncRateLimiter` allow to perform bulk
+operations while gracefully handling error responses and adding delays
+when needed.
+
+In the example below a delay of 1 second (``min_delay_seconds=1``)
+will be added between each pair of ``geolocator.geocode`` calls; all
+:class:`geopy.exc.GeocoderServiceError` exceptions will be retried
+(up to ``max_retries`` times)::
+
+    import pandas as pd
+    df = pd.DataFrame({'name': ['paris', 'berlin', 'london']})
+
+    from geopy.geocoders import Nominatim
+    geolocator = Nominatim(user_agent="specify_your_app_name_here")
+
+    from geopy.extra.rate_limiter import RateLimiter
+    geocode = RateLimiter(geolocator.geocode, min_delay_seconds=1)
+    df['location'] = df['name'].apply(geocode)
+
+    df['point'] = df['location'].apply(lambda loc: tuple(loc.point) if loc else None)
+
+This would produce the following DataFrame::
+
+    >>> df
+         name                                           location  \\
+    0   paris  (Paris, Île-de-France, France métropolitaine, ...
+    1  berlin  (Berlin, 10117, Deutschland, (52.5170365, 13.3...
+    2  london  (London, Greater London, England, SW1A 2DU, UK...
+
+                               point
+    0   (48.8566101, 2.3514992, 0.0)
+    1  (52.5170365, 13.3888599, 0.0)
+    2  (51.5073219, -0.1276474, 0.0)
+
+To pass extra options to the `geocode` call::
+
+    from functools import partial
+    df['location'] = df['name'].apply(partial(geocode, language='de'))
+
+To see a progress bar::
+
+    from tqdm import tqdm
+    tqdm.pandas()
+    df['location'] = df['name'].progress_apply(geocode)
+
+Before using rate limiting classes, please consult with the Geocoding
+service ToS, which might explicitly consider bulk requests (even throttled)
+a violation.
+"""
+
+import asyncio
+import inspect
+import threading
 from itertools import chain, count
 from time import sleep
 from timeit import default_timer
@@ -5,71 +58,174 @@ from timeit import default_timer
 from geopy.exc import GeocoderServiceError
 from geopy.util import logger
 
+__all__ = ("AsyncRateLimiter", "RateLimiter")
+
 
 def _is_last_gen(count):
     """list(_is_last_gen(2)) -> [False, False, True]"""
     return chain((False for _ in range(count)), [True])
 
 
-class RateLimiter:
-    """RateLimiter allows to perform bulk operations while gracefully
-    handling error responses and adding delays when needed.
+class BaseRateLimiter:
+    """Base Rate Limiter class for both sync and async versions."""
 
-    In the example below a delay of 1 second (``min_delay_seconds=1``)
-    will be added between each pair of ``geolocator.geocode`` calls; all
-    :class:`geopy.exc.GeocoderServiceError` exceptions will be retried
-    (up to ``max_retries`` times)::
+    _retry_exceptions = (GeocoderServiceError,)
 
-        import pandas as pd
-        df = pd.DataFrame({'name': ['paris', 'berlin', 'london']})
+    def __init__(
+        self,
+        *,
+        min_delay_seconds,
+        max_retries,
+        swallow_exceptions,
+        return_value_on_exception
+    ):
+        self.min_delay_seconds = min_delay_seconds
+        self.max_retries = max_retries
+        self.swallow_exceptions = swallow_exceptions
+        self.return_value_on_exception = return_value_on_exception
+        assert max_retries >= 0
 
-        from geopy.geocoders import Nominatim
-        geolocator = Nominatim(user_agent="specify_your_app_name_here")
+        # State:
+        self._lock = threading.Lock()
+        self._last_call = None
+
+    def _clock(self):  # pragma: no cover
+        return default_timer()
+
+    def _acquire_request_slot_gen(self):
+        # Requests rate is limited by `min_delay_seconds` interval.
+        #
+        # Imagine the time axis as a grid with `min_delay_seconds` step,
+        # where we would call each step as a "request slot". RateLimiter
+        # guarantees that each "request slot" contains at most 1 request.
+        #
+        # Note that actual requests might take longer time than
+        # `min_delay_seconds`. In that case you might want to consider
+        # parallelizing requests (with a ThreadPool for sync mode and
+        # asyncio tasks for async), to keep the requests rate closer
+        # to `min_delay_seconds`.
+        #
+        # This generator thread-safely acquires a "request slot", and
+        # if it fails to do that at this time, it yields the amount
+        # of seconds to sleep until the next attempt. The generator
+        # stops only when the "request slot" has been successfully
+        # acquired.
+        #
+        # There's no ordering between the concurrent requests. The first
+        # request to acquire the lock wins the next "request slot".
+        while True:
+            with self._lock:
+                clock = self._clock()
+                if self._last_call is None:
+                    # A first iteration -- start immediately.
+                    self._last_call = clock
+                    return
+                seconds_since_last_call = clock - self._last_call
+                wait = self.min_delay_seconds - seconds_since_last_call
+                if wait <= 0:
+                    # A successfully acquired request slot.
+                    self._last_call = clock
+                    return
+            # Couldn't acquire a request slot. Wait until the beginning
+            # of the next slot to try again.
+            yield wait
+
+    def _retries_gen(self, args, kwargs):
+        for i, is_last_try in zip(count(), _is_last_gen(self.max_retries)):
+            try:
+                yield i  # Run the function.
+            except self._retry_exceptions:
+                if is_last_try:
+                    yield True  # The exception should be raised
+                else:
+                    logger.warning(
+                        type(self).__name__ + " caught an error, retrying "
+                        "(%s/%s tries). Called with (*%r, **%r).",
+                        i,
+                        self.max_retries,
+                        args,
+                        kwargs,
+                        exc_info=True,
+                    )
+                    yield False  # The exception has been swallowed.
+                    continue
+            else:
+                # A successful run -- stop retrying:
+                return  # pragma: no cover
+
+    def _handle_exc(self, args, kwargs):
+        if self.swallow_exceptions:
+            logger.warning(
+                type(self).__name__ + " swallowed an error after %r retries. "
+                "Called with (*%r, **%r).",
+                self.max_retries,
+                args,
+                kwargs,
+                exc_info=True,
+            )
+            return self.return_value_on_exception
+        else:
+            raise
+
+
+class RateLimiter(BaseRateLimiter):
+    """This is a Rate Limiter implementation for synchronous functions
+    (like geocoders with the default :class:`geopy.adapters.BaseSyncAdapter`).
+
+    Examples::
 
         from geopy.extra.rate_limiter import RateLimiter
+        from geopy.geocoders import Nominatim
+
+        geolocator = Nominatim(user_agent="specify_your_app_name_here")
+
+        search = ["moscow", "paris", "berlin", "tokyo", "beijing"]
         geocode = RateLimiter(geolocator.geocode, min_delay_seconds=1)
-        df['location'] = df['name'].apply(geocode)
+        locations = [geocode(s) for s in search]
 
-        df['point'] = df['location'].apply(lambda loc: tuple(loc.point) if loc else None)
+        search = [
+            (55.47, 37.32), (48.85, 2.35), (52.51, 13.38),
+            (34.69, 139.40), (39.90, 116.39)
+        ]
+        reverse = RateLimiter(geolocator.reverse, min_delay_seconds=1)
+        locations = [reverse(s) for s in search]
 
-    This would produce the following DataFrame::
+    RateLimiter class is thread-safe. If geocoding service's responses
+    are slower than `min_delay_seconds`, then you can benefit from
+    parallelizing the work::
 
-        >>> df
-             name                                           location  \\
-        0   paris  (Paris, Île-de-France, France métropolitaine, ...
-        1  berlin  (Berlin, 10117, Deutschland, (52.5170365, 13.3...
-        2  london  (London, Greater London, England, SW1A 2DU, UK...
+        import concurrent.futures
 
-                                   point
-        0   (48.8566101, 2.3514992, 0.0)
-        1  (52.5170365, 13.3888599, 0.0)
-        2  (51.5073219, -0.1276474, 0.0)
+        geolocator = OpenMapQuest(api_key="...")
+        geocode = RateLimiter(geolocator.geocode, min_delay_seconds=1/20)
 
-    To pass extra options to the `geocode` call::
+        with concurrent.futures.ThreadPoolExecutor() as e:
+            locations = list(e.map(geocode, search))
 
-        from functools import partial
-        df['location'] = df['name'].apply(partial(geocode, language='de'))
-
-    To see a progress bar::
-
-        from tqdm import tqdm
-        tqdm.pandas()
-        df['location'] = df['name'].progress_apply(geocode)
-
-    Before using this class, please consult with the Geocoding service
-    ToS, which might explicitly consider bulk requests (even throttled)
-    a violation.
+    .. versionchanged:: 2.0
+       Added thread-safety support.
     """
 
-    def __init__(self, func, min_delay_seconds=0.0, max_retries=2,
-                 error_wait_seconds=5.0,
-                 swallow_exceptions=True, return_value_on_exception=None):
+    def __init__(
+        self,
+        func,
+        *,
+        min_delay_seconds=0.0,
+        max_retries=2,
+        error_wait_seconds=5.0,
+        swallow_exceptions=True,
+        return_value_on_exception=None
+    ):
         """
         :param callable func:
-            A function which should be wrapped by the :class:`.RateLimiter`.
+            A function which should be wrapped by the rate limiter.
 
         :param float min_delay_seconds:
             Minimum delay in seconds between the wrapped ``func`` calls.
+            To convert :abbr:`RPS (Requests Per Second)` rate to
+            ``min_delay_seconds`` you need to divide 1 by RPS. For example,
+            if you need to keep the rate at 20 RPS, you can use
+            ``min_delay_seconds=1/20``.
 
         :param int max_retries:
             Number of retries on exceptions. Only
@@ -91,54 +247,158 @@ class RateLimiter:
             Value to return on failure when ``swallow_exceptions=True``.
 
         """
+        super().__init__(
+            min_delay_seconds=min_delay_seconds,
+            max_retries=max_retries,
+            swallow_exceptions=swallow_exceptions,
+            return_value_on_exception=return_value_on_exception,
+        )
         self.func = func
-        self.min_delay_seconds = min_delay_seconds
-        self.max_retries = max_retries
         self.error_wait_seconds = error_wait_seconds
-        self.swallow_exceptions = swallow_exceptions
-        self.return_value_on_exception = return_value_on_exception
         assert error_wait_seconds >= min_delay_seconds
         assert max_retries >= 0
 
-        self._last_call = self._clock() - min_delay_seconds
-
-    def _clock(self):  # pragma: no coverage
-        return default_timer()
-
-    def _sleep(self, seconds):  # pragma: no coverage
-        logger.debug('RateLimiter sleep(%r)', seconds)
+    def _sleep(self, seconds):  # pragma: no cover
+        logger.debug(type(self).__name__ + " sleep(%r)", seconds)
         sleep(seconds)
 
-    def _sleep_between(self):
-        seconds_since_last_call = self._clock() - self._last_call
-        wait = self.min_delay_seconds - seconds_since_last_call
-        if wait > 0:
+    def _acquire_request_slot(self):
+        for wait in self._acquire_request_slot_gen():
             self._sleep(wait)
 
     def __call__(self, *args, **kwargs):
-        self._sleep_between()
-
-        for i, is_last_try in zip(count(), _is_last_gen(self.max_retries)):
+        gen = self._retries_gen(args, kwargs)
+        for _ in gen:
+            self._acquire_request_slot()
             try:
-                return self.func(*args, **kwargs)
-            except GeocoderServiceError:
-                if not is_last_try:
-                    logger.warning(
-                        'RateLimiter caught an error, retrying '
-                        '(%s/%s tries). Called with (*%r, **%r).',
-                        i, self.max_retries, args, kwargs, exc_info=True
+                res = self.func(*args, **kwargs)
+                if inspect.isawaitable(res):
+                    raise ValueError(
+                        "An async awaitable has been passed to `RateLimiter`. "
+                        "Use `AsyncRateLimiter` instead, which supports awaitables."
                     )
-                    self._sleep(self.error_wait_seconds)
-                    continue
+                return res
+            except self._retry_exceptions as e:
+                if gen.throw(e):
+                    # A final try
+                    return self._handle_exc(args, kwargs)
+                self._sleep(self.error_wait_seconds)
 
-                if self.swallow_exceptions:
-                    logger.warning(
-                        'RateLimiter swallowed an error after %r retries. '
-                        'Called with (*%r, **%r).',
-                        i, args, kwargs, exc_info=True
-                    )
-                    return self.return_value_on_exception
-                else:
-                    raise
-            finally:
-                self._last_call = self._clock()
+        raise RuntimeError("Should not have been reached")  # pragma: no cover
+
+
+class AsyncRateLimiter(BaseRateLimiter):
+    """This is a Rate Limiter implementation for asynchronous functions
+    (like geocoders with :class:`geopy.adapters.BaseAsyncAdapter`).
+
+    Examples::
+
+        from geopy.adapters import AioHTTPAdapter
+        from geopy.extra.rate_limiter import AsyncRateLimiter
+        from geopy.geocoders import Nominatim
+
+        async with Nominatim(
+            user_agent="specify_your_app_name_here",
+            adapter_factory=AioHTTPAdapter,
+        ) as geolocator:
+
+            search = ["moscow", "paris", "berlin", "tokyo", "beijing"]
+            geocode = AsyncRateLimiter(geolocator.geocode, min_delay_seconds=1)
+            locations = [await geocode(s) for s in search]
+
+            search = [
+                (55.47, 37.32), (48.85, 2.35), (52.51, 13.38),
+                (34.69, 139.40), (39.90, 116.39)
+            ]
+            reverse = AsyncRateLimiter(geolocator.reverse, min_delay_seconds=1)
+            locations = [await reverse(s) for s in search]
+
+    AsyncRateLimiter class is safe to use across multiple concurrent tasks.
+    If geocoding service's responses are slower than `min_delay_seconds`,
+    then you can benefit from parallelizing the work::
+
+        import asyncio
+
+        async with OpenMapQuest(
+            api_key="...", adapter_factory=AioHTTPAdapter
+        ) as geolocator:
+
+            geocode = AsyncRateLimiter(geolocator.geocode, min_delay_seconds=1/20)
+            locations = await asyncio.gather(*(geocode(s) for s in search))
+
+    .. versionadded:: 2.0
+    """
+
+    def __init__(
+        self,
+        func,
+        *,
+        min_delay_seconds=0.0,
+        max_retries=2,
+        error_wait_seconds=5.0,
+        swallow_exceptions=True,
+        return_value_on_exception=None
+    ):
+        """
+        :param callable func:
+            A function which should be wrapped by the rate limiter.
+
+        :param float min_delay_seconds:
+            Minimum delay in seconds between the wrapped ``func`` calls.
+            To convert :abbr:`RPS (Requests Per Second)` rate to
+            ``min_delay_seconds`` you need to divide 1 by RPS. For example,
+            if you need to keep the rate at 20 RPS, you can use
+            ``min_delay_seconds=1/20``.
+
+        :param int max_retries:
+            Number of retries on exceptions. Only
+            :class:`geopy.exc.GeocoderServiceError` exceptions are
+            retried -- others are always re-raised. ``max_retries + 1``
+            requests would be performed at max per query. Set
+            ``max_retries=0`` to disable retries.
+
+        :param float error_wait_seconds:
+            Time to wait between retries after errors. Must be
+            greater or equal to ``min_delay_seconds``.
+
+        :param bool swallow_exceptions:
+            Should an exception be swallowed after retries? If not,
+            it will be re-raised. If yes, the ``return_value_on_exception``
+            will be returned.
+
+        :param return_value_on_exception:
+            Value to return on failure when ``swallow_exceptions=True``.
+
+        """
+        super().__init__(
+            min_delay_seconds=min_delay_seconds,
+            max_retries=max_retries,
+            swallow_exceptions=swallow_exceptions,
+            return_value_on_exception=return_value_on_exception,
+        )
+        self.func = func
+        self.error_wait_seconds = error_wait_seconds
+        assert error_wait_seconds >= min_delay_seconds
+        assert max_retries >= 0
+
+    async def _sleep(self, seconds):  # pragma: no cover
+        logger.debug(type(self).__name__ + " sleep(%r)", seconds)
+        await asyncio.sleep(seconds)
+
+    async def _acquire_request_slot(self):
+        for wait in self._acquire_request_slot_gen():
+            await self._sleep(wait)
+
+    async def __call__(self, *args, **kwargs):
+        gen = self._retries_gen(args, kwargs)
+        for _ in gen:
+            await self._acquire_request_slot()
+            try:
+                return await self.func(*args, **kwargs)
+            except self._retry_exceptions as e:
+                if gen.throw(e):
+                    # A final try
+                    return self._handle_exc(args, kwargs)
+                await self._sleep(self.error_wait_seconds)
+
+        raise RuntimeError("Should not have been reached")  # pragma: no cover

--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -124,13 +124,13 @@ implementations for many different services in a single package.
 Therefore:
 
 1. Different services have different Terms of Use, quotas, pricing,
-   geodatabases and so on. For example, :class:`geopy.geocoders.Nominatim`
+   geodatabases and so on. For example, :class:`.Nominatim`
    is free, but provides low request limits. If you need to make more queries,
    consider using another (probably paid) service, such as
-   :class:`geopy.geocoders.OpenMapQuest` or :class:`geopy.geocoders.PickPoint`
+   :class:`.OpenMapQuest` or :class:`.PickPoint`
    (these two are commercial providers of Nominatim, so they should
    have the same data and APIs). Or, if you are ready to wait, you can try
-   :class:`geopy.extra.rate_limiter.RateLimiter`.
+   :mod:`geopy.extra.rate_limiter`.
 
 2. geopy cannot be responsible for the geocoding services' databases.
    If you have issues with some queries which the service cannot fulfill,

--- a/test/extra/rate_limiter.py
+++ b/test/extra/rate_limiter.py
@@ -1,99 +1,167 @@
+import warnings
 from unittest.mock import MagicMock, patch, sentinel
 
 import pytest
 
 from geopy.exc import GeocoderQuotaExceeded, GeocoderServiceError
-from geopy.extra.rate_limiter import RateLimiter
+from geopy.extra.rate_limiter import AsyncRateLimiter, RateLimiter
+
+
+@pytest.fixture(params=[False, True])
+def is_async(request):
+    return request.param
 
 
 @pytest.fixture
-def mock_clock():
-    with patch.object(RateLimiter, '_clock') as mock_clock:
+def auto_async(is_async):
+    if is_async:
+        async def auto_async(coro):
+            return await coro
+    else:
+        async def auto_async(result):
+            return result
+    return auto_async
+
+
+@pytest.fixture
+def auto_async_side_effect(is_async):
+    def auto_async_side_effect(side_effect):
+        if not is_async:
+            return side_effect
+
+        mock = MagicMock(side_effect=side_effect)
+
+        async def func(*args, **kwargs):
+            return mock(*args, **kwargs)
+
+        return func
+
+    return auto_async_side_effect
+
+
+@pytest.fixture
+def rate_limiter_cls(is_async):
+    if is_async:
+        return AsyncRateLimiter
+    else:
+        return RateLimiter
+
+
+@pytest.fixture
+def mock_clock(rate_limiter_cls):
+    with patch.object(rate_limiter_cls, '_clock') as mock_clock:
         yield mock_clock
 
 
 @pytest.fixture
-def mock_sleep():
-    with patch.object(RateLimiter, '_sleep') as mock_sleep:
+def mock_sleep(auto_async_side_effect, rate_limiter_cls):
+    with patch.object(rate_limiter_cls, '_sleep') as mock_sleep:
+        mock_sleep.side_effect = auto_async_side_effect(None)
         yield mock_sleep
 
 
-def test_min_delay(mock_clock, mock_sleep):
-    min_delay = 3.5
+async def test_min_delay(
+    rate_limiter_cls, mock_clock, mock_sleep, auto_async_side_effect, auto_async
+):
     mock_func = MagicMock()
+    mock_func.side_effect = auto_async_side_effect(None)
+    min_delay = 3.5
 
     mock_clock.side_effect = [1]
-    rl = RateLimiter(mock_func, min_delay_seconds=min_delay)
+    rl = rate_limiter_cls(mock_func, min_delay_seconds=min_delay)
 
     # First call -- no delay
     clock_first = 10
     mock_clock.side_effect = [clock_first, clock_first]  # no delay here
-    rl(sentinel.arg, kwa=sentinel.kwa)
+    await auto_async(rl(sentinel.arg, kwa=sentinel.kwa))
     mock_sleep.assert_not_called()
     mock_func.assert_called_once_with(sentinel.arg, kwa=sentinel.kwa)
 
     # Second call after min_delay/3 seconds -- should be delayed
     clock_second = clock_first + (min_delay / 3)
     mock_clock.side_effect = [clock_second, clock_first + min_delay]
-    rl(sentinel.arg, kwa=sentinel.kwa)
+    await auto_async(rl(sentinel.arg, kwa=sentinel.kwa))
     mock_sleep.assert_called_with(min_delay - (clock_second - clock_first))
     mock_sleep.reset_mock()
 
     # Third call after min_delay*2 seconds -- no delay again
     clock_third = clock_first + min_delay + min_delay * 2
     mock_clock.side_effect = [clock_third, clock_third]
-    rl(sentinel.arg, kwa=sentinel.kwa)
+    await auto_async(rl(sentinel.arg, kwa=sentinel.kwa))
     mock_sleep.assert_not_called()
 
 
-def test_max_retries(mock_clock, mock_sleep):
+async def test_max_retries(
+    rate_limiter_cls, mock_clock, mock_sleep, auto_async_side_effect, auto_async
+):
     mock_func = MagicMock()
     mock_clock.return_value = 1
-    rl = RateLimiter(mock_func, max_retries=3,
-                     return_value_on_exception=sentinel.return_value)
+    rl = rate_limiter_cls(
+        mock_func, max_retries=3,
+        return_value_on_exception=sentinel.return_value,
+    )
 
     # Non-geopy errors must not be swallowed
-    mock_func.side_effect = ValueError
+    mock_func.side_effect = auto_async_side_effect(ValueError)
     with pytest.raises(ValueError):
-        rl(sentinel.arg)
+        await auto_async(rl(sentinel.arg))
     assert 1 == mock_func.call_count
     mock_func.reset_mock()
 
     # geopy errors must be swallowed and retried
-    mock_func.side_effect = GeocoderServiceError
-    assert sentinel.return_value == rl(sentinel.arg)
+    mock_func.side_effect = auto_async_side_effect(GeocoderServiceError)
+    assert sentinel.return_value == await auto_async(rl(sentinel.arg))
     assert 4 == mock_func.call_count
     mock_func.reset_mock()
 
     # Successful value must be returned
-    mock_func.side_effect = [
+    mock_func.side_effect = auto_async_side_effect(side_effect=[
         GeocoderServiceError, GeocoderServiceError, sentinel.good
-    ]
-    assert sentinel.good == rl(sentinel.arg)
+    ])
+    assert sentinel.good == await auto_async(rl(sentinel.arg))
     assert 3 == mock_func.call_count
     mock_func.reset_mock()
 
     # When swallowing is disabled, the exception must be raised
     rl.swallow_exceptions = False
-    mock_func.side_effect = GeocoderQuotaExceeded
+    mock_func.side_effect = auto_async_side_effect(GeocoderQuotaExceeded)
     with pytest.raises(GeocoderQuotaExceeded):
-        rl(sentinel.arg)
+        await auto_async(rl(sentinel.arg))
     assert 4 == mock_func.call_count
     mock_func.reset_mock()
 
 
-def test_error_wait_seconds(mock_clock, mock_sleep):
+async def test_error_wait_seconds(
+    rate_limiter_cls, mock_clock, mock_sleep, auto_async_side_effect, auto_async
+):
     mock_func = MagicMock()
     error_wait = 3.3
 
     mock_clock.return_value = 1
-    rl = RateLimiter(mock_func, max_retries=3,
-                     error_wait_seconds=error_wait,
-                     return_value_on_exception=sentinel.return_value)
+    rl = rate_limiter_cls(
+        mock_func, max_retries=3,
+        error_wait_seconds=error_wait,
+        return_value_on_exception=sentinel.return_value,
+    )
 
-    mock_func.side_effect = GeocoderServiceError
-    assert sentinel.return_value == rl(sentinel.arg)
+    mock_func.side_effect = auto_async_side_effect(GeocoderServiceError)
+    assert sentinel.return_value == await auto_async(rl(sentinel.arg))
     assert 4 == mock_func.call_count
     assert 3 == mock_sleep.call_count
     mock_sleep.assert_called_with(error_wait)
     mock_func.reset_mock()
+
+
+async def test_sync_raises_for_awaitable():
+    def g():  # non-async function returning an awaitable -- like `geocode`.
+        async def coro():
+            pass  # pragma: no cover
+        return coro()
+
+    rl = RateLimiter(g)
+
+    # silence `coroutine 'coro' was never awaited`:
+    with warnings.catch_warnings(record=True):
+
+        with pytest.raises(ValueError):
+            await rl()


### PR DESCRIPTION
(This PR contains a subset of commits from #335).

RateLimiter wouldn't work with async adapters, so this PR adds an AsyncRateLimiter. Interface is the same, except that it works with awaitables.

Also RateLimiter has been made thread-safe.