### PR TITLE
Guard Point.from_string against ReDoS on very long inputs (#608)

### DIFF
--- a/geopy/point.py
+++ b/geopy/point.py
@@ -151,6 +151,13 @@ class Point:
 
     POINT_PATTERN = POINT_PATTERN
 
+    # Upper bound on the length of a string parsed by ``from_string``. A valid
+    # coordinate string is short (the longest realistic one is well under this),
+    # so longer inputs cannot be valid points. Capping the length keeps
+    # ``POINT_PATTERN`` from doing pathological amounts of backtracking on very
+    # long adversarial inputs (ReDoS, CWE-1333). See GH-608.
+    _MAX_STRING_LENGTH = 256
+
     def __new__(cls, latitude=None, longitude=None, altitude=None):
         """
         :param float latitude: Latitude of point.
@@ -423,6 +430,10 @@ class Point:
             - ``UT: N 39°20' 0'' / W 74°35' 0''``
 
         """
+        if len(string) > cls._MAX_STRING_LENGTH:
+            raise ValueError(
+                "Failed to create Point instance from string: unknown format."
+            )
         match = re.match(cls.POINT_PATTERN, re.sub(r"''", r'"', string))
         if match:
             latitude_direction = None

--- a/test/test_point.py
+++ b/test/test_point.py
@@ -72,6 +72,13 @@ class PointTestCase(unittest.TestCase):
         self.assertEqual(Point("UT: N 39\xb020' 0'' / W 74\xb035' 0''"),
                          (39.333333333333336, -74.58333333333333, 0.0))
 
+    def test_point_from_string_tolerates_irrelevant_surroundings(self):
+        self.assertEqual(Point("aaa 41.5 -81.0"), (41.5, -81.0, 0.0))
+        self.assertEqual(Point("  41.5 -81.0  "), (41.5, -81.0, 0.0))
+        with self.assertRaises(ValueError):
+            # Non-whitespace trailing data is not tolerated:
+            Point("41.5 -81.0 aaa")
+
     def test_point_from_string_rejects_overlong_input(self):
         # A valid coordinate string is short. A very long adversarial string
         # must be rejected quickly rather than triggering catastrophic regex

--- a/test/test_point.py
+++ b/test/test_point.py
@@ -1,6 +1,7 @@
 import math
 import pickle
 import sys
+import time
 import unittest
 import warnings
 
@@ -70,6 +71,18 @@ class PointTestCase(unittest.TestCase):
                          (23.439444444444444, 23.458333333333332, 0.0))
         self.assertEqual(Point("UT: N 39\xb020' 0'' / W 74\xb035' 0''"),
                          (39.333333333333336, -74.58333333333333, 0.0))
+
+    def test_point_from_string_rejects_overlong_input(self):
+        # A valid coordinate string is short. A very long adversarial string
+        # must be rejected quickly rather than triggering catastrophic regex
+        # backtracking in POINT_PATTERN (ReDoS, GH-608). Without the length
+        # guard this input takes tens of seconds; the bound below has a huge
+        # margin so it is not timing-sensitive.
+        adversarial = "<" + " " * 100_000 + "X"
+        start = time.perf_counter()
+        with self.assertRaises(ValueError):
+            Point(adversarial)
+        self.assertLess(time.perf_counter() - start, 1.0)
 
     def test_point_format_altitude(self):
         point = Point(latitude=41.5, longitude=81.0, altitude=2.5)


### PR DESCRIPTION
## Summary

Fixes #608 (ReDoS in `geopy.Point`, CWE-1333). `POINT_PATTERN` starts with `.*?` (so a coordinate can appear after some leading text, e.g. `UT: N 39°20' 0''`) and matches whitespace in several overlapping places. On a long **non-matching** input it backtracks quadratically:

```python
geopy.Point("<" + " " * 3000 + "X")   # ~0.2s, and grows with input size
```

An endpoint that forwards user input to `geopy.Point()` (as the docs suggest for coordinate strings) can be tied up with modest request volume.

## Fix

A valid coordinate string is short (the longest in the test suite is 46 chars), so cap the input length in `from_string()` before matching and reject longer strings with the usual `ValueError`. This bounds the worst‑case matching time to well under a millisecond.

Atomic groups / possessive quantifiers would also help, but they require Python 3.11+ and geopy supports 3.7+; and because the leading `.*?` scans every position, the match is inherently O(n²) regardless — so bounding the length is the reliable mitigation.

The limit (256) is a generous ~5× the longest realistic coordinate string; happy to adjust it, or add a changelog entry, if you prefer.

## Verification

- Added `test_point_from_string_rejects_overlong_input`: a 100 000‑char adversarial string must raise `ValueError` in well under a second (it takes tens of seconds on `master` — the bound has a huge margin, so it isn't timing‑sensitive).
- Full `test/test_point.py` passes (27); all documented `from_string` examples (including the `UT:`‑prefixed one) still parse; `flake8` and `isort` clean.

*Disclosure: prepared with AI assistance; reviewed and verified locally.*
