### PR TITLE
Updated databc.py

### DIFF
--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -13,10 +13,10 @@ class DataBC(Geocoder):
     """Geocoder using the Physical Address Geocoder from DataBC.
 
     Documentation at:
-        http://www.data.gov.bc.ca/dbc/geographic/locate/geocoding.page
+        https://www2.gov.bc.ca/gov/content?id=118DD57CD9674D57BDBD511C2E78DC0D
     """
 
-    geocode_path = '/pub/geocoder/addresses.geojson'
+    geocode_path = '/addresses.geojson'
 
     def __init__(
             self,
@@ -59,7 +59,7 @@ class DataBC(Geocoder):
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
         )
-        domain = 'apps.gov.bc.ca'
+        domain = 'geocoder.api.gov.bc.ca'
         self.api = '%s://%s%s' % (self.scheme, domain, self.geocode_path)
 
     def geocode(

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -10,7 +10,7 @@ __all__ = ("DataBC", )
 
 
 class DataBC(Geocoder):
-    """Geocoder using the Physical Address Geocoder from DataBC.
+    """Geocoder using the BC Address Geocoder from DataBC.
 
     Documentation at:
         https://www2.gov.bc.ca/gov/content?id=118DD57CD9674D57BDBD511C2E78DC0D


### PR DESCRIPTION
Updated the link to the BC Address Geocoder documentation and the values for the _geocode_path_ and _domain_ variables. The previous geocoder url is deprecated (https://apps.gov.bc.ca/pub/geocoder) and has been replaced by the following -> https://geocoder.api.gov.bc.ca. Parameters and API response remain the same.
