### PR TITLE
remove unneded 'or None' that caused crashes

### DIFF
--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -218,8 +218,8 @@ class Photon(Geocoder):
                 in name_elements if resource['properties'].get(k)]
         location = ', '.join(name)
 
-        latitude = resource['geometry']['coordinates'][1] or None
-        longitude = resource['geometry']['coordinates'][0] or None
+        latitude = resource['geometry']['coordinates'][1]
+        longitude = resource['geometry']['coordinates'][0]
         if latitude and longitude:
             latitude = float(latitude)
             longitude = float(longitude)


### PR DESCRIPTION
I am a bit worried as I am unsure why this part of code was added
but this change is not causing any tests to fail and it fixes #436

this part of code was already in initial commit adding support to Photon,
so maybe it was simply a mistake (it was not added as an explicit workaround or fix)