### PR TITLE
Allowing optional language for geocode.

### DIFF
--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -94,6 +94,7 @@ class MapBox(Geocoder):
             timeout=DEFAULT_SENTINEL,
             proximity=None,
             country=None,
+            language=None,
             bbox=None
     ):
         """
@@ -119,6 +120,11 @@ class MapBox(Geocoder):
             Might be a Python list of strings.
 
         :type country: str or list
+
+        :param str language: This parameter controls the language of the text supplied in
+            responses, and also affects result scoring, with results matching the user’s
+            query in the requested language being preferred over results that match in
+            another language. You can pass two letters country codes (ISO 639-1).
 
         :param bbox: The bounding box of the viewport within which
             to bias geocode results more prominently.
@@ -146,6 +152,9 @@ class MapBox(Geocoder):
         if proximity:
             p = Point(proximity)
             params['proximity'] = "%s,%s" % (p.longitude, p.latitude)
+
+        if language:
+            params['language'] = language
 
         quoted_query = quote(query.encode('utf-8'))
         url = "?".join((self.api % dict(query=quoted_query),

--- a/test/geocoders/mapbox.py
+++ b/test/geocoders/mapbox.py
@@ -82,3 +82,11 @@ class TestMapBox(BaseTestGeocoder):
             {},
         )
         assert len(list_result) >= 3
+
+    async def test_geocode_language(self):
+        res = await self.geocode_run(
+            {"query": "Frankfurt", "language": "DE"},
+            {}
+        )
+
+        assert "Frankfurt am Main, Hessen, Deutschland" in res.address


### PR DESCRIPTION
The mapbox api allows to specify the language used
in geocoding results. The test executes a query, which
return the state and country name in German to verify
the implementation. This test is inspired by the Bing
culture reverse geocoding tests.