### PR TITLE
Make from_string altitude units case-insensitive, as documented

### DIFF
--- a/geopy/point.py
+++ b/geopy/point.py
@@ -29,7 +29,7 @@ POINT_PATTERN = re.compile(r"""
     %(SEP)s
       (?P<altitude>
         (?P<altitude_distance>[+-]?%(FLOAT)s)[ ]*
-        (?P<altitude_units>km|m|mi|ft|nm|nmi)))?
+        (?P<altitude_units>(?i:km|m|mi|ft|nm|nmi))))?
     \s*$
 """ % {
     "FLOAT": r'\d+(?:\.\d+)?',
@@ -382,7 +382,7 @@ class Point:
                 'nmi': lambda d: units.kilometers(nautical=d)
             }
             try:
-                return CONVERTERS[unit](distance)
+                return CONVERTERS[unit.lower()](distance)
             except KeyError:
                 raise NotImplementedError(
                     'Bad distance unit specified, valid ones are: %r' %

--- a/test/test_point.py
+++ b/test/test_point.py
@@ -91,6 +91,17 @@ class PointTestCase(unittest.TestCase):
             Point(adversarial)
         self.assertLess(time.perf_counter() - start, 1.0)
 
+    def test_point_from_string_altitude_units_case_insensitive(self):
+        # from_string's docstring promises the unit abbreviations are
+        # case-insensitive, so an upper- or mixed-case unit must parse to the
+        # same altitude as its lowercase spelling.
+        for unit in ("km", "m", "mi", "ft", "nm", "nmi"):
+            expected = Point("1,2,2.5" + unit).altitude
+            self.assertEqual(Point("1,2,2.5" + unit.upper()).altitude, expected)
+            self.assertEqual(
+                Point("1,2,2.5" + unit.capitalize()).altitude, expected
+            )
+
     def test_point_format_altitude(self):
         point = Point(latitude=41.5, longitude=81.0, altitude=2.5)
         self.assertEqual(point.format(), "41 30m 0s N, 81 0m 0s E, 2.5km")


### PR DESCRIPTION
`Point.from_string`'s docstring says the altitude unit abbreviations are
case-insensitive:

> The following unit abbreviations (case-insensitive) are supported: `km`, `m`, `mi`, `ft`, `nm`, `nmi`

But they aren't — `POINT_PATTERN` only matches the units in lower case and
`parse_altitude` keys its converter table with lower-case strings, so:

```python
Point.from_string("1,2,2.5km")   # -> altitude 2.5
Point.from_string("1,2,2.5KM")   # ValueError: unknown format
```

Any upper- or mixed-case unit raises, which is easy to hit with altitude
strings coming from external/user data.

Fix: apply an inline `(?i:...)` flag to just the units token (a blanket
`re.IGNORECASE` would collide with the lower-case `m`/`s` arcminute/arcsecond
markers and the upper-case `N/S/E/W` directions) and lower-case the unit before
the converter lookup. Added a test that every unit parses the same in lower,
upper, and title case.

---
This PR was authored by an AI coding agent (Claude Code) running on this
account: the AI found the bug, ran the repro, wrote the test, and wrote this
description. The human account holder reviews every change and is accountable
for it. The verification is real and re-runnable from the diff. If this isn't
the kind of contribution you want, say so and I'll close it.
