### PR TITLE
Fix Github actions build badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ geopy
     :target: https://pypi.python.org/pypi/geopy/
     :alt: Latest Version
 
-.. image:: https://img.shields.io/github/workflow/status/geopy/geopy/CI?style=flat-square
-    :target: https://github.com/geopy/geopy/actions
+.. image:: https://img.shields.io/github/actions/workflow/status/geopy/geopy/ci.yml?branch=master&style=flat-square
+    :target: https://github.com/geopy/geopy/actions/workflows/ci.yml?query=branch%3Amaster
     :alt: Build Status
 
 .. image:: https://img.shields.io/github/license/geopy/geopy.svg?style=flat-square


### PR DESCRIPTION
The build badge is currently broken:

![Screenshot 2023-01-20 at 14 46 12](https://user-images.githubusercontent.com/20516159/213726630-1102ab3a-ffef-4250-af42-de278a43a957.png)

This PR fixes it:

![Screenshot 2023-01-20 at 14 46 32](https://user-images.githubusercontent.com/20516159/213726691-2493163c-d943-4c1f-8871-323d83a61341.png)

In summary, these badges were changed in a breaking fashion such that the badges were just linking to the github issue rather than showing the data. Updating the url resolves this.

See the linked GitHub issue from the previous version of the badge for the details: https://github.com/badges/shields/issues/8671

I also updated the link added to the badge image, so that it's restricted to the specific action and the branch in the way the badge is.