### PR TITLE
Fix applying pytest mark to fixture

### DIFF
--- a/test/adapters/each_adapter.py
+++ b/test/adapters/each_adapter.py
@@ -80,9 +80,10 @@ def proxy_url(request, proxy_server):
     return proxy_server.get_proxy_url(with_scheme)
 
 
-@pytest.mark.skipif(WITH_SYSTEM_PROXIES, reason="There're active system proxies")
 @pytest.fixture
 def inject_proxy_to_system_env(proxy_url):
+    if WITH_SYSTEM_PROXIES:
+        pytest.skip("There're active system proxies")
     assert os.environ.get("http_proxy") is None
     assert os.environ.get("https_proxy") is None
     os.environ["http_proxy"] = proxy_url


### PR DESCRIPTION
pytest >= 9.1 enforces the deprecation that marks cannot be applied to fixtures. Move the skipif logic inside the fixture body using pytest.skip() instead.

See https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function

Assisted-by: Claude Opus 4.6