### PR TITLE
Add ip2geo IP geolocation geocoder

### DIFF
--- a/geopy/geocoders/__init__.py
+++ b/geopy/geocoders/__init__.py
@@ -199,6 +199,7 @@ __all__ = (
     "GeoNames",
     "GoogleV3",
     "Geolake",
+    "Ip2geo",
     "Here",
     "HereV7",
     "IGNFrance",
@@ -235,6 +236,7 @@ from geopy.geocoders.geolake import Geolake
 from geopy.geocoders.geonames import GeoNames
 from geopy.geocoders.google import GoogleV3
 from geopy.geocoders.here import Here, HereV7
+from geopy.geocoders.ip2geo import Ip2geo
 from geopy.geocoders.ignfrance import IGNFrance
 from geopy.geocoders.mapbox import MapBox
 from geopy.geocoders.mapquest import MapQuest
@@ -269,6 +271,7 @@ SERVICE_TO_GEOCODER = {
     "here": Here,
     "herev7": HereV7,
     "ignfrance": IGNFrance,
+    "ip2geo": Ip2geo,
     "mapbox": MapBox,
     "mapquest": MapQuest,
     "maptiler": MapTiler,

--- a/geopy/geocoders/ip2geo.py
+++ b/geopy/geocoders/ip2geo.py
@@ -1,0 +1,178 @@
+from functools import partial
+from urllib.parse import urlencode
+
+from geopy.exc import (
+    GeocoderAuthenticationFailure,
+    GeocoderQueryError,
+    GeocoderQuotaExceeded,
+    GeocoderServiceError,
+)
+from geopy.geocoders.base import DEFAULT_SENTINEL, Geocoder
+from geopy.location import Location
+from geopy.util import logger
+
+__all__ = ("Ip2geo",)
+
+
+class Ip2geo(Geocoder):
+    """Geocoder using the ip2geo IP geolocation service.
+
+    Documentation at:
+        https://ip2geo.dev/docs
+
+    .. versionadded:: 2.5
+    """
+
+    geocode_path = '/convert'
+
+    def __init__(
+            self,
+            api_key,
+            *,
+            domain='api.ip2geo.dev',
+            scheme=None,
+            timeout=DEFAULT_SENTINEL,
+            proxies=DEFAULT_SENTINEL,
+            user_agent=None,
+            ssl_context=DEFAULT_SENTINEL,
+            adapter_factory=None
+    ):
+        """
+
+        :param str api_key: The API key required by ip2geo
+            to perform geocoding requests. You can get your key here:
+            https://ip2geo.dev
+
+        :param str domain: Domain where the target ip2geo service
+            is hosted.
+
+        :param str scheme:
+            See :attr:`geopy.geocoders.options.default_scheme`.
+
+        :param int timeout:
+            See :attr:`geopy.geocoders.options.default_timeout`.
+
+        :param dict proxies:
+            See :attr:`geopy.geocoders.options.default_proxies`.
+
+        :param str user_agent:
+            See :attr:`geopy.geocoders.options.default_user_agent`.
+
+        :type ssl_context: :class:`ssl.SSLContext`
+        :param ssl_context:
+            See :attr:`geopy.geocoders.options.default_ssl_context`.
+
+        :param callable adapter_factory:
+            See :attr:`geopy.geocoders.options.default_adapter_factory`.
+
+        """
+        super().__init__(
+            scheme=scheme,
+            timeout=timeout,
+            proxies=proxies,
+            user_agent=user_agent,
+            ssl_context=ssl_context,
+            adapter_factory=adapter_factory,
+        )
+
+        self.api_key = api_key
+        self.domain = domain.strip('/')
+        self.api = '%s://%s%s' % (self.scheme, self.domain,
+                                  self.geocode_path)
+
+    def geocode(
+            self,
+            query,
+            *,
+            exactly_one=True,
+            timeout=DEFAULT_SENTINEL
+    ):
+        """
+        Return a location for the given IP address.
+
+        :param str query: The IP address you wish to geolocate.
+
+        :param bool exactly_one: Return one result or a list of
+            results, if available. ip2geo always returns a single
+            result per IP address.
+
+        :param int timeout: Time, in seconds, to wait for the
+            geocoding service to respond before raising a
+            :class:`geopy.exc.GeocoderTimedOut` exception. Set this
+            only if you wish to override, on this call only, the
+            value set during the geocoder's initialization.
+
+        :rtype: ``None``, :class:`geopy.location.Location` or a
+            list of them, if ``exactly_one=False``.
+        """
+        params = {
+            'ip': query,
+        }
+
+        url = "?".join((self.api, urlencode(params)))
+
+        logger.debug(
+            "%s.geocode: %s", self.__class__.__name__, url
+        )
+        callback = partial(
+            self._parse_json, exactly_one=exactly_one
+        )
+        return self._call_geocoder(
+            url,
+            callback,
+            timeout=timeout,
+            headers={'X-Api-Key': self.api_key},
+        )
+
+    def _parse_json(self, page, exactly_one=True):
+        self._check_status(page)
+
+        data = page.get('data')
+        if not data:
+            return None
+
+        location = self._parse_location(data)
+
+        if exactly_one:
+            return location
+        else:
+            return [location]
+
+    def _parse_location(self, data):
+        continent = data.get('continent') or {}
+        country = continent.get('country') or {}
+        city = country.get('city') or {}
+        subdivision = country.get('subdivision') or {}
+
+        city_name = city.get('name') or ''
+        state_name = subdivision.get('name') or ''
+        country_name = country.get('name') or ''
+
+        parts = [p for p in (city_name, state_name,
+                             country_name) if p]
+        address = ', '.join(parts)
+
+        latitude = city.get('latitude')
+        longitude = city.get('longitude')
+
+        point = (latitude, longitude) if latitude and longitude \
+            else None
+
+        return Location(address, point, data)
+
+    def _check_status(self, page):
+        success = page.get('success')
+        if success:
+            return
+
+        code = page.get('code', 0)
+        message = page.get('message', 'Unknown error')
+
+        if code == 401:
+            raise GeocoderAuthenticationFailure(message)
+        elif code == 429:
+            raise GeocoderQuotaExceeded(message)
+        elif code == 400:
+            raise GeocoderQueryError(message)
+        else:
+            raise GeocoderServiceError(message)

--- a/test/geocoders/ip2geo.py
+++ b/test/geocoders/ip2geo.py
@@ -1,0 +1,41 @@
+from geopy.geocoders import Ip2geo
+from test.geocoders.util import BaseTestGeocoder, env
+
+
+class TestIp2geo(BaseTestGeocoder):
+
+    @classmethod
+    def make_geocoder(cls, **kwargs):
+        return Ip2geo(api_key=env['IP2GEO_KEY'], **kwargs)
+
+    async def test_user_agent_custom(self):
+        geocoder = self.make_geocoder(user_agent='my_user_agent/1.0')
+        assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
+
+    async def test_geocode(self):
+        location = await self.geocode_run(
+            {"query": "134.201.250.155"},
+            {"latitude": 34.0, "longitude": -118.2},
+            skipIfParseError=True,
+        )
+        if location:
+            assert location.address
+
+    async def test_geocode_no_city(self):
+        location = await self.geocode_run(
+            {"query": "8.8.8.8"},
+            {"latitude": 37.7, "longitude": -97.8},
+            skipIfParseError=True,
+        )
+        if location:
+            assert location.raw.get('ip') == '8.8.8.8'
+
+    async def test_geocode_exactly_one_false(self):
+        result = await self.geocode_run(
+            {"query": "134.201.250.155", "exactly_one": False},
+            {},
+            skipIfParseError=True,
+        )
+        if result:
+            assert isinstance(result, list)
+            assert len(result) == 1


### PR DESCRIPTION
## Summary

Adds a new geocoder for the [ip2geo](https://ip2geo.dev) IP geolocation API. This is the **first IP address geocoder in geopy**, enabling IP-to-location lookups alongside the existing address-based geocoders.

- Supports IPv4 and IPv6 address geocoding
- Returns `Location` objects with address, coordinates, and full raw API data (city, country, continent, ASN, currency, flag, timezone, etc.)
- Authentication via `X-Api-Key` header using `_call_geocoder(headers=...)` 
- Proper error handling for 401/429/400 status codes
- Follows all geopy conventions (RST docstrings, `DEFAULT_SENTINEL`, explicit params)

## Usage

```python
from geopy.geocoders import Ip2geo

geo = Ip2geo(api_key='your-api-key')
location = geo.geocode('134.201.250.155')

print(location.address)    # "Los Angeles, California, United States"
print(location.latitude)   # 34.0544
print(location.longitude)  # -118.244
print(location.raw['asn']) # {'number': 25876, 'name': 'Los Angeles Department Of Water & Power'}

# Also available via service name lookup
from geopy.geocoders import get_geocoder_for_service
cls = get_geocoder_for_service('ip2geo')
```

## Files changed

- **New:** `geopy/geocoders/ip2geo.py` — geocoder implementation
- **New:** `test/geocoders/ip2geo.py` — async test cases
- **Modified:** `geopy/geocoders/__init__.py` — register in `__all__`, imports, and `SERVICE_TO_GEOCODER`

## Test plan

- [x] `python3 -c "import ast; ..."` syntax check passes
- [x] Provider loads and registers via `get_geocoder_for_service('ip2geo')`
- [x] Live API test: `geocode('134.201.250.155')` returns correct Location (Los Angeles, 34.0544, -118.244)
- [x] Live API test: `geocode('8.8.8.8')` returns Location with coordinates for IPs without city data
- [x] `exactly_one=False` returns list of one Location
- [x] Service name lookup works