### PR TITLE
Implement `httpx` async adapter

### DIFF
--- a/geopy/adapters.py
+++ b/geopy/adapters.py
@@ -61,6 +61,12 @@ try:
 except ImportError:
     aiohttp_available = False
 
+try:
+    import httpx
+    httpx_available = True
+except ImportError:
+    httpx_available = False
+
 
 class AdapterHTTPError(IOError):
     """An exception which must be raised by adapters when an HTTP response
@@ -681,3 +687,51 @@ class RequestsHTTPWithSSLContextAdapter(RequestsHTTPAdapter):
             conn.ca_cert_dir = None
             conn.cert_file = None
             conn.key_file = None
+
+
+class AsyncHttpxAdapter(BaseAsyncAdapter):
+    is_available = httpx_available
+
+    def __init__(self, *, proxies, ssl_context):
+        if not httpx_available:
+            raise ImportError(
+                "`httpx` must be installed in order to use AsyncHttpxAdapter. "
+                "If you have installed geopy via pip, you may use "
+                "this command to install httpx: "
+                '`pip install httpx`.'
+            )
+        proxies = _normalize_proxies(proxies)
+        super().__init__(proxies=proxies, ssl_context=ssl_context)
+
+        self.proxies = proxies
+        self.ssl_context = ssl_context
+
+    @property
+    def session(self):
+        # Lazy session creation, which allows to avoid "unclosed socket"
+        # warnings if a Geocoder instance is created without entering
+        # async context and making any requests.
+        session = self.__dict__.get("session")
+        if session is None:
+            session = httpx.AsyncClient(
+                trust_env=False,  # don't use system proxies
+            )
+            self.__dict__["session"] = session
+        return session
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.session.aclose()
+
+    async def get_text(self, url, *, timeout, headers):
+        response = await self.session.get(
+            url,
+            timeout=httpx.Timeout(timeout),
+            headers=headers
+        )
+        return response.text
+
+    async def get_json(self, *args, **kwargs):
+        return json.loads(await self.get_text(*args, **kwargs))

--- a/test/adapters/each_adapter.py
+++ b/test/adapters/each_adapter.py
@@ -12,6 +12,7 @@ from geopy.adapters import (
     AdapterHTTPError,
     AioHTTPAdapter,
     BaseAsyncAdapter,
+    HttpxAsyncAdapter,
     RequestsAdapter,
     URLLibAdapter,
 )
@@ -47,6 +48,13 @@ except ImportError:
     NOT_AVAILABLE_ADAPTERS.append(AioHTTPAdapter)
 else:
     AVAILABLE_ADAPTERS.append(AioHTTPAdapter)
+
+try:
+    import httpx  # noqa
+except ImportError:
+    NOT_AVAILABLE_ADAPTERS.append(HttpxAsyncAdapter)
+else:
+    AVAILABLE_ADAPTERS.append(HttpxAsyncAdapter)
 
 
 class DummyGeocoder(Geocoder):


### PR DESCRIPTION
Closes #544

Note that this PR implements _only_ the async adapter. `httpx` can also work synchronously.