### PR TITLE
Fix incorrect type hints for timeout and language params in Nominatim and Photon

### DIFF
--- a/geopy/geocoders/nominatim.py
+++ b/geopy/geocoders/nominatim.py
@@ -1,5 +1,6 @@
 import collections.abc
 from functools import partial
+from typing import Optional, Union
 from urllib.parse import urlencode
 
 from geopy.exc import ConfigurationError, GeocoderQueryError
@@ -137,10 +138,10 @@ class Nominatim(Geocoder):
             query,
             *,
             exactly_one=True,
-            timeout=DEFAULT_SENTINEL,
+            timeout: Optional[Union[int, float]] = DEFAULT_SENTINEL,
             limit=None,
             addressdetails=False,
-            language=False,
+            language: Optional[str] = None,
             geometry=None,
             extratags=False,
             country_codes=None,
@@ -301,8 +302,8 @@ class Nominatim(Geocoder):
             query,
             *,
             exactly_one=True,
-            timeout=DEFAULT_SENTINEL,
-            language=False,
+            timeout: Optional[Union[int, float]] = DEFAULT_SENTINEL,
+            language: Optional[str] = None,
             addressdetails=True,
             zoom=None,
             namedetails=False,

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -1,5 +1,6 @@
 import collections.abc
 from functools import partial
+from typing import Optional, Union
 from urllib.parse import urlencode
 
 from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
@@ -82,9 +83,9 @@ class Photon(Geocoder):
             query,
             *,
             exactly_one=True,
-            timeout=DEFAULT_SENTINEL,
+            timeout: Optional[Union[int, float]] = DEFAULT_SENTINEL,
             location_bias=None,
-            language=False,
+            language: Optional[str] = None,
             limit=None,
             osm_tag=None,
             bbox=None
@@ -170,8 +171,8 @@ class Photon(Geocoder):
             query,
             *,
             exactly_one=True,
-            timeout=DEFAULT_SENTINEL,
-            language=False,
+            timeout: Optional[Union[int, float]] = DEFAULT_SENTINEL,
+            language: Optional[str] = None,
             limit=None
     ):
         """


### PR DESCRIPTION
## Problem (fixes #590, #593, #594)

Static type checkers (Pylance, mypy) report spurious errors for standard usage of `geocode()` and `reverse()` in the Nominatim and Photon geocoders.

**Issue 1 – `timeout` parameter (#590)**

```python
geolocator.geocode("London", timeout=5)
# Pylance: Argument of type "Literal[5]" cannot be assigned to parameter
#          "timeout" of type "object" in function "geocode"
```

`DEFAULT_SENTINEL` is created via `type('object', (object,), ...)()`, giving it the class name `'object'`. Pylance treats this as `geopy.geocoders.base.object` (not `builtins.object`), so any integer or float is seen as incompatible.

**Issue 2 – `language` parameter (#593, #594)**

```python
geolocator.geocode("London", language="de")
# Pylance: Argument of type "Literal['de']" cannot be assigned to
#          parameter "language" of type "bool" in function "geocode"
```

`language=False` causes Pylance to infer the parameter type as `bool`.

## Fix

Add explicit type annotations to `geocode()` and `reverse()` in **Nominatim** and **Photon**:

- `timeout: Optional[Union[int, float]] = DEFAULT_SENTINEL`
- `language: Optional[str] = None`  (default changed from `False` to `None`;
  both are falsy so all `if language:` checks are unaffected)

The fix uses `typing.Optional`/`typing.Union` for Python 3.7 compatibility.

Made with [Cursor](https://cursor.com)