### PR TITLE
OpenCage provider: use no_annotations=1 as returned data is not used

### DIFF
--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -123,6 +123,7 @@ class OpenCage(Geocoder):
         params = {
             'key': self.api_key,
             'q': query,
+            'no_annotations': 1,
         }
         if bounds:
             params['bounds'] = self._format_bounding_box(


### PR DESCRIPTION
OpenCage results include https://opencagedata.com/api#annotations data by default. As this data isn't put into the Location response object it can be skipped in the request.