### PR TITLE
Implement basic geocode functionality for Amazon Location Services.

### DIFF
--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -187,6 +187,7 @@ __all__ = (
     # Also don't forget to pull up the list of geocoders
     # in the docs: docs/index.rst
     "AlgoliaPlaces",
+    "AmazonLocationServices",
     "ArcGIS",
     "AzureMaps",
     "Baidu",
@@ -221,6 +222,7 @@ __all__ = (
 
 from geopy.exc import GeocoderNotFound
 from geopy.geocoders.algolia import AlgoliaPlaces
+from geopy.geocoders.amazonlocationservices import AmazonLocationServices
 from geopy.geocoders.arcgis import ArcGIS
 from geopy.geocoders.azure import AzureMaps
 from geopy.geocoders.baidu import Baidu, BaiduV3
@@ -251,6 +253,7 @@ from geopy.geocoders.yandex import Yandex
 
 SERVICE_TO_GEOCODER = {
     "algolia": AlgoliaPlaces,
+    "amazonlocationservices": AmazonLocationServices,
     "arcgis": ArcGIS,
     "azure": AzureMaps,
     "baidu": Baidu,
@@ -318,6 +321,6 @@ def get_geocoder_for_service(service):
         return SERVICE_TO_GEOCODER[service.lower()]
     except KeyError:
         raise GeocoderNotFound(
-            "Unknown geocoder '%s'; options are: %s" %
-            (service, SERVICE_TO_GEOCODER.keys())
+            "Unknown geocoder '%s'; options are: %s"
+            % (service, SERVICE_TO_GEOCODER.keys())
         )

--- a/geopy/geocoders/amazonlocationservices.py
+++ b/geopy/geocoders/amazonlocationservices.py
@@ -1,0 +1,154 @@
+import importlib
+from copy import copy
+
+from geopy.exc import GeocoderTimedOut
+from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
+from geopy.location import Location
+
+__all__ = ("AmazonLocationServices",)
+
+
+class AmazonLocationServices(Geocoder):
+    """Amazon Location Services geocoder.
+
+    Documentation at:
+        https://docs.aws.amazon.com/location-places/latest/APIReference/Welcome.html
+    """
+
+    def __init__(
+        self,
+        *,
+        retries=0,
+        scheme=None,
+        timeout=DEFAULT_SENTINEL,
+        proxies=DEFAULT_SENTINEL,
+        user_agent=None,
+        ssl_context=DEFAULT_SENTINEL,
+        adapter_factory=None,
+    ):
+        """
+        :param ing retries: Number of times to retry a request.
+        :param str scheme:
+            See :attr:`geopy.geocoders.options.default_scheme`.
+        :param int timeout:
+            See :attr:`geopy.geocoders.options.default_timeout`.
+        :param dict proxies:
+            See :attr:`geopy.geocoders.options.default_proxies`.
+        :param str user_agent:
+            See :attr:`geopy.geocoders.options.default_user_agent`.
+        :type ssl_context: :class:`ssl.SSLContext`
+        :param ssl_context:
+            See :attr:`geopy.geocoders.options.default_ssl_context`.
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+            .. versionadded:: 2.0
+        """
+        self._boto3 = importlib.import_module("boto3")
+        self._Config = importlib.import_module("botocore.config").Config
+        self._ReadTimeoutError = importlib.import_module(
+            "botocore.exceptions"
+        ).ReadTimeoutError
+
+        super().__init__(
+            scheme=scheme,
+            timeout=timeout,
+            proxies=proxies,
+            user_agent=user_agent,
+            ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
+        )
+
+        self._config = self._Config(
+            retries={"total_max_attempts": retries + 1, "mode": "standard"},
+        )
+        if timeout is not DEFAULT_SENTINEL:
+            self._config.read_timeout = timeout
+
+        self.client = self._boto3.client(
+            "location",
+            config=self._config,
+        )
+
+    def geocode(
+        self,
+        query,
+        *,
+        index_name,
+        filter_countries=None,
+        exactly_one=True,
+        max_results=50,
+        timeout=DEFAULT_SENTINEL,
+    ):
+        """
+        Return a location point by address.
+
+        :param str query: The address or query you wish to geocode.
+        :param str index_name: The name of the PlaceIndex to query (created in
+            Amazon Location Services).
+        :param str filter_countries: Bias results to this country (ISO alpha-3).
+        :param bool exactly_one: Return one result or a list of results, if
+            available.
+        :param int max_results: Limit the number of results returned, only applies
+            if :paramref:`exactly_one` is ``False``.
+        :param int timeout: Time, in seconds, to wait for the geocoding service
+            to respond before raising a :class:`geopy.exc.GeocoderTimedOut`
+            exception. Set this only if you wish to override, on this call
+            only, the value set during the geocoder's initialization. NB: This
+            will create a new client with the timeout config.
+        :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
+            ``exactly_one=False``.
+        """
+
+        # Create a new client for this request only, it will be thrown away at
+        # the end.
+        if not (timeout is DEFAULT_SENTINEL):
+            config = copy(self._config)
+            config.read_timeout = timeout
+            req_client = self._boto3.client("location", config=config)
+        # Otherwise use the initialised client.
+        else:
+            req_client = self.client
+
+        params = {
+            "Text": query,
+            "IndexName": index_name,
+            "MaxResults": max_results,
+        }
+
+        if filter_countries:
+            params["FilterCountries"] = filter_countries
+
+        try:
+            response = req_client.search_place_index_for_text(**params)
+        except self._ReadTimeoutError as exc:
+            raise GeocoderTimedOut(
+                "Geocoder timed out waiting for a response, try increasing the "
+                "timeout value."
+            ) from exc
+
+        return self._parse_json(response=response, exactly_one=exactly_one)
+
+    def _parse_code(self, result):
+        place = result.get("Place", {})
+        geometry = place.get("Geometry", {})
+        point = geometry.get("Point", [])
+
+        if len(point) != 2:
+            raise AssertionError("Point is empty, or it is a WGS84 point (1 number).")
+
+        latitude = point[1]
+        longitude = point[0]
+        placename = place.get("Label")
+
+        return Location(placename, (latitude, longitude), result)
+
+    def _parse_json(self, response, exactly_one):
+        if response is None:
+            return None
+        results = response["Results"]
+        if not len(results):
+            return None
+        if exactly_one:
+            return self._parse_code(results[0])
+        else:
+            return [self._parse_code(result) for result in results]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.version_info < (3, 5):
 from geopy import __version__ as version  # noqa  # isort:skip
 
 INSTALL_REQUIRES = [
-    'geographiclib<2,>=1.49',
+    "geographiclib<2,>=1.49",
 ]
 
 EXTRAS_DEV_TESTFILES_COMMON = [
@@ -45,30 +45,34 @@ EXTRAS_DEV_DOCS = [
     "sphinx_rtd_theme>=0.5.0",
 ]
 
+EXTRAS_FEATURE_AWS = [
+    "boto3>=1.18.42",
+]
+
 setup(
-    name='geopy',
+    name="geopy",
     version=version,
-    description='Python Geocoding Toolbox',
-    long_description=open('README.rst').read(),
-    maintainer='Kostya Esmukov',
-    maintainer_email='kostya@esmukov.ru',
-    url='https://github.com/geopy/geopy',
-    download_url=(
-        'https://github.com/geopy/geopy/archive/%s.tar.gz' % version
-    ),
+    description="Python Geocoding Toolbox",
+    long_description=open("README.rst").read(),
+    maintainer="Kostya Esmukov",
+    maintainer_email="kostya@esmukov.ru",
+    url="https://github.com/geopy/geopy",
+    download_url=("https://github.com/geopy/geopy/archive/%s.tar.gz" % version),
     packages=find_packages(exclude=["*test*"]),
     install_requires=INSTALL_REQUIRES,
     extras_require={
-        "dev": sorted(set(
-            EXTRAS_DEV_TESTFILES_COMMON +
-            EXTRAS_DEV_LINT +
-            EXTRAS_DEV_TEST +
-            EXTRAS_DEV_DOCS
-        )),
-        "dev-lint": (EXTRAS_DEV_TESTFILES_COMMON +
-                     EXTRAS_DEV_LINT),
-        "dev-test": (EXTRAS_DEV_TESTFILES_COMMON +
-                     EXTRAS_DEV_TEST),
+        "aws": [EXTRAS_FEATURE_AWS],
+        "dev": sorted(
+            set(
+                EXTRAS_DEV_TESTFILES_COMMON
+                + EXTRAS_DEV_LINT
+                + EXTRAS_DEV_TEST
+                + EXTRAS_DEV_DOCS
+                + EXTRAS_FEATURE_AWS
+            )
+        ),
+        "dev-lint": (EXTRAS_DEV_TESTFILES_COMMON + EXTRAS_DEV_LINT),
+        "dev-test": (EXTRAS_DEV_TESTFILES_COMMON + EXTRAS_DEV_TEST),
         "dev-docs": EXTRAS_DEV_DOCS,
         "aiohttp": ["aiohttp"],
         "requests": [
@@ -76,15 +80,14 @@ setup(
             # ^^^ earlier versions would work, but a custom ssl
             # context would silently have system certificates be loaded as
             # trusted: https://github.com/urllib3/urllib3/pull/1566
-
             "requests>=2.16.2",
             # ^^^ earlier versions would work, but they use an older
             # vendored version of urllib3 (see note above)
         ],
         "timezone": ["pytz"],
     },
-    license='MIT',
-    keywords='geocode geocoding gis geographical maps earth distance',
+    license="MIT",
+    keywords="geocode geocoding gis geographical maps earth distance",
     python_requires=">=3.5",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -104,5 +107,5 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
-    ]
+    ],
 )


### PR DESCRIPTION
Haven't written the tests yet, I'm not sure how to go about it as it requires and AWS account (I believe, still to investigate a bit more).

Happy for some feedback and further direction, especially want some feedback on putting optional dependencies behind a feature flag.

Changes:
- Added `AmazonLocationServices` as a new `Geocoder`.
- Put the `AmazonLocationServices` `Geocoder` behind a 'feature flag' as it
  pulls in `boto3` as a dependency. This involves a bit of lazy importing
hackery to make sure the library functions as normal for everyone who **does
not** care about this particular `Geocoder`.