### PR TITLE
Getting rid of Python 2 relics

### DIFF
--- a/geopy/adapters.py
+++ b/geopy/adapters.py
@@ -296,7 +296,7 @@ class URLLibAdapter(BaseSyncAdapter):
         try:
             page = self.urlopen(req, timeout=timeout)
         except Exception as error:
-            message = str(error.args[0]) if len(error.args) else str(error)
+            message = str(error.args[0]) if error.args else str(error)
             if isinstance(error, HTTPError):
                 code = error.getcode()
                 response_headers = {

--- a/geopy/extra/rate_limiter.py
+++ b/geopy/extra/rate_limiter.py
@@ -210,9 +210,9 @@ class RateLimiter(BaseRateLimiter):
         self,
         func,
         *,
-        min_delay_seconds=0.0,
+        min_delay_seconds=0,
         max_retries=2,
-        error_wait_seconds=5.0,
+        error_wait_seconds=5,
         swallow_exceptions=True,
         return_value_on_exception=None
     ):
@@ -333,9 +333,9 @@ class AsyncRateLimiter(BaseRateLimiter):
         self,
         func,
         *,
-        min_delay_seconds=0.0,
+        min_delay_seconds=0,
         max_retries=2,
-        error_wait_seconds=5.0,
+        error_wait_seconds=5,
         swallow_exceptions=True,
         return_value_on_exception=None
     ):

--- a/geopy/extra/rate_limiter.py
+++ b/geopy/extra/rate_limiter.py
@@ -51,7 +51,7 @@ a violation.
 import asyncio
 import inspect
 import threading
-from itertools import chain, count
+from itertools import chain, count, repeat
 from time import sleep
 from timeit import default_timer
 
@@ -63,7 +63,7 @@ __all__ = ("AsyncRateLimiter", "RateLimiter")
 
 def _is_last_gen(count):
     """list(_is_last_gen(2)) -> [False, False, True]"""
-    return chain((False for _ in range(count)), [True])
+    return chain(repeat(False, count), [True])
 
 
 class BaseRateLimiter:

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -177,7 +177,7 @@ class ArcGIS(Geocoder):
             raise GeocoderServiceError(str(response['error']))
 
         # Success; convert from the ArcGIS JSON format.
-        if not len(response['candidates']):
+        if not response['candidates']:
             return None
         geocoded = []
         for resource in response['candidates']:
@@ -227,7 +227,7 @@ class ArcGIS(Geocoder):
         return self._authenticated_call_geocoder(url, callback, timeout=timeout)
 
     def _parse_reverse(self, response, exactly_one):
-        if not len(response):
+        if not response:
             return None
         if 'error' in response:
             # https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm

--- a/geopy/geocoders/banfrance.py
+++ b/geopy/geocoders/banfrance.py
@@ -172,7 +172,7 @@ class BANFrance(Geocoder):
         if response is None or 'features' not in response:
             return None
         features = response['features']
-        if not len(features):
+        if not features:
             return None
         if exactly_one:
             return self._parse_feature(features[0])

--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -230,7 +230,7 @@ class Bing(Geocoder):
                 raise GeocoderServiceError(err)
 
         resources = doc['resourceSets'][0]['resources']
-        if resources is None or not len(resources):
+        if not resources:
             return None
 
         def parse_resource(resource):

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -125,7 +125,7 @@ class DataBC(Geocoder):
 
     def _parse_json(self, response, exactly_one):
         # Success; convert from GeoJSON
