### PR TITLE
Feat/nominatim email

### DIFF
--- a/geopy/geocoders/nominatim.py
+++ b/geopy/geocoders/nominatim.py
@@ -88,7 +88,14 @@ class Nominatim(Geocoder):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
-            .. versionadded:: 2.0
+        :param str email: Valid email address of the application owner,
+            included as the ``email`` query parameter in requests to
+            Nominatim. This allows Nominatim administrators to contact
+            you in case of operational issues. See the Nominatim
+            `usage policy <https://operations.osmfoundation.org/policies/nominatim/>`_
+            for details.
+
+            .. versionadded:: 2.5
         """
         super().__init__(
             scheme=scheme,

--- a/geopy/geocoders/nominatim.py
+++ b/geopy/geocoders/nominatim.py
@@ -59,7 +59,8 @@ class Nominatim(Geocoder):
             scheme=None,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            email=None,
             # Make sure to synchronize the changes of this signature in the
             # inheriting classes (e.g. PickPoint).
     ):
@@ -99,7 +100,7 @@ class Nominatim(Geocoder):
         )
 
         self.domain = domain.strip('/')
-
+        self.email = email
         if (self.domain == _DEFAULT_NOMINATIM_DOMAIN
                 and self.headers['User-Agent'] in _REJECTED_USER_AGENTS):
             raise ConfigurationError(
@@ -130,6 +131,8 @@ class Nominatim(Geocoder):
 
         :return: string URL.
         """
+        if self.email:
+            params["email"] = self.email
         return "?".join((base_api, urlencode(params)))
 
     def geocode(

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -24,7 +24,8 @@ class PickPoint(Nominatim):
             scheme=None,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            email=None
     ):
         """
 
@@ -64,6 +65,7 @@ class PickPoint(Nominatim):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            email=email
         )
         self.api_key = api_key
 

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -375,3 +375,21 @@ class TestNominatim(BaseTestNominatim):
             from geopy.geocoders.osm import Nominatim as OsmNominatim
         assert len(w) == 1
         assert OsmNominatim is Nominatim
+
+    async def test_email_stored(self):
+        geocoder = self.make_geocoder(email='test@example.com')
+        assert geocoder.email == 'test@example.com'
+
+    async def test_email_none_by_default(self):
+        geocoder = self.make_geocoder()
+        assert geocoder.email is None
+
+    async def test_email_in_constructed_url(self):
+        geocoder = self.make_geocoder(email='test@example.com')
+        url = geocoder._construct_url(geocoder.api, {'q': 'London', 'format': 'json'})
+        assert 'email=test%40example.com' in url
+
+    async def test_no_email_in_constructed_url(self):
+        geocoder = self.make_geocoder()
+        url = geocoder._construct_url(geocoder.api, {'q': 'London', 'format': 'json'})
+        assert 'email' not in url


### PR DESCRIPTION
Related to discussion #576.

## Summary

Adds support for an optional `email` parameter to the `Nominatim` geocoder.

When provided, the email address is forwarded as the `email` query parameter in requests to the Nominatim API, aligning GeoPy with the official Nominatim API and usage recommendations.

## Motivation

The Nominatim API supports an `email` parameter for identifying applications, particularly for high-volume usage. While GeoPy already exposes the `user_agent` parameter, it does not provide a dedicated way to specify an email address, requiring users to manually include it in the `User-Agent` string.

This change exposes the supported API parameter directly through GeoPy's interface.

## Changes

- Added an optional `email` parameter to `Nominatim`.
- Included the `email` query parameter in Nominatim requests when provided.
- Preserved existing behavior when `email` is not specified.
- Added tests and updated the documentation.