### PR TITLE
Add geocoder signature tests

### DIFF
--- a/geopy/geocoders/banfrance.py
+++ b/geopy/geocoders/banfrance.py
@@ -91,13 +91,13 @@ class BANFrance(Geocoder):
             results the BAN API will return 5 results by default.
             This will be reset to one if ``exactly_one`` is True.
 
+        :param bool exactly_one: Return one result or a list of results, if
+            available.
+
         :param int timeout: Time, in seconds, to wait for the geocoding service
             to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
-
-        :param bool exactly_one: Return one result or a list of results, if
-            available.
 
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -274,7 +274,7 @@ class GeoNames(Geocoder):
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
 
-        :rtype: :class:`geopy.timezone.Timezone`
+        :rtype: :class:`geopy.timezone.Timezone`.
         """
         ensure_pytz_is_installed()
 

--- a/geopy/geocoders/googlev3.py
+++ b/geopy/geocoders/googlev3.py
@@ -343,7 +343,7 @@ class GoogleV3(Geocoder):
             exception. Set this only if you wish to override, on this call
             only, the value set during the geocoder's initialization.
 
-        :rtype: ``None`` or :class:`geopy.timezone.Timezone`
+        :rtype: ``None`` or :class:`geopy.timezone.Timezone`.
         """
         ensure_pytz_is_installed()
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ EXTRAS_DEV_TEST = [
     "coverage",
     "pytest-aiohttp",  # for `async def` tests
     "pytest>=3.10",
+    "sphinx",  # `docutils` from sphinx is used in tests
 ]
 
 EXTRAS_DEV_DOCS = [
@@ -58,10 +59,12 @@ setup(
     packages=find_packages(exclude=["*test*"]),
     install_requires=INSTALL_REQUIRES,
     extras_require={
-        "dev": (EXTRAS_DEV_TESTFILES_COMMON +
-                EXTRAS_DEV_LINT +
-                EXTRAS_DEV_TEST +
-                EXTRAS_DEV_DOCS),
+        "dev": sorted(set(
+            EXTRAS_DEV_TESTFILES_COMMON +
+            EXTRAS_DEV_LINT +
+            EXTRAS_DEV_TEST +
+            EXTRAS_DEV_DOCS
+        )),
         "dev-lint": (EXTRAS_DEV_TESTFILES_COMMON +
                      EXTRAS_DEV_LINT),
         "dev-test": (EXTRAS_DEV_TESTFILES_COMMON +

--- a/test/geocoders/__init__.py
+++ b/test/geocoders/__init__.py
@@ -1,0 +1,217 @@
+import importlib
+import inspect
+import pkgutil
+
+import pytest
+
+import geopy.geocoders
+from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
+
+skip_modules = [
+    "geopy.geocoders.base",  # doesn't contain actual geocoders
+    "geopy.geocoders.osm",  # deprecated
+]
+
+geocoder_modules = sorted(
+    [
+        importlib.import_module(name)
+        for _, name, _ in pkgutil.iter_modules(
+            geopy.geocoders.__path__, "geopy.geocoders."
+        )
+        if name not in skip_modules
+    ],
+    key=lambda m: m.__name__,
+)
+
+geocoder_classes = sorted(
+    {
+        v
+        for v in (
+            getattr(module, name) for module in geocoder_modules for name in dir(module)
+        )
+        if inspect.isclass(v) and issubclass(v, Geocoder) and v is not Geocoder
+    },
+    key=lambda cls: cls.__name__,
+)
+
+
+def assert_no_varargs(sig):
+    assert not [
+        str(p)
+        for p in sig.parameters.values()
+        if p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    ], (
+        "Geocoders must not have any (*args) or (**kwargs). "
+        "See CONTRIBUTING.md for explanation."
+    )
+
+
+def test_all_geocoders_are_exported_from_package():
+    expected = {cls.__name__ for cls in geocoder_classes}
+    actual = set(dir(geopy.geocoders))
+    not_exported = expected - actual
+    assert not not_exported, (
+        "These geocoders must be exported (via imports) "
+        "in geopy/geocoders/__init__.py"
+    )
+
+
+def test_all_geocoders_are_listed_in_all():
+    expected = {cls.__name__ for cls in geocoder_classes}
+    actual = set(geopy.geocoders.__all__)
+    not_exported = expected - actual
+    assert not not_exported, (
+        "These geocoders must be listed in the `__all__` tuple "
+        "in geopy/geocoders/__init__.py"
+    )
+
+
+def test_all_geocoders_are_listed_in_service_to_geocoder():
+    assert set(geocoder_classes) == set(geopy.geocoders.SERVICE_TO_GEOCODER.values()), (
+        "All geocoders must be listed in the `SERVICE_TO_GEOCODER` dict "
+        "in geopy/geocoders/__init__.py"
+    )
+
+
+@pytest.mark.parametrize("geocoder_module", geocoder_modules, ids=lambda m: m.__name__)
+def test_geocoder_module_all(geocoder_module):
+    current_all = geocoder_module.__all__
+    expected_all = tuple(
+        cls.__name__
+        for cls in geocoder_classes
+        if cls.__module__ == geocoder_module.__name__
+    )
+    assert expected_all == current_all
+
+
+@pytest.mark.parametrize("geocoder_cls", geocoder_classes)
+def test_init_method_signature(geocoder_cls):
+    method = geocoder_cls.__init__
+    sig = inspect.signature(method)
+
+    assert_no_varargs(sig)
+
+    sig_timeout = sig.parameters["timeout"]
+    assert sig_timeout.kind == inspect.Parameter.KEYWORD_ONLY
+    assert sig_timeout.default is DEFAULT_SENTINEL
+
+    sig_proxies = sig.parameters["proxies"]
+    assert sig_proxies.kind == inspect.Parameter.KEYWORD_ONLY
+    assert sig_proxies.default is DEFAULT_SENTINEL
+
+    sig_user_agent = sig.parameters["user_agent"]
+    assert sig_user_agent.kind == inspect.Parameter.KEYWORD_ONLY
+    assert sig_user_agent.default is None
+
+    sig_ssl_context = sig.parameters["ssl_context"]
+    assert sig_ssl_context.kind == inspect.Parameter.KEYWORD_ONLY
+    assert sig_ssl_context.default is DEFAULT_SENTINEL
+
+    sig_adapter_factory = sig.parameters["adapter_factory"]
+    assert sig_adapter_factory.kind == inspect.Parameter.KEYWORD_ONLY
+    assert sig_adapter_factory.default is None
+
+
+@pytest.mark.parametrize("geocoder_cls", geocoder_classes)
+def test_geocode_method_signature(geocoder_cls):
+    # Every geocoder should have at least a `geocode` method.
+    method = geocoder_cls.geocode
+    sig = inspect.signature(method)
+
+    assert_no_varargs(sig)
+
+    # The first arg (except self) must be called `query`:
+    sig_query = list(sig.parameters.values())[1]
+    assert sig_query.name == "query"
+    assert sig_query.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+    # The rest must be kwargs-only:
+    sig_kwargs = list(sig.parameters.values())[2:]
+    assert all(p.kind == inspect.Parameter.KEYWORD_ONLY for p in sig_kwargs), (
+        "All method args except `query` must be keyword-only "
+        "(i.e. separated with an `*`)."
+    )
+
+    # kwargs must contain `exactly_one`:
+    sig_exactly_one = sig.parameters["exactly_one"]
+    assert sig_exactly_one.default is True, "`exactly_one` must be True"
+
+    # kwargs must contain `timeout`:
+    sig_timeout = sig.parameters["timeout"]
+    assert sig_timeout.default is DEFAULT_SENTINEL, "`timeout` must be DEFAULT_SENTINEL"
+
+
+@pytest.mark.parametrize(
+    "geocoder_cls",
+    [cls for cls in geocoder_classes if getattr(cls, "reverse", None)],
+)
+def test_reverse_method_signature(geocoder_cls):
+    # `reverse` method is optional.
+    method = geocoder_cls.reverse
+    sig = inspect.signature(method)
+
+    assert_no_varargs(sig)
+
+    # First arg (except self) must be called `query`:
+    sig_query = list(sig.parameters.values())[1]
+    assert sig_query.name == "query"
+    assert sig_query.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+    # The rest must be kwargs-only:
+    sig_kwargs = list(sig.parameters.values())[2:]
+    assert all(p.kind == inspect.Parameter.KEYWORD_ONLY for p in sig_kwargs), (
+        "All method args except `query` must be keyword-only "
+        "(i.e. separated with an `*`)."
+    )
+
+    # kwargs must contain `exactly_one`:
+    sig_exactly_one = sig.parameters["exactly_one"]
+    assert sig_exactly_one.default is True, "`exactly_one` must be True"
+
+    # kwargs must contain `timeout`:
+    sig_timeout = sig.parameters["timeout"]
+    assert sig_timeout.default is DEFAULT_SENTINEL, "`timeout` must be DEFAULT_SENTINEL"
+
+
+@pytest.mark.parametrize(
+    "geocoder_cls",
+    [cls for cls in geocoder_classes if getattr(cls, "reverse_timezone", None)],
+)
+def test_reverse_timezone_method_signature(geocoder_cls):
+    method = geocoder_cls.reverse_timezone
+    sig = inspect.signature(method)
+
+    assert_no_varargs(sig)
+
+    # First arg (except self) must be called `query`:
+    sig_query = list(sig.parameters.values())[1]
+    assert sig_query.name == "query"
+    assert sig_query.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+    # The rest must be kwargs-only:
+    sig_kwargs = list(sig.parameters.values())[2:]
+    assert all(p.kind == inspect.Parameter.KEYWORD_ONLY for p in sig_kwargs), (
+        "All method args except `query` must be keyword-only "
+        "(i.e. separated with an `*`)."
+    )
+
+    # kwargs must contain `timeout`:
+    sig_timeout = sig.parameters["timeout"]
+    assert sig_timeout.default is DEFAULT_SENTINEL, "`timeout` must be DEFAULT_SENTINEL"
+
+
+@pytest.mark.parametrize("geocoder_cls", geocoder_classes)
+def test_no_extra_public_methods(geocoder_cls):
+    methods = {
+        n
+        for n in dir(geocoder_cls)
+        if not n.startswith("_") and inspect.isfunction(getattr(geocoder_cls, n))
+    }
+    allowed = {
+        "geocode",
+        "reverse",
+        "reverse_timezone",
+    }
+    assert methods <= allowed, (
+        "Geopy geocoders are currently allowed to only have these methods: %s" % allowed
+    )

--- a/test/geocoders/algolia.py
+++ b/test/geocoders/algolia.py
@@ -60,7 +60,7 @@ class TestAlgoliaPlaces(BaseTestGeocoder):
         assert "Madrid" in location.address
 
     async def test_countries_no_result(self):
-        countries = ["NO", "IT"]
+        countries = ["UA", "RU"]
         await self.geocode_run(
             {'query': 'Madrid', 'language': 'en',
              'countries': countries},

--- a/test/geocoders/algolia.py
+++ b/test/geocoders/algolia.py
@@ -33,14 +33,6 @@ class TestAlgoliaPlaces(BaseTestGeocoder):
         )
         assert 'A272' in location.address
 
-    async def test_reverse_no_result(self):
-        await self.reverse_run(
-            # North Atlantic Ocean
-            {'query': (35.173809, -37.485351)},
-            {},
-            expect_failure=True
-        )
-
     async def test_explicit_type(self):
         location = await self.geocode_run(
             {'query': 'Madrid', 'type': 'city', 'language': 'en'},

--- a/test/geocoders/mapquest.py
+++ b/test/geocoders/mapquest.py
@@ -35,13 +35,6 @@ class TestMapQuest(BaseTestGeocoder):
             expect_failure=True,
         )
 
-    async def test_geocode_empty(self):
-        await self.geocode_run(
-            {'query': 'sldkfhdskjfhsdkhgflaskjgf'},
-            {},
-            expect_failure=True,
-        )
-
     async def test_geocode_bbox(self):
         await self.geocode_run(
             {

--- a/test/geocoders/util.py
+++ b/test/geocoders/util.py
@@ -109,10 +109,11 @@ class BaseTestGeocoder(ABC):
             skiptest_on_errors=skiptest_on_errors,
             **payload,
         )
+        if expect_failure:
+            assert result is None
+            return
         if result is None:
-            if expect_failure:
-                return
-            elif skiptest_on_failure:
+            if skiptest_on_failure:
                 pytest.skip('%s: Skipping test due to empty result' % cls.__name__)
             else:
                 pytest.fail('%s: No result found' % cls.__name__)
@@ -138,10 +139,11 @@ class BaseTestGeocoder(ABC):
             skiptest_on_errors=skiptest_on_errors,
             **payload,
         )
+        if expect_failure:
+            assert result is None
+            return
         if result is None:
-            if expect_failure:
-                return
-            elif skiptest_on_failure:
+            if skiptest_on_failure:
                 pytest.skip('%s: Skipping test due to empty result' % cls.__name__)
             else:
                 pytest.fail('%s: No result found' % cls.__name__)


### PR DESCRIPTION
Add new geocoders tests for checking that:
- All geocoders are exported and have expected `__all__` values.
- All required params in `__init__`, `geocode`/`reverse`/`reverse_timezone` methods are present in the signatures and have expected defaults.
- All params are documented with `:param ...:` directives.
- No unexpected public methods are introduced.

This should highlight interface errors early before a PR review when a new geocoder class is introduced.