### PR TITLE
Bing: Include strictMatch in Forward Geocoding

### DIFF
--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -97,7 +97,8 @@ class Bing(Geocoder):
             timeout=DEFAULT_SENTINEL,
             culture=None,
             include_neighborhood=None,
-            include_country_code=False
+            include_country_code=False,
+            strict_match=False
     ):
         """
         Return a location point by address.
@@ -131,6 +132,13 @@ class Bing(Geocoder):
             two-letter ISO code of the country in the response (field name
             'countryRegionIso2').
 
+        :param bool strict_match: Restricts the geocode result to the country
+            or region that is specified in the countryRegion field and the state,
+            province or territory specified in the adminDistrict field.
+                - 1: Restrict results to the specified countryRegion and adminDistrict.
+                - 0 [default]: Do not restrict results to the specified countryRegion
+                and adminDistrict.
+
         :rtype: ``None``, :class:`geopy.location.Location` or a list of them, if
             ``exactly_one=False``.
         """
@@ -157,6 +165,7 @@ class Bing(Geocoder):
             params['includeNeighborhood'] = include_neighborhood
         if include_country_code:
             params['include'] = 'ciso2'  # the only acceptable value
+        params['strictMatch'] = int(strict_match)
 
         url = "?".join((self.geocode_api, urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)

--- a/test/geocoders/bing.py
+++ b/test/geocoders/bing.py
@@ -84,3 +84,26 @@ class TestBing(BaseTestGeocoder):
         )
         address = res.raw['address']
         assert address['locality'] == "Broomfield"
+
+    async def test_structured_strict_match(self):
+        payload = {"strict_match": False,
+                   "include_country_code": True,
+                   "query": {'postalCode': '316000', 'countryRegion': 'HK',
+                             'locality': 'Hong Kong',
+                             'addressLine': '100 Castle Perk Road'}}
+
+        res = await self.geocode_run(
+            payload,
+            {},
+        )
+        address = res.raw['address']
+        assert address['countryRegionIso2'] == "US"
+
+        payload["strict_match"] = True
+
+        res_strict_match_true = await self.geocode_run(
+            payload,
+            {},
+        )
+        address = res_strict_match_true.raw['address']
+        assert address['countryRegionIso2'] == "HK"


### PR DESCRIPTION
Hi!,

First of all, first PR here, so please if something is missing let me know!

Reasoning for the change.

We use Bing Locations REST API to perform Forward Geocoding of addresses by components

Take the following Location to Geocode:

    postalCode=316000
	countryRegion=HK
	locality=Hong+Kong
	addressLine=100+Castle+Perk+Road

	include=ciso2

Even though it is a valid address in Hong Kong, Bing returns an address in the US. Somehow it seems it has a bias for the US when is unsure.

Link to bing maps for address: https://www.bing.com/maps?cp=22.332245%7E114.165984&lvl=16.8

Address returned by Forward geocode:

    "address": {
            "addressLine": "100 Hong Kong Rd",
            "adminDistrict": "NY",
            "adminDistrict2": "Oswego County",
            "countryRegion": "United States",
            "formattedAddress": "100 Hong Kong Rd, Parish, NY 13131",
            "locality": "Parish",
            "postalCode": "13131",
            "countryRegionIso2": "US"
          },


This is because the default behaviour if 'strictMatch' is not specified is to go with '0'. From the documentation
`strictMatch`

> 
> `sm`
> 
> **Optional.**  Restricts the geocode result to the country or region that is specified in the countryRegion field and the state, province
> or territory specified in the adminDistrict field.
> 
> One of the following values:  
>   
> -  `1`: Restrict results to the specified countryRegion and adminDistrict.  
> -  `0`  **[default]**: Do not restrict results to the specified countryRegion and adminDistrict.     
> **Example:**   `strictMatch=1`
> 
> https://learn.microsoft.com/en-us/bingmaps/rest-services/locations/find-a-location-by-address

Solution proposed in the PR, add parameter 'strict_match' (by default False, to not alter current usage) so it can be called with strict_match = True.

Doing the call with strict_match=True we get:

     "address": {
                "addressLine": "Castle Peak Rd100",
                "adminDistrict2": "Kowloon",
                "countryRegion": "Hong Kong SAR",
                "formattedAddress": "100 Castle Peak Rd, Sham Shui Po District, Kowloon, Hong Kong SAR",
                "locality": "Sham Shui Po District",
                "countryRegionIso2": "HK"
              },
          
Which in this case is correct. 

