### PR TITLE
Update URL and endpoint in DataBC geocoder

### DIFF
--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -1,7 +1,7 @@
 from functools import partial
 from urllib.parse import urlencode
 
-from geopy.exc import GeocoderQueryError
+from geopy.exc import ConfigurationError, GeocoderQueryError
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
 from geopy.location import Location
 from geopy.util import logger
@@ -16,7 +16,7 @@ class DataBC(Geocoder):
         http://www.data.gov.bc.ca/dbc/geographic/locate/geocoding.page
     """
 
-    geocode_path = '/pub/geocoder/addresses.geojson'
+    geocode_path = '/addresses.geojson'
 
     def __init__(
             self,
@@ -59,7 +59,12 @@ class DataBC(Geocoder):
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
         )
-        domain = 'apps.gov.bc.ca'
+
+        if self.scheme != 'https':
+            raise ConfigurationError(
+                'DataBC only supports `https` scheme as of December 2020.'
+            )
+        domain = 'geocoder.api.gov.bc.ca'
         self.api = '%s://%s%s' % (self.scheme, domain, self.geocode_path)
 
     def geocode(


### PR DESCRIPTION
**Note that this is a breaking change for people trying to use plain http at DataBC, however that should already be broken for them (at least it was for me)**

Per [DataBC documentation](https://www2.gov.bc.ca/gov/content/data/geographic-data-services/location-services/geocoder), the URL used in geopy was deprecated in 2018 and should have been shut down in December 2020: 
```
December 1, 2020
The following URLs were deprecated on Sep. 1, 2018 and are now shut down:

http://apps.gov.bc.ca/pub/geocoder
https://apps.gov.bc.ca/pub/geocoder
This URL should now be used, with or without an API key: https://geocoder.api.gov.bc.ca
```

These endpoints have apparently continued to silently work, until August 22, 2023, when DataBC has started bouncing plain `http` requests at the old URL/endpoint.

This change updates the URL, and raises `ConfigurationError` if the DataBC geocoder is initialized with `scheme='http'`.

