### PR TITLE
allow geographiclib 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.version_info < (3, 5):
 from geopy import __version__ as version  # noqa  # isort:skip
 
 INSTALL_REQUIRES = [
-    'geographiclib<2,>=1.49',
+    'geographiclib<3,>=1.49',
 ]
 
 EXTRAS_DEV_TESTFILES_COMMON = [


### PR DESCRIPTION
surprisingly hard to track down an upstream changelog, https://geographiclib.sourceforge.io/html/C/changes.html suggests that the API is basically unchanged despite the major version bump.