-        if not len(response['features']):
+        if not response['features']:
             return None
         geocoded = []
         for feature in response['features']:

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -328,7 +328,7 @@ class GeoNames(Geocoder):
         """
         places = doc.get('geonames', [])
         self._raise_for_error(doc)
-        if not len(places):
+        if not places:
             return None
 
         def parse_code(place):

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -206,7 +206,7 @@ class OpenCage(Geocoder):
         '''Returns location, (latitude, longitude) from json feed.'''
 
         places = page.get('results', [])
-        if not len(places):
+        if not places:
             self._check_status(page.get('status'))
             return None
 

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -238,7 +238,7 @@ class Pelias(Geocoder):
         if response is None:
             return None
         features = response['features']
-        if not len(features):
+        if not features:
             return None
         if exactly_one:
             return self._parse_code(features[0])

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -221,7 +221,7 @@ class Photon(Geocoder):
         """
         Parse display name, latitude, and longitude from a JSON response.
         """
-        if not len(resources['features']):  # pragma: no cover
+        if not resources['features']:  # pragma: no cover
             return None
         if exactly_one:
             return self._parse_resource(resources['features'][0])

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -124,7 +124,7 @@ class LiveAddress(Geocoder):
         """
         Parse responses as JSON objects.
         """
-        if not len(response):
+        if not response:
             return None
         if exactly_one:
             return self._format_structured_address(response[0])

--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -18,10 +18,7 @@ def _check_query(query):
     """
     Check query validity with regex
     """
-    if not _MULTIPLE_WORD_RE.match(query):
-        return False
-    else:
-        return True
+    return bool(_MULTIPLE_WORD_RE.match(query))
 
 
 class What3Words(Geocoder):

--- a/geopy/point.py
+++ b/geopy/point.py
@@ -44,8 +44,8 @@ def _normalize_angle(x, limit):
     """
     Normalize angle `x` to be within `[-limit; limit)` range.
     """
-    double_limit = limit * 2.0
-    modulo = fmod(x, double_limit) or 0.0  # `or 0` is to turn -0 to +0.
+    double_limit = limit * 2
+    modulo = fmod(x, double_limit) or 0  # `or 0` is to turn -0 to +0.
     if modulo < -limit:
         return modulo + double_limit
     if modulo >= limit:
@@ -54,9 +54,9 @@ def _normalize_angle(x, limit):
 
 
 def _normalize_coordinates(latitude, longitude, altitude):
-    latitude = float(latitude or 0.0)
-    longitude = float(longitude or 0.0)
-    altitude = float(altitude or 0.0)
+    latitude = float(latitude or 0)
+    longitude = float(longitude or 0)
+    altitude = float(altitude or 0)
 
     is_all_finite = all(isfinite(x) for x in (latitude, longitude, altitude))
     if not is_all_finite:
@@ -76,7 +76,7 @@ def _normalize_coordinates(latitude, longitude, altitude):
     if abs(longitude) > 180:
         # Longitude normalization is pretty straightforward and doesn't seem
         # to be error-prone, so there's nothing to complain about.
-        longitude = _normalize_angle(longitude, 180.0)
+        longitude = _normalize_angle(longitude, 180)
 
     return latitude, longitude, altitude
 
@@ -437,15 +437,15 @@ class Point:
             elif match.group("longitude_direction_back"):
                 longitude_direction = match.group("longitude_direction_back")
             latitude = cls.parse_degrees(
-                match.group('latitude_degrees') or 0.0,
-                match.group('latitude_arcminutes') or 0.0,
-                match.group('latitude_arcseconds') or 0.0,
+                match.group('latitude_degrees') or 0,
+                match.group('latitude_arcminutes') or 0,
+                match.group('latitude_arcseconds') or 0,
                 latitude_direction
             )
             longitude = cls.parse_degrees(
-                match.group('longitude_degrees') or 0.0,
-                match.group('longitude_arcminutes') or 0.0,
-                match.group('longitude_arcseconds') or 0.0,
+                match.group('longitude_degrees') or 0,
+                match.group('longitude_arcminutes') or 0,
+                match.group('longitude_arcseconds') or 0,
                 longitude_direction
             )
             altitude = cls.parse_altitude(

--- a/geopy/units.py
+++ b/geopy/units.py
@@ -14,13 +14,13 @@ def degrees(radians=0, arcminutes=0, arcseconds=0):
     """
     Convert angle to degrees.
     """
-    deg = 0.
+    deg = 0
     if radians:
         deg = math.degrees(radians)
     if arcminutes:
-        deg += arcminutes / arcmin(degrees=1.)
+        deg += arcminutes / arcmin(degrees=1)
     if arcseconds:
-        deg += arcseconds / arcsec(degrees=1.)
+        deg += arcseconds / arcsec(degrees=1)
     return deg
 
 
@@ -29,9 +29,9 @@ def radians(degrees=0, arcminutes=0, arcseconds=0):
     Convert angle to radians.
     """
     if arcminutes:
