### PR TITLE
Avoid narrowing DEFAULT_SENTINEL type inference

### DIFF
--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -189,8 +189,10 @@ class options:
 
 # Create an object which `repr` returns 'DEFAULT_SENTINEL'. Sphinx (docs) uses
 # this value when generating method's signature.
-DEFAULT_SENTINEL = type('object', (object,),
-                        {'__repr__': lambda self: 'DEFAULT_SENTINEL'})()
+# Keep the static type broad so source-based type checkers don't infer each
+# DEFAULT_SENTINEL-backed parameter as accepting only this singleton.
+DEFAULT_SENTINEL: object = type('object', (object,),
+                                {'__repr__': lambda self: 'DEFAULT_SENTINEL'})()
 
 ERROR_CODE_MAP = {
     400: GeocoderQueryError,


### PR DESCRIPTION
Fixes #604.

## Summary
- annotate `DEFAULT_SENTINEL` as an opaque `object` so source-based type checkers do not infer sentinel-backed parameters as accepting only the generated singleton type
- keep the runtime sentinel object and its `repr` unchanged for Sphinx-generated signatures

## Validation
- `npx --yes pyright` on a repro using `Nominatim(user_agent="city_map_poster", timeout=10)`
- `python -m pytest test/geocoders/base.py test/geocoders/nominatim.py test/geocoders/__init__.py --skip-tests-requiring-internet`
- `python -m flake8 geopy/geocoders/base.py`
- `python -m isort --check-only geopy/geocoders/base.py`
- `git diff --check`

I also attempted the full local no-internet pytest run. It reached 500 passing tests but 8 proxy-specific adapter tests failed in this Windows environment because local proxy expectations were not met; the targeted geocoder/signature tests above pass.
