### PR TITLE
Add bearing calculation to distance class

### DIFF
--- a/geopy/distance.py
+++ b/geopy/distance.py
@@ -122,7 +122,7 @@ from geographiclib.geodesic import Geodesic
 
 from geopy import units, util
 from geopy.point import Point
-from geopy.units import radians
+from geopy.units import degrees, radians
 
 # IUGG mean earth radius in kilometers, from
 # https://en.wikipedia.org/wiki/Earth_radius#Mean_radius.  Using a
@@ -331,6 +331,35 @@ class Distance:
         # to be used directly.
         raise NotImplementedError("Distance is an abstract class")
 
+    def bearing(self, start, end):
+        """
+        Calculate the bearing from a starting point to an end point as defined
+        at the starting point.
+
+        Example: Bearing due North::
+
+            >>> import geopy.distance
+            >>> geopy.distance.distance().bearing((34, 148), (34, 140))
+            0.0
+
+        Example: A bearing due East::
+
+            >>> import geopy.distance
+            >>> geopy.distance.distance().bearing((0,150),(0,155))
+            90.0
+
+        :param start: Starting point, bearing is calculated from start
+        :type point: :class:`geopy.point.Point`, list or tuple of ``(latitude,
+            longitude)``, or string as ``"%(latitude)s, %(longitude)s"``.
+        :param end: Ending point.
+        :type point: :class:`geopy.point.Point`, list or tuple of ``(latitude,
+            longitude)``, or string as ``"%(latitude)s, %(longitude)s"``.
+
+        :return: Bearing at ``start`` towards ``end`` in degrees clockwise from true north
+        :rtype: float
+        """
+        raise NotImplementedError("Distance is an abstract class")
+
     def destination(self, point, bearing, distance=None):
         """
         Calculate destination point using a starting point, bearing
@@ -480,6 +509,19 @@ class great_circle(Distance):
 
         return self.RADIUS * d
 
+    def bearing(self, start, end):
+        # Uses bearing formula from https://www.movable-type.co.uk/scripts/latlong.html
+        start, end = Point(start), Point(end)
+        _ensure_same_altitude(start, end)
+
+        lat1, lng1 = radians(degrees=start.latitude), radians(degrees=start.longitude)
+        lat2, lng2 = radians(degrees=end.latitude), radians(degrees=end.longitude)
+
+        return degrees(atan2(
+            sin(lng2 - lng1) * cos(lat2),
+            cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(lng2 - lng1)
+            ))
+
     def destination(self, point, bearing, distance=None):
         point = Point(point)
         lat1 = units.radians(degrees=point.latitude)
@@ -567,6 +609,21 @@ class geodesic(Distance):
                                 Geodesic.DISTANCE)['s12']
 
         return s12
+
+    def bearing(self, start, end):
+        start, end = Point(start), Point(end)
+        _ensure_same_altitude(start, end)
+        lat1, lon1 = start.latitude, start.longitude
+        lat2, lon2 = end.latitude, end.longitude
+
+        if not (isinstance(self.geod, Geodesic) and
+                self.geod.a == self.ELLIPSOID[0] and
+                self.geod.f == self.ELLIPSOID[2]):
+            self.geod = Geodesic(self.ELLIPSOID[0], self.ELLIPSOID[2])
+
+        azi1 = self.geod.Inverse(lat1, lon1, lat2, lon2, Geodesic.AZIMUTH)['azi1']
+
+        return azi1
 
     def destination(self, point, bearing, distance=None):
         point = Point(point)

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -65,6 +65,21 @@ class CommonDistanceComputationCases:
             self.assertAlmostEqual(p.latitude, 59.9878, delta=1e-3)
             self.assertAlmostEqual(p.longitude, 161.79, delta=1e-2)
 
+    def test_bearing(self):
+        distance = self.cls()
+        east = distance.bearing((0, 150), (0, 151))
+        north = distance.bearing((45, 150), (46, 150))
+        south = distance.bearing((45, 100), (-45, 100))
+        west = distance.bearing((0, 150), (0, 10))
+        # East-West bearing deviates as you travel from the equator
+        not_east = distance.bearing((45, 150), (45, 151))
+
+        self.assertAlmostEqual(east, 90.0)
+        self.assertAlmostEqual(north, 0.0)
+        self.assertAlmostEqual(south, 180.0)
+        self.assertAlmostEqual(west, -90.0)
+        self.assertNotAlmostEqual(not_east, 90.0)
+
     def test_should_recognize_equivalence_of_pos_and_neg_180_longitude(self):
         distance1 = self.cls((0, -180), (0, 180)).kilometers
         distance2 = self.cls((0, 180), (0, -180)).kilometers


### PR DESCRIPTION
Add bearing calculation for distance class.
Distance seems the appropriate place to put it, since this is just using geographiclib to solve the inverse geodesic problem, but it does make the interface a little odd:

```python
import geopy.distance
bearing = geopy.distance.distance().bearing(point1, point2)
```

It's a little more sensible if the user cares about geodesics or constructs their own:

```python
import geopy.distance.distance
geodesic = geopy.distance.geodesic
bearing = geodesic.bearing(point1, point2)
```

Closes https://github.com/geopy/geopy/issues/128