### PR TITLE
Fix format_degrees floating-point noise in DMS decomposition

### DIFF
--- a/geopy/format.py
+++ b/geopy/format.py
@@ -62,13 +62,21 @@ def format_degrees(degrees, fmt=DEGREES_FORMAT, symbols=None):
     TODO docs.
     """
     symbols = symbols or ASCII_SYMBOLS
-    arcminutes = units.arcminutes(degrees=degrees - int(degrees))
-    arcseconds = units.arcseconds(arcminutes=arcminutes - int(arcminutes))
+    # Convert to total arcseconds and round to remove floating-point noise
+    # before decomposing, to avoid small errors (e.g. 2.1e-12 arcseconds)
+    # that arise from the cascading degrees -> arcminutes -> arcseconds chain.
+    total_arcsec = round(abs(degrees) * 3600, 8)
+    whole_degrees = int(total_arcsec) // 3600
+    remaining = total_arcsec - whole_degrees * 3600
+    arcminutes = int(remaining) // 60
+    arcseconds = remaining - arcminutes * 60
+    if degrees < 0:
+        whole_degrees = -whole_degrees
     format_dict = dict(
         symbols,
-        degrees=degrees,
-        minutes=abs(arcminutes),
-        seconds=abs(arcseconds)
+        degrees=whole_degrees,
+        minutes=arcminutes,
+        seconds=arcseconds,
     )
     return fmt % format_dict
 

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -16,14 +16,11 @@ def test_format_simple(input, expected):
     assert format_degrees(Point.parse_degrees(*input)) == expected
 
 
-# These tests currently fail, because conversion to degrees (as float)
-# causes loss in precision (mostly because of divisions by 3):
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "input, expected",
     [
-        (("13", "20", 0), "13 20' 0\""),  # actual: `13 20' 2.13163e-12"`
-        (("-13", "19", 0), "-13 19' 0\""),  # actual: `-13 18' 60"`
+        (("13", "20", 0), "13 20' 0\""),
+        (("-13", "19", 0), "-13 19' 0\""),
     ],
 )
 def test_format_float_precision(input, expected):


### PR DESCRIPTION
## Summary

`format_degrees` decomposed a decimal-degrees float into DMS by repeatedly
subtracting the integer part and multiplying the fraction by 60. This cascading
chain amplifies binary floating-point noise:

```
>>> from geopy.format import format_degrees
>>> from geopy.point import Point
>>> format_degrees(Point.parse_degrees('13', '20', 0))
"13 20' 2.13163e-12\""   # should be "13 20' 0\""
>>> format_degrees(Point.parse_degrees('-13', '19', 0))
"-13 18' 60\""           # should be "-13 19' 0\""
```

Both failures were already captured as `@pytest.mark.xfail` in
`test/test_format.py`.

## Fix

Convert the input to total arcseconds first (rounding to 8 decimal places to
eliminate the binary-float noise), then decompose with integer arithmetic:

```python
total_arcsec = round(abs(degrees) * 3600, 8)
whole_degrees = int(total_arcsec) // 3600
remaining     = total_arcsec - whole_degrees * 3600
arcminutes    = int(remaining) // 60
arcseconds    = remaining - arcminutes * 60
```

The two previously-xfailing tests now pass, all other format/point/distance
tests remain green, and the `xfail` markers are removed.

This pull request was prepared with the assistance of AI, under my direction and review.