### PR TITLE
use tox `allowlist_externals` instead of `whitelist_externals`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ extras =
     requests
     timezone
 passenv = *
-whitelist_externals = make
+allowlist_externals = make
 commands = make {env:GEOPY_TOX_TARGET:test}
 
 [testenv:py37-async]


### PR DESCRIPTION
closes [#539](https://github.com/geopy/geopy/issues/539)