### PR TITLE
Update Geocode Earth docs

### DIFF
--- a/geopy/geocoders/geocodeearth.py
+++ b/geopy/geocoders/geocodeearth.py
@@ -7,6 +7,12 @@ __all__ = ("GeocodeEarth", )
 class GeocodeEarth(Pelias):
     """Geocode Earth, a Pelias-based service provided by the developers
     of Pelias itself.
+
+    Documentation at:
+        https://geocode.earth/docs
+
+    Pricing details:
+        https://geocode.earth/#pricing
     """
 
     def __init__(

--- a/geopy/geocoders/geocodeearth.py
+++ b/geopy/geocoders/geocodeearth.py
@@ -5,7 +5,7 @@ __all__ = ("GeocodeEarth", )
 
 
 class GeocodeEarth(Pelias):
-    """geocode.earth, a Pelias-based service provided by the developers
+    """Geocode Earth, a Pelias-based service provided by the developers
     of Pelias itself.
     """
 


### PR DESCRIPTION
Hi!

The Geocode Earth docs in Geopy do not include a link to the Geocode Earth documentation (I think because when Geocode Earth support was added to Geopy, our documentation didn't exist yet! 😆)

This PR adds some documentation and pricing links following the conventions of other geocoding services.

Let me know how it looks.