-        degrees += arcminutes / arcmin(degrees=1.)
+        degrees += arcminutes / arcmin(degrees=1)
     if arcseconds:
-        degrees += arcseconds / arcsec(degrees=1.)
+        degrees += arcseconds / arcsec(degrees=1)
     return math.radians(degrees)
 
 
@@ -42,8 +42,8 @@ def arcminutes(degrees=0, radians=0, arcseconds=0):
     if radians:
         degrees += math.degrees(radians)
     if arcseconds:
-        degrees += arcseconds / arcsec(degrees=1.)
-    return degrees * 60.
+        degrees += arcseconds / arcsec(degrees=1)
+    return degrees * 60
 
 
 def arcseconds(degrees=0, radians=0, arcminutes=0):
@@ -53,8 +53,8 @@ def arcseconds(degrees=0, radians=0, arcminutes=0):
     if radians:
         degrees += math.degrees(radians)
     if arcminutes:
-        degrees += arcminutes / arcmin(degrees=1.)
-    return degrees * 3600.
+        degrees += arcminutes / arcmin(degrees=1)
+    return degrees * 3600
 
 
 # Lengths
@@ -63,13 +63,13 @@ def kilometers(meters=0, miles=0, feet=0, nautical=0):
     """
     Convert distance to kilometers.
     """
-    ret = 0.
+    ret = 0
     if meters:
-        ret += meters / 1000.
+        ret += meters / 1000
     if feet:
-        ret += feet / ft(1.)
+        ret += feet / ft(1)
     if nautical:
-        ret += nautical / nm(1.)
+        ret += nautical / nm(1)
     ret += miles * 1.609344
     return ret
 
@@ -85,13 +85,13 @@ def miles(kilometers=0, meters=0, feet=0, nautical=0):
     """
     Convert distance to miles.
     """
-    ret = 0.
+    ret = 0
     if nautical:
-        kilometers += nautical / nm(1.)
+        kilometers += nautical / nm(1)
     if feet:
-        kilometers += feet / ft(1.)
+        kilometers += feet / ft(1)
     if meters:
-        kilometers += meters / 1000.
+        kilometers += meters / 1000
     ret += kilometers / 1.609344
     return ret
 
@@ -100,11 +100,11 @@ def feet(kilometers=0, meters=0, miles=0, nautical=0):
     """
     Convert distance to feet.
     """
-    ret = 0.
+    ret = 0
     if nautical:
-        kilometers += nautical / nm(1.)
+        kilometers += nautical / nm(1)
     if meters:
-        kilometers += meters / 1000.
+        kilometers += meters / 1000
     if kilometers:
         miles += mi(kilometers=kilometers)
     ret += miles * 5280
@@ -115,13 +115,13 @@ def nautical(kilometers=0, meters=0, miles=0, feet=0):
     """
     Convert distance to nautical miles.
     """
-    ret = 0.
+    ret = 0
     if feet:
-        kilometers += feet / ft(1.)
+        kilometers += feet / ft(1)
     if miles:
         kilometers += km(miles=miles)
     if meters:
-        kilometers += meters / 1000.
+        kilometers += meters / 1000
     ret += kilometers / 1.852
     return ret
 

--- a/geopy/util.py
+++ b/geopy/util.py
@@ -13,8 +13,7 @@ def pairwise(seq):
     """
     Pair an iterable, e.g., (1, 2, 3, 4) -> ((1, 2), (2, 3), (3, 4))
     """
-    for i in range(0, len(seq) - 1):
-        yield (seq[i], seq[i + 1])
+    yield from zip(seq, seq[1:])
 
 
 def join_filter(sep, seq, pred=bool):

--- a/test/test_timezone.py
+++ b/test/test_timezone.py
@@ -17,7 +17,7 @@ except ImportError:
 @pytest.mark.skipif("not pytz_available")
 class TimezoneTestCase(unittest.TestCase):
 
-    timezone_gmt_offset_hours = 3.0
+    timezone_gmt_offset_hours = 3
     timezone_name = "Europe/Moscow"  # a DST-less timezone
 
     def test_create_from_timezone_name(self):


### PR DESCRIPTION
1. Use integers where floats were needed in Python 2
2. Simplify conditions and loops