### PR TITLE
Update tomtom.py for correct address encoding

### DIFF
--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -121,7 +121,7 @@ class TomTom(Geocoder):
         if language:
             params['language'] = language
 
-        quoted_query = quote(query.encode('utf-8'))
+        quoted_query = quote(query.encode('utf-8'), safe="")
         url = "?".join((self.api % dict(query=quoted_query),
                         urlencode(params)))
         logger.debug("%s.geocode: %s", self.__class__.__name__, url)


### PR DESCRIPTION
# Fix TomTom geocoder: fully URL-encode the query (including "/") to prevent 404 errors on valid addresses

## Summary

The current implementation of the TomTom geocoder in `geopy` does not fully URL-encode the geocoding query.  
It uses:

```python
quoted_query = quote(query.encode("utf-8"))
```

However, `urllib.parse.quote()` uses `safe='/'` by default, meaning the slash character **is not encoded**.

This leads to URLs such as:

```
https://api.tomtom.com/search/2/geocode/.../5/1с1.json
```

TomTom interprets `/` as a **path separator**, not as part of the address string, which results in:

- **404 Not Found**
- incorrect internal path resolution on TomTom's side
- failure to geocode valid addresses containing slashes (e.g., `5/1`, `12/3`, `31/29`)

Such address formats are extremely common in Russia, Poland, Czech Republic and many other countries.

## Fix

Replace:

```python
quoted_query = quote(query.encode("utf-8"))
```

with:

```python
quoted_query = quote(query.encode("utf-8"), safe="")
```

This ensures _all_ characters are encoded — including `/`.

Example:

```
"5/1с1" → "5%2F1%D1%811"
```

Resulting in a correct TomTom URL:

```
https://api.tomtom.com/search/2/geocode/...5%2F1%D1%811.json
```

TomTom handles this correctly and returns proper geocoding results.

## Examples of correct vs. incorrect URLs

### 1. Address: “Москва, Красная площадь, 1” (no slash)

Both current and fixed implementations encode this correctly.

**Current geopy:**

```
https://api.tomtom.com/search/2/geocode/%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0%2C%20%D0%9A%D1%80%D0%B0%D1%81%D0%BD%D0%B0%D1%8F%20%D0%BF%D0%BB%D0%BE%D1%89%D0%B0%D0%B4%D1%8C%2C%201.json?key=KEY
```

**Proposed encoding:**  
(same result)

```
https://api.tomtom.com/search/2/geocode/%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0%2C%20%D0%9A%D1%80%D0%B0%D1%81%D0%BD%D0%B0%D1%8F%20%D0%BF%D0%BB%D0%BE%D1%89%D0%B0%D0%B4%D1%8C%2C%201.json?key=KEY
```

### 2. Address: “Москва, Никольская улица, 5/1с1” (problem case)

#### 🔴 Current geopy (incorrect)
Slash is **not encoded** → treated as path separator:

```
https://api.tomtom.com/search/2/geocode/%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0%2C%20%D0%9D%D0%B8%D0%BA%D0%BE%D0%BB%D1%8C%D1%81%D0%BA%D0%B0%D1%8F%20%D1%83%D0%BB%D0%B8%D1%86%D0%B0%2C%205/1%D1%811.json?key=KEY
```

TomTom interprets this as:

- path: `/5/`
- file: `1с1.json`

→ **404 Not Found**

#### 🟢 With fix (correct)

```
https://api.tomtom.com/search/2/geocode/%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0%2C%20%D0%9D%D0%B8%D0%BA%D0%BE%D0%BB%D1%8C%D1%81%D0%BA%D0%B0%D1%8F%20%D1%83%D0%BB%D0%B8%D1%86%D0%B0%2C%205%2F1%D1%811.json?key=KEY
```

TomTom returns valid results.

## Patch (diff)

```diff
diff --git a/geopy/geocoders/tomtom.py b/geopy/geocoders/tomtom.py
index f495974..6a78ad0 100644
--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -121,7 +121,7 @@ def geocode(
        if language:
            params['language'] = language

        quoted_query = quote(query.encode('utf-8'))
        quoted_query = quote(query.encode('utf-8'), safe="")
        url = "?".join((self.api % dict(query=quoted_query),
                        urlencode(params)))
        logger.debug("%s.geocode: %s", self.__class__.__name__, url)